### PR TITLE
feat: v0.7.x contract-shape adoption + Line-Level Drilldown + GitHub-…

### DIFF
--- a/optimus/analyze.py
+++ b/optimus/analyze.py
@@ -298,7 +298,7 @@ def _bg_wait_for_pending_jobs(session_uuid: str, docname: str, deadline):
 	except Exception:
 		pass
 	_publish_progress(
-		2, f"Waiting for {len(still_running)} background job(s) to finish…", session_uuid
+		2, f"Waiting for {len(still_running)} RQ Job(s) to finish…", session_uuid
 	)
 
 	# Throttle, then re-enqueue ourselves so the worker can run the pending
@@ -391,9 +391,9 @@ def run(session_uuid: str, _bg_wait_until: float | None = None):
 		# v0.6.0: if we hit the wait cap with jobs still running, say so.
 		if bg_jobs_unfinished:
 			context.warnings.append(
-				f"{bg_jobs_unfinished} background job(s) the flow enqueued were still "
-				"running when analysis started — they aren't included. Click Retry "
-				"Analyze once they finish, or raise 'Wait for Background Jobs' in "
+				f"{bg_jobs_unfinished} RQ Job(s) the flow enqueued were still "
+				"running when analysis started - they aren't included. Click Retry "
+				"Analyze once they finish, or raise 'Wait for RQ Jobs' in "
 				"Optimus Settings."
 			)
 
@@ -1462,8 +1462,9 @@ def _ai_payload_for_finding(
 	renderer's normalized finding dict plus a wider source-code window around
 	the callsite, plus — when a Phase-2 line-profile pass instrumented this
 	finding's function — the hottest line from it (number / content / ms /
-	hits). ``phase2_index`` is a ``renderer._build_phase2_callsite_index``
-	result, ``{(basename, function): hotline}``.
+	hits). ``phase2_index`` is a
+	``renderer._build_line_drilldown_callsite_index`` result,
+	``{(basename, function): hotline}``.
 
 	v0.6.x: when both ``recordings_by_uuid`` (``{recording_uuid: recording}``)
 	and ``actions_by_idx`` (``{idx: action_dict}``) are provided AND the
@@ -1572,13 +1573,15 @@ def _maybe_attach_recorded_queries(
 
 
 def _phase2_index_for(doc_or_docname) -> dict:
-	"""``renderer._build_phase2_callsite_index`` for a session doc / docname,
-	or ``{}`` on any error (no phase-2 runs yet, doc gone, etc.)."""
+	"""``renderer._build_line_drilldown_callsite_index`` for a session
+	doc / docname, or ``{}`` on any error (no phase-2 runs yet, doc
+	gone, etc.).
+	"""
 	try:
 		doc = doc_or_docname
 		if isinstance(doc, str):
 			doc = frappe.get_doc("Optimus Session", doc)
-		return renderer._build_phase2_callsite_index(doc) or {}
+		return renderer._build_line_drilldown_callsite_index(doc) or {}
 	except Exception:
 		return {}
 
@@ -2127,7 +2130,7 @@ def _build_summary_html(
 	parts = [
 		f"This session covered <strong>{n_actions} operation"
 		f"{'s' if n_actions != 1 else ''}</strong> (page loads, saves and "
-		f"background jobs) with <strong>{total_queries} database "
+		f"RQ Jobs) with <strong>{total_queries} database "
 		f"quer{'ies' if total_queries != 1 else 'y'}</strong>."
 	]
 
@@ -2161,7 +2164,7 @@ def _build_summary_html(
 				title = title[len(prefix):]
 			pri = _PRIORITY_WORD.get(f.get("severity") or "", "")
 			impact = f.get("estimated_impact_ms") or 0
-			tail = f" (~{impact:.0f}ms" + (f" — {pri} priority" if pri else "") + ")"
+			tail = f" (~{impact:.0f}ms" + (f" - {pri} priority" if pri else "") + ")"
 			return f"<strong>{html.escape(title)}</strong>{tail}"
 
 		# Prefer a finding tied to this specific action (via action_ref);
@@ -2182,7 +2185,7 @@ def _build_summary_html(
 		if tied_finding:
 			parts.append(
 				f"The slowest one was <strong>{slowest_label_esc}</strong> at "
-				f"{slowest_ms:.0f}ms — and most of its time went into "
+				f"{slowest_ms:.0f}ms - and most of its time went into "
 				f"{_finding_phrase(tied_finding)}. See the Findings section below "
 				"for what to ask your developer to fix."
 			)
@@ -2202,14 +2205,14 @@ def _build_summary_html(
 	if not findings:
 		# Two-bullet reassurance (was one block of two <p>s pre-v0.7.x).
 		parts.append(
-			"We checked your flow for the usual culprits — "
+			"We checked your flow for the usual culprits - "
 			"<strong>repeated queries (N+1 patterns)</strong>, "
 			"<strong>full table scans</strong>, "
 			"<strong>filesort operations</strong>, "
 			"<strong>temporary table creation</strong>, "
 			"<strong>low filter ratios</strong>, "
 			"<strong>missing indexes</strong>, and "
-			"<strong>individually slow queries</strong> (&gt;200ms) — "
+			"<strong>individually slow queries</strong> (&gt;200ms) - "
 			"and nothing significant turned up."
 		)
 		parts.append(
@@ -2227,7 +2230,7 @@ def _build_summary_html(
 			bits.append(f"{medium} medium")
 		if low:
 			bits.append(f"{low} minor")
-		breakdown = (" — " + ", ".join(bits)) if bits else ""
+		breakdown = (" - " + ", ".join(bits)) if bits else ""
 		parts.append(
 			f"We found <strong>{total_issues} potential issue"
 			f"{'s' if total_issues != 1 else ''}</strong>{breakdown}. See the "

--- a/optimus/analyzers/infra_pressure.py
+++ b/optimus/analyzers/infra_pressure.py
@@ -295,7 +295,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
             "severity": severity,
             "title": f"RQ queue depth peaked at {max_peak} during session",
             "customer_description": (
-                f"A background job queue had more than {rq_warn} pending jobs "
+                f"An RQ Job queue had more than {rq_warn} pending jobs "
                 f"during your flow (peak {max_peak}). If your flow enqueues "
                 "work, it's waiting behind other jobs."
             ),

--- a/optimus/analyzers/per_action.py
+++ b/optimus/analyzers/per_action.py
@@ -9,7 +9,7 @@ row is the unit the customer sorts/filters by in the report — "which step
 of my flow took the longest?".
 
 Label detection strategy:
-    1. Background jobs: "Job: <last component of method name>"
+    1. RQ Jobs: "Job: <last component of method name>"
     2. frappe.client.{save,insert,submit,cancel,delete}: "<Verb> <DocType>"
     3. frappe.client.get_list: "List <DocType>"
     4. Other cmd: use the cmd verbatim
@@ -66,11 +66,11 @@ def _label(recording: dict) -> str:
 	re-enabling the full humanization pipeline (which the user
 	wanted off in technical breakdowns).
 	"""
-	if recording.get("event_type") == "Background Job":
-		path = recording.get("path") or "Background Job"
+	if recording.get("event_type") == "RQ Job":
+		path = recording.get("path") or "RQ Job"
 		# Trim long module paths to the last component for readability
 		short = path.split(".")[-1] if "." in path else path
-		return f"Job: {short}"
+		return f"RQ Job: {short}"
 
 	cmd = recording.get("cmd") or ""
 	if not cmd:
@@ -186,8 +186,8 @@ def humanized_label(recording: dict) -> str:
 	humanization rules — so unknown cmds produce the same technical
 	label they would in the per-action table, not an empty string.
 	"""
-	if recording.get("event_type") == "Background Job":
-		# Background jobs use the same label in both views — the
+	if recording.get("event_type") == "RQ Job":
+		# RQ Jobs use the same label in both views — the
 		# "Job: <method>" form is already readable.
 		return _label(recording)
 

--- a/optimus/renderer.py
+++ b/optimus/renderer.py
@@ -21,8 +21,78 @@ from typing import Any
 
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 from markupsafe import Markup
+from pygments import highlight as _pyg_highlight
+from pygments.formatters import HtmlFormatter as _PygHtmlFormatter
+from pygments.lexers import PythonLexer as _PygPythonLexer
 
 from optimus.analyzers.base import SEVERITY_ORDER
+
+_PY_LEXER = _PygPythonLexer(stripnl=False, ensurenl=False)
+_PY_HTML_FMT = _PygHtmlFormatter(nowrap=True, classprefix="tok-")
+
+
+def _highlight_python_snippet(lines):
+	"""Mutate each ``{"lineno", "content"}`` dict in ``lines`` to add a
+	``content_html`` field carrying Pygments-highlighted span markup
+	(VSCode Dark+ palette via CSS in the template).
+
+	The lines are joined into one source block before highlighting so
+	multi-line strings, decorators, and other multi-line constructs
+	keep correct tokenisation; the resulting HTML is then split per
+	``\\n`` and each chunk assigned back to its source line. Idempotent
+	on lines that already carry ``content_html``. Falls back to
+	``content_html = None`` (template uses plain ``content``) on any
+	Pygments failure.
+	"""
+	if not lines:
+		return
+	if all(isinstance(l, dict) and l.get("content_html") is not None for l in lines):
+		return
+	try:
+		src = "\n".join((l.get("content") or "") for l in lines if isinstance(l, dict))
+		out = _pyg_highlight(src, _PY_LEXER, _PY_HTML_FMT)
+		out = out.rstrip("\n")
+		chunks = out.split("\n")
+		if len(chunks) != len(lines):
+			for l in lines:
+				if isinstance(l, dict):
+					l["content_html"] = None
+			return
+		for l, chunk in zip(lines, chunks, strict=True):
+			if isinstance(l, dict):
+				l["content_html"] = chunk
+	except Exception:
+		for l in lines:
+			if isinstance(l, dict):
+				l["content_html"] = None
+
+
+def _highlight_all_snippets(actions, all_findings):
+	"""Walk findings + actions and apply VSCode Dark+ syntax highlighting
+	to every ``source_snippet`` list reachable from the data shapes the
+	template + line-prof builder iterate. Mutates in place.
+	"""
+	for f in all_findings or []:
+		if not isinstance(f, dict):
+			continue
+		td = f.get("technical_detail")
+		if not isinstance(td, dict):
+			continue
+		cs = td.get("callsite")
+		if isinstance(cs, dict):
+			_highlight_python_snippet(cs.get("source_snippet") or [])
+		for chain_key in ("drilldown_chain", "frame_chain", "call_chain"):
+			chain = td.get(chain_key)
+			if isinstance(chain, list):
+				for step in chain:
+					if isinstance(step, dict):
+						_highlight_python_snippet(step.get("source_snippet") or [])
+	for a in actions or []:
+		if not isinstance(a, dict):
+			continue
+		ec = a.get("entry_callsite")
+		if isinstance(ec, dict):
+			_highlight_python_snippet(ec.get("source_snippet") or [])
 
 _TEMPLATES_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), "templates")
 
@@ -112,7 +182,7 @@ def render(
 			if (a.get("duration_ms") or 0) >= _min_action_ms
 		]
 	# v0.6.x: per-action entry-point source location + ±1-line snippet,
-	# shown under each row in the per-action breakdown and Background Jobs
+	# shown under each row in the per-action breakdown and RQ Jobs
 	# sections. One shared file-line cache so a cluster of actions in the
 	# same source file reads it once. Done before build_background_jobs so
 	# the job dicts can copy the resolved callsite off the action dict.
@@ -145,15 +215,41 @@ def render(
 		return bool((callsite.get("filename") or "").strip())
 
 	all_findings = [f for f in all_findings if _has_renderable_callsite(f)]
-	# v0.7.x: phase-2 callsite index built once and reused for the Jinja
-	# lookup the template uses for cross-link callouts ("Phase 2: hottest
-	# line N — Mms / X hits"). The smoking-gun retargeting reads
-	# drill-down chains (not phase-2) and is wired in after
-	# _attach_drilldown_chains populates them on the findings.
-	_phase2_index = _build_phase2_callsite_index(session_doc)
+	# v0.7.x: line-drilldown callsite index built once and reused for the
+	# Jinja lookup the template uses for cross-link callouts ("Line-Level
+	# Drilldown: hottest line N - Mms / X hits"). The smoking-gun
+	# retargeting reads drill-down chains (not line-drilldown) and is
+	# wired in after _attach_drilldown_chains populates them on the
+	# findings.
+	_line_drilldown_index = _build_line_drilldown_callsite_index(session_doc)
 	# v0.6.x: which document each save/submit action touched, and which
 	# doc-event lifecycle hook each slow function fired in.
 	_attach_action_context(actions, all_findings, recordings_by_uuid)
+	# v0.7.x: VSCode Dark+ syntax highlighting for every source_snippet
+	# we'll render. Done once, in place, after all snippets are attached.
+	# Adds a ``content_html`` field to each line dict; the template (or
+	# the line-prof renderer) uses it via ``| safe`` with a graceful
+	# fallback to plain ``content`` if Pygments failed.
+	_highlight_all_snippets(actions, all_findings)
+	# v0.7.x J.13: render-time em-dash sweep over analyzer-baked prose.
+	# The analyzer wrote em dashes into customer_description, llm_fix HTML,
+	# session.notes_html, and summary_html during analyse-time (pre-J.12).
+	# Replace at render time so existing reports get the hyphen treatment
+	# without requiring a Retry Analyze.
+	def _strip_em(s):
+		if isinstance(s, str) and "—" in s:
+			return s.replace("—", "-")
+		return s
+	for _f in (all_findings or []):
+		if not isinstance(_f, dict):
+			continue
+		_f["customer_description"] = _strip_em(_f.get("customer_description"))
+		_f["title"] = _strip_em(_f.get("title"))
+		_lf = _f.get("llm_fix")
+		if isinstance(_lf, dict):
+			for _k in ("diagnosis_html", "patch_html", "rationale_html", "verify_html", "description_html", "code_html", "why_html"):
+				if _k in _lf:
+					_lf[_k] = _strip_em(_lf[_k])
 	# v0.6.x: "Ignored Apps" — drop findings whose blame app is in the
 	# admin's exclusion list, BEFORE anything downstream sees the list
 	# (doc-event breakdown, background-jobs tally, exec summary, severity
@@ -181,7 +277,28 @@ def render(
 	# _attach_action_context just attached).
 	doc_event_breakdown = _build_doc_event_breakdown(all_findings)
 
-	# v0.6.0: the "Background jobs" section — the captured background-job
+	# v0.7.x J.11: enrich finding callsite function names with the DocType
+	# suffix for display. Runs AFTER _build_doc_event_breakdown because
+	# that function parses ``callsite.function`` against the lifecycle
+	# event vocabulary (``validate``, ``on_submit``, ...) — suffixing
+	# before classification would break the match.
+	for _f in (all_findings or []):
+		if not isinstance(_f, dict):
+			continue
+		_detail = _f.get("technical_detail")
+		if not isinstance(_detail, dict):
+			continue
+		_td = _detail.get("target_doc")
+		_dt = _td.get("doctype") if isinstance(_td, dict) else None
+		if not _dt:
+			continue
+		_cs = _detail.get("callsite")
+		if isinstance(_cs, dict):
+			_cs_fn = _cs.get("function") or ""
+			if _cs_fn and " (" not in _cs_fn:
+				_cs["function"] = f"{_cs_fn} ({_dt})"
+
+	# v0.6.0: the "RQ Jobs" section — the captured background-job
 	# recordings, surfaced on their own (they also stay in the per-action
 	# table). Derived from the persisted action rows; uses all findings
 	# (actionable + observational) for the per-job findings tally.
@@ -210,6 +327,7 @@ def render(
 			raw = (_t["ai_index"].get("suggestion") or "").strip()
 			if raw:
 				_t["ai_index"]["suggestion_html"] = _markdown_to_safe_html(raw)
+
 
 	# v0.6.x: a per-section LLM toggle being off is a hard disable — drop any
 	# previously-generated AI output for that section so re-rendering an older
@@ -375,9 +493,12 @@ def render(
 			# If sanitize_html blows up for any reason (unexpected input
 			# type, nh3/bleach internal error), fall back to HTML-escaping
 			# via html.escape so the report NEVER renders unsanitized
-			# user input — safe by default.
+			# user input - safe by default.
 			import html as html_mod
 			notes_html = html_mod.escape(notes_html)
+		# v0.7.x J.13: strip em dashes the analyzer wrote into auto-notes
+		# / humanized-notes prose at analyse-time.
+		notes_html = notes_html.replace("—", "-")
 
 	# v0.5.2: Analyzer warnings are stored as a newline-joined string
 	# (see analyze.py). Split into a list of non-empty bullets for the
@@ -487,7 +608,7 @@ def render(
 		_a["related_findings"] = _findings_by_action_ref.get(
 			str(_a.get("idx", "")), [],
 		)
-	# v0.7.x: same linkage for Background Jobs rows. Jobs carry the
+	# v0.7.x: same linkage for RQ Jobs rows. Jobs carry the
 	# original action ``idx`` (set in ``build_background_jobs``) so
 	# they look up against the same per-action-ref map. With this
 	# the BG row macro embeds the same finding cards as action_row,
@@ -522,18 +643,43 @@ def render(
 		lambda r: (r.get("function") or "").split("::", 1)[0],
 		tracked_apps,
 	)
-	hot_frames_rows = build_hot_frames_table(_hf_raw_custom)
-	hot_frames_rows_framework = build_hot_frames_table(_hf_raw_framework)
+	hot_frames_rows = build_hot_frames_table(_hf_raw_custom, is_hot=True)
+	hot_frames_rows_framework = build_hot_frames_table(_hf_raw_framework, is_hot=False)
 
 	# v0.5.2 round 3: executive summary — top 3 most-impactful findings
 	# stated in plain English, rendered in a card at the top of the
 	# report. A non-developer (e.g. a project manager) reading this
 	# should be able to decide "do we have a problem" in 30 seconds
 	# without scrolling past the first screen.
-	executive_summary = _build_executive_summary(
-		findings=findings,
-		session_doc=session_doc,
-		v5=v5,
+	# v0.7.x Phase H: the v0.5.2 `executive_summary` data layer was
+	# orphaned after the TL;DR hero (Phase B) + Action plan (Phase C)
+	# took over its on-page responsibilities. The function is left in
+	# the module for back-compat (existing test fixtures call it
+	# directly) but is no longer wired into render_raw's context.
+	tldr = _compose_tldr(
+		all_findings,
+		session_doc,
+		large_duration_threshold_ms=_large_duration_threshold_ms,
+		actions=list(actions) + list(actions_framework),
+	)
+	# Phase K.5: nested-<details> call-tree panel for the slowest
+	# action. Empty string when no action carries a call_tree_json.
+	call_tree_html = _render_call_tree_panel(list(actions) + list(actions_framework))
+	# v0.7.x redesign Phase C: Recommended Action plan + waterfall.
+	# Action plan: top-3 highest-impact findings, verb-led titles.
+	# Waterfall: top-8 actions by duration, horizontal bars scaled
+	# to the displayed slice's max so short actions stay visible.
+	action_plan = _build_action_plan(
+		all_findings,
+		large_duration_threshold_ms=_large_duration_threshold_ms,
+	)
+	# Waterfall spans both tracked-apps + framework actions; the
+	# split below is for the per-action breakdown table. The reader
+	# wants to see ALL slow actions in the timeline, framework
+	# included.
+	waterfall_rows = _build_waterfall(
+		list(actions) + list(actions_framework),
+		all_findings,
 		large_duration_threshold_ms=_large_duration_threshold_ms,
 	)
 
@@ -560,6 +706,10 @@ def render(
 		int(getattr(session_doc, "total_queries", 0) or 0),
 		recordings,
 	)
+	# v0.7.x J.13: strip em dashes from the render-time summary HTML
+	# (analyze.py's prose composer may still produce them on cached doc rows).
+	if summary_html_rendered:
+		summary_html_rendered = summary_html_rendered.replace("—", "-")
 
 	context = {
 		"session": session_doc,
@@ -579,7 +729,6 @@ def render(
 		"truncation_banner": truncation_banner,
 		"findings_by_app": findings_by_app,
 		"observational_findings_by_app": observational_findings_by_app,
-		"executive_summary": executive_summary,
 		# v0.5.2: "findings" holds actionable items only (shown in
 		# "Findings — what to fix"); "observational_findings" the rest.
 		# "all_findings" is the full list — the "Issues found" stat card
@@ -637,15 +786,17 @@ def render(
 		"frontend_orphans": v5.get("frontend_orphans") or [],
 		"frontend_summary": v5.get("frontend_summary") or {},
 		"notes_html": notes_html,  # sanitized, safe to pass through |safe
-		# v0.6.0 phase-2 line profiler — pre-rendered HTML so the existing
-		# report.html template only needs a single {{ phase2_html | safe }}
-		# include instead of growing by 100+ lines of new markup.
-		"phase2_html": _render_phase2_panel(session_doc),
-		# v0.6.0 finding-card smoking gun: cross-link a finding's callsite
-		# to its hottest phase-2 line when the same function was
-		# instrumented. Helper rather than raw dict because Jinja can't
-		# build tuple keys for the basename + function lookup.
-		"phase2_for_callsite": _make_phase2_lookup(_phase2_index),
+		# v0.7.x J.16 (renamed from phase2_html): the Line-Level Drilldown
+		# panel pre-rendered server-side so the template only needs a
+		# single ``{{ line_drilldown_html | safe }}`` include instead of
+		# growing by 100+ lines of new markup.
+		"line_drilldown_html": _render_line_drilldown_panel(session_doc),
+		# v0.7.x J.16 (renamed from phase2_for_callsite): cross-link a
+		# finding's callsite to its hottest line-drilldown line when the
+		# same function was instrumented. Helper rather than raw dict
+		# because Jinja can't build tuple keys for the basename +
+		# function lookup.
+		"line_drilldown_for_callsite": _make_line_drilldown_lookup(_line_drilldown_index),
 		# v0.6.x: snapshot of the render-affecting settings, stamped in the
 		# report footer so a user opening a saved HTML file can immediately
 		# tell which toggles were in effect when it was rendered. (Saved
@@ -656,7 +807,57 @@ def render(
 		# ``_build_summary_html`` call). The template prefers this over
 		# the stored ``session.summary_html``.
 		"summary_html": summary_html_rendered,
+		# v0.7.x redesign Phase B: TL;DR hero — single composed headline
+		# keyed off the highest-impact finding, with `<span class="hot">`
+		# inline emphases (rendered as Markup so Jinja autoescape leaves
+		# them intact).
+		"tldr": tldr,
+		# Phase K.5: nested-<details> call-tree panel for the slowest
+		# action. Empty string when no action carries a call_tree_json;
+		# template ``{% if %}`` guards the section.
+		"call_tree_html": call_tree_html,
+		# v0.7.x redesign Phase C: top-3 verb-led action plan steps.
+		# Empty list → template hides the section.
+		"action_plan": action_plan,
+		# v0.7.x redesign Phase C: top-8 actions by duration, scaled to
+		# the displayed slice's max. Empty list → template hides.
+		"waterfall_rows": waterfall_rows,
 	}
+
+	# v0.7.x Phase J.1 — contract-shape adapter. Exposes the 19-key dict
+	# per template_variable_contract.md under a single ``report_data``
+	# namespace; Phase J.2 migrated every template section to read from
+	# it instead of the flat legacy keys.
+	from optimus.report_context import build_report_context as _build_report_context
+	context["report_data"] = _build_report_context(session_doc, context)
+
+	# v0.7.x Phase J.3 — drop the now-unused legacy top-level keys.
+	# Template grep confirms zero remaining references; the adapter has
+	# already consumed them (the pop runs AFTER build_report_context).
+	# Keys kept: session, fmt_dt/fmt_ms, generated_at/server_tz, severity_counts,
+	# ignored_apps, ignored_findings_count, hidden_db_tables_count, donut_*,
+	# truncation_banner, analyzer_warnings, recordings_by_uuid,
+	# line_drilldown_for_callsite, redact_frame_name, from_json - all
+	# directly used by template markup or finding_card cross-link.
+	for _legacy_key in (
+		"notes_html", "summary_html", "line_drilldown_html",
+		"waterfall_rows",
+		"hot_frames_rows", "hot_frames_rows_framework",
+		"top_queries", "top_queries_framework",
+		"table_breakdown",
+		"infra_summary", "infra_timeline",
+		"frontend_vitals_by_page", "frontend_xhr_matched",
+		"frontend_orphans", "frontend_summary",
+		"doc_event_breakdown",
+		"actions", "actions_framework",
+		"background_jobs",
+		"findings", "findings_by_app",
+		"observational_findings", "observational_findings_by_app",
+		"all_findings",
+		"tldr", "action_plan",
+		"render_config",
+	):
+		context.pop(_legacy_key, None)
 
 	return template.render(**context)
 
@@ -667,11 +868,11 @@ def _e(text: object) -> str:
 	return _html.escape("" if text is None else str(text))
 
 
-def _build_phase2_callsite_index(session_doc: Any) -> dict:
+def _build_line_drilldown_callsite_index(session_doc: Any) -> dict:
 	"""Build a (basename, function_name) → hottest-line lookup from the
-	session's phase-2 runs. Used by ``finding_card`` to inject a "Phase 2
-	hot line: …" callout whenever a finding's callsite resolves to a
-	function that was line-profiled.
+	session's phase-2 runs. Used by ``finding_card`` to inject a
+	"Line-Level Drilldown hot line: ..." callout whenever a finding's
+	callsite resolves to a function that was line-profiled.
 
 	Keyed by file basename (not absolute path) so the lookup survives
 	dev-vs-deploy path differences. When the same function appears in
@@ -732,10 +933,13 @@ def _build_phase2_callsite_index(session_doc: Any) -> dict:
 	return index
 
 
-def _make_phase2_lookup(index: dict):
-	"""Wrap the phase-2 callsite index in a small lookup callable so
-	Jinja can call ``phase2_for_callsite(filename, function_name)`` —
-	Jinja cannot index dicts by tuple keys directly.
+_build_phase2_callsite_index = _build_line_drilldown_callsite_index
+
+
+def _make_line_drilldown_lookup(index: dict):
+	"""Wrap the line-drilldown callsite index in a small lookup callable
+	so Jinja can call ``line_drilldown_for_callsite(filename,
+	function_name)`` - Jinja cannot index dicts by tuple keys directly.
 	"""
 	import os
 
@@ -745,6 +949,9 @@ def _make_phase2_lookup(index: dict):
 		return index.get((os.path.basename(filename), function_name))
 
 	return lookup
+
+
+_make_phase2_lookup = _make_line_drilldown_lookup
 
 
 def _find_call_line_in_function_body(
@@ -1168,89 +1375,72 @@ def _render_phase2_function_table(fn: dict) -> str:
 	user's pick appears flush-left, each auto-expanded descendant a
 	level deeper.
 	"""
+	# v0.7.x Phase F: editorial styling. Replaces inline-styled divs +
+	# table with `.phase2-func` + `.line-prof` classes. Auto-expanded
+	# descendants get progressive indent (`.indent-1` for now; deeper
+	# chains can roll into `.indent-2` / `.indent-3` if a future patch
+	# tracks chain depth on the row).
 	rows = fn.get("lines") or []
 	dotted = fn.get("dotted_path", "")
 	file_path = fn.get("file", "")
 	source = fn.get("source") or "curated"
 
-	# Auto-expanded descendants get a chain-indent + arrow so the report
-	# reads top-down as "you picked X; we drilled into ↳ Y; ↳ Z; …".
 	is_descendant = source == "auto_expand"
-	container_margin_left = "24px" if is_descendant else "0"
+	indent_cls = " indent-1" if is_descendant else ""
 	header_prefix = (
-		'<span style="color: #9ca3af; margin-right: 6px;">↳</span>'
-		if is_descendant
-		else ""
+		'<span class="arrow">&#x21B3;</span>' if is_descendant else ""
 	)
 
 	html = [
-		f'<div class="phase2-function" '
-		f'style="margin: 12px 0 12px {container_margin_left}; padding: 8px; '
-		f'border: 1px solid #d1d5db; border-radius: 4px;">',
-		f'<div style="font-family: ui-monospace, Menlo, monospace; '
-		f'font-weight: 600; margin-bottom: 4px;">{header_prefix}{_e(dotted)}</div>',
-		f'<div style="color: #6b7280; font-size: 12px; margin-bottom: 8px;">'
-		f'{_e(file_path)}</div>',
+		f'<div class="phase2-func{indent_cls}">',
+		f'<div class="fn-name">{header_prefix}{_e(dotted)}</div>',
+		f'<div class="fn-path">{_e(file_path)}</div>',
 	]
 
 	if not rows:
 		html.append(
-			'<div style="font-style: italic; color: #6b7280;">'
+			'<div class="picks"><em>'
 			'Function was instrumented but never invoked during phase 2.'
-			'</div></div>'
+			'</em></div></div>'
 		)
 		return "".join(html)
 
 	html.append(
-		'<table style="width: 100%; border-collapse: collapse; '
-		'font-family: ui-monospace, Menlo, monospace; font-size: 12px;">'
-		'<thead style="background: #f9fafb;">'
-		'<tr>'
-		'<th style="text-align: right; padding: 4px 8px; '
-		'border-bottom: 1px solid #e5e7eb;">#</th>'
-		'<th style="text-align: right; padding: 4px 8px; '
-		'border-bottom: 1px solid #e5e7eb;">hits</th>'
-		# v0.7.x: unit suffixes ("total ms" / "per hit µs") dropped —
-		# the cells now flow through ``_format_duration_ms`` which
-		# emits the unit itself ("ms" or "s") and highlights values
-		# that cross the 1s threshold. The header just labels the
-		# field; the cell carries the unit.
-		'<th style="text-align: right; padding: 4px 8px; '
-		'border-bottom: 1px solid #e5e7eb;">total</th>'
-		'<th style="text-align: right; padding: 4px 8px; '
-		'border-bottom: 1px solid #e5e7eb;">per hit</th>'
-		'<th style="text-align: left; padding: 4px 8px; '
-		'border-bottom: 1px solid #e5e7eb;">source</th>'
+		'<table class="line-prof">'
+		'<thead><tr>'
+		'<th class="num">#</th>'
+		'<th class="num">hits</th>'
+		'<th class="num">total</th>'
+		'<th class="num">per hit</th>'
+		'<th>source</th>'
 		'</tr></thead><tbody>'
 	)
 
-	# Find the hot line so we can highlight it.
+	# Hot-row threshold: a line is hot when its total_ms is ≥25% of the
+	# function's max line ms (the existing heat-map rule).
 	max_ms = max((r.get("total_ms") or 0) for r in rows)
+
+	# v0.7.x: VSCode Dark+ syntax highlighting for the per-function
+	# source column. Highlighting the whole function's rows together
+	# preserves multi-line tokenisation state.
+	_highlight_python_snippet(rows)
 
 	for line in rows:
 		ms = line.get("total_ms") or 0
-		# Highlight rows that account for ≥25% of the function's max line ms
-		# AND > 0 — gives the eye a heat-map of where time goes.
-		highlight = max_ms > 0 and ms / max_ms >= 0.25
-		row_style = (
-			'background: #fef3c7;' if highlight and ms > 0 else 'background: transparent;'
-		)
-		source_cell = (
-			f'<code style="white-space: pre;">{_e(line.get("content", ""))}</code>'
-		)
-		# v0.7.x: honour the report-wide timing rule. ``_format_duration_ms``
-		# returns Markup with the ``<span class="time-high">…</span>``
-		# highlight when the value crosses the 1s threshold; sub-1s values
-		# render plain. ``per_hit_us`` is microseconds — convert to ms first
-		# so the same rule applies in the same unit-scale.
+		is_hot = max_ms > 0 and ms > 0 and ms / max_ms >= 0.25
+		tr_cls = ' class="hot"' if is_hot else ""
+		# `per_hit_us` is microseconds — convert to ms so the timing
+		# rule (1s threshold for the `.time-high` highlight) applies.
 		per_hit_ms = (line.get("per_hit_us") or 0) / 1000.0
+		_src_html = line.get("content_html")
+		_src_cell = _src_html if _src_html else _e(line.get("content", ""))
 		html.append(
-			f'<tr style="{row_style}">'
-			f'<td style="text-align: right; padding: 2px 8px; color: #6b7280;">{line.get("lineno", "")}</td>'
-			f'<td style="text-align: right; padding: 2px 8px;">{line.get("hits", 0)}</td>'
-			f'<td style="text-align: right; padding: 2px 8px;">{_format_duration_ms(ms, decimals=2)}</td>'
-			f'<td style="text-align: right; padding: 2px 8px;">{_format_duration_ms(per_hit_ms, decimals=2)}</td>'
-			f'<td style="padding: 2px 8px;">{source_cell}</td>'
+			f'<tr{tr_cls}>'
+			f'<td class="ln">{line.get("lineno", "")}</td>'
+			f'<td class="num">{line.get("hits", 0)}</td>'
+			f'<td class="num">{_format_duration_ms(ms, decimals=2)}</td>'
+			f'<td class="num">{_format_duration_ms(per_hit_ms, decimals=2)}</td>'
+			f'<td class="src"><code>{_src_cell}</code></td>'
 			'</tr>'
 		)
 
@@ -1265,66 +1455,75 @@ def _render_phase2_diff_table(diff_rows: list[dict]) -> str:
 	v0.6.0 Round 7: source column always shows full code (was previously
 	gated by ``mode == "safe"`` + the safe-source toggle).
 	"""
+	# v0.7.x Phase F: cross-run diff uses the same `.line-prof` base
+	# class as the per-function table, with extra `.added` / `.removed`
+	# row tints for matched-faster / matched-slower / added / removed
+	# statuses (CSS overlays in the `.line-prof` block).
 	if not diff_rows:
 		return ""
 
 	html = [
-		'<table style="width: 100%; border-collapse: collapse; '
-		'font-family: ui-monospace, Menlo, monospace; font-size: 12px; '
-		'margin-top: 8px;">',
-		'<thead style="background: #f9fafb;"><tr>'
-		'<th style="text-align: left; padding: 4px 8px; border-bottom: 1px solid #e5e7eb;">status</th>'
-		'<th style="text-align: right; padding: 4px 8px; border-bottom: 1px solid #e5e7eb;">prev #</th>'
-		'<th style="text-align: right; padding: 4px 8px; border-bottom: 1px solid #e5e7eb;">curr #</th>'
-		'<th style="text-align: right; padding: 4px 8px; border-bottom: 1px solid #e5e7eb;">prev ms</th>'
-		'<th style="text-align: right; padding: 4px 8px; border-bottom: 1px solid #e5e7eb;">curr ms</th>'
-		'<th style="text-align: right; padding: 4px 8px; border-bottom: 1px solid #e5e7eb;">Δ ms</th>'
-		'<th style="text-align: left; padding: 4px 8px; border-bottom: 1px solid #e5e7eb;">source</th>'
+		'<table class="line-prof line-prof-diff">'
+		'<thead><tr>'
+		'<th>status</th>'
+		'<th class="num">prev #</th>'
+		'<th class="num">curr #</th>'
+		'<th class="num">prev ms</th>'
+		'<th class="num">curr ms</th>'
+		'<th class="num">&Delta; ms</th>'
+		'<th>source</th>'
 		'</tr></thead><tbody>',
 	]
 
+	# v0.7.x: VSCode Dark+ syntax highlighting for the cross-run diff
+	# source column. Highlight all diff rows together so multi-line
+	# constructs across the diff window stay correctly tokenised.
+	_highlight_python_snippet(diff_rows)
+
 	for row in diff_rows:
 		status = row.get("status", "")
-		# Status background: green for matched-faster, red for matched-slower,
-		# blue for added, gray for removed.
-		bg = "transparent"
 		delta = row.get("delta_ms")
+		# Row-class: `added` (green tint) for matched-faster + new
+		# rows; `removed` (red tint) for matched-slower + dropped
+		# rows. Matches the `.line-prof` CSS overlays.
+		tr_cls = ""
 		if status == "matched" and delta is not None:
 			if delta < -0.5:
-				bg = "#dcfce7"  # green-50
+				tr_cls = ' class="added"'
 			elif delta > 0.5:
-				bg = "#fee2e2"  # red-50
+				tr_cls = ' class="removed"'
 		elif status == "added":
-			bg = "#dbeafe"  # blue-50
+			tr_cls = ' class="added"'
 		elif status == "removed":
-			bg = "#f3f4f6"  # gray-100
+			tr_cls = ' class="removed"'
 
 		def _fmt(v):
 			return "—" if v is None else (f"{v:.2f}" if isinstance(v, float) else str(v))
 
-		source_cell = (
-			f'<code style="white-space: pre;">{_e(row.get("content", ""))}</code>'
-		)
+		_src_html = row.get("content_html")
+		_src = _src_html if _src_html else _e(row.get("content", ""))
+		source_cell = f'<code>{_src}</code>'
 
 		html.append(
-			f'<tr style="background: {bg};">'
-			f'<td style="padding: 2px 8px;">{_e(status)}</td>'
-			f'<td style="text-align: right; padding: 2px 8px; color: #6b7280;">{_fmt(row.get("lineno_old"))}</td>'
-			f'<td style="text-align: right; padding: 2px 8px; color: #6b7280;">{_fmt(row.get("lineno_new"))}</td>'
-			f'<td style="text-align: right; padding: 2px 8px;">{_fmt(row.get("ms_old"))}</td>'
-			f'<td style="text-align: right; padding: 2px 8px;">{_fmt(row.get("ms_new"))}</td>'
-			f'<td style="text-align: right; padding: 2px 8px;">{_fmt(delta)}</td>'
-			f'<td style="padding: 2px 8px;">{source_cell}</td>'
+			f'<tr{tr_cls}>'
+			f'<td>{_e(status)}</td>'
+			f'<td class="ln">{_fmt(row.get("lineno_old"))}</td>'
+			f'<td class="ln">{_fmt(row.get("lineno_new"))}</td>'
+			f'<td class="num">{_fmt(row.get("ms_old"))}</td>'
+			f'<td class="num">{_fmt(row.get("ms_new"))}</td>'
+			f'<td class="num">{_fmt(delta)}</td>'
+			f'<td class="src">{source_cell}</td>'
 			'</tr>'
 		)
 	html.append('</tbody></table>')
 	return "".join(html)
 
 
-def _render_phase2_panel(session_doc: Any) -> str:
-	"""Build the phase-2 section HTML. Returns an empty string when the
-	session has no phase-2 runs (the template's ``{% if phase2_html %}``
-	guard then skips the section entirely).
+def _render_line_drilldown_panel(session_doc: Any) -> str:
+	"""Build the Line-Level Drilldown section HTML. Returns an empty
+	string when the session has no phase-2 runs (the template's
+	``{% if line_drilldown_html %}`` guard then skips the section
+	entirely).
 
 	v0.6.0 Round 7: source-line text is always rendered (was previously
 	gated by the ``safe_report_include_source_lines`` setting in safe
@@ -1392,17 +1591,24 @@ def _render_phase2_panel(session_doc: Any) -> str:
 			"rows": _lp_diff.align_function(prev_fn["lines"], curr_fn["lines"]),
 		}
 
+	# v0.7.x Phase F: editorial section head with per-run cards +
+	# per-function blocks. Uses the shared `.section` / `.section-head` /
+	# `.phase2-run` / `.phase2-func` / `.line-prof` classes.
+	n_runs = len(parsed_runs)
 	html = [
-		'<details class="section" style="margin-top: 32px; padding: 16px; '
-		'border: 1px solid #d1d5db; border-radius: 6px; background: #ffffff;">',
-		'<summary><h2 style="margin: 0 0 8px 0;">Phase 2: Line-Level Drilldown</h2></summary>',
-		'<div style="background: #fef3c7; border-left: 4px solid #f59e0b; '
-		'padding: 8px 12px; margin-bottom: 16px; font-size: 13px;">'
-		'Phase 2 captures only the flow you ran during the line-profile '
-		'recording. Make sure your phase-2 reproduction exercises the same '
-		'code paths as phase 1 — function-not-invoked warnings indicate '
-		"otherwise."
-		'</div>',
+		'<details class="section" id="line-drilldown">',
+		'<summary>'
+		'<div class="section-head">'
+		'<h2>Line-Level Drilldown</h2>'
+		f'<span class="section-tag">{n_runs} run{"s" if n_runs != 1 else ""}</span>'
+		'</div>'
+		'</summary>',
+		'<p class="section-intro">'
+		'Line-Level Drilldown captures only the flow you ran during the '
+		'line-profile recording. Make sure the line-profile reproduction '
+		'exercises the same code paths as the initial session recording - '
+		'function-not-invoked warnings indicate otherwise.'
+		'</p>',
 	]
 
 	for run_idx, run in enumerate(parsed_runs, start=1):
@@ -1410,37 +1616,31 @@ def _render_phase2_panel(session_doc: Any) -> str:
 		picks_summary = ", ".join(
 			_e(p.get("dotted_path", "?")) for p in run.get("picks", [])
 		)
-		status_color = {
-			"Ready": "#16a34a",
-			"Recording": "#0ea5e9",
-			"Analyzing": "#f59e0b",
-			"Failed": "#dc2626",
-		}.get(run.get("status", ""), "#6b7280")
+		status = _e(run.get("status", ""))
+		total_ms = run.get("total_ms", 0)
 		html.append(
-			f'<div style="margin: 16px 0; padding: 12px; '
-			f'background: #f9fafb; border-radius: 4px;">'
-			f'<div style="display: flex; justify-content: space-between; '
-			f'align-items: baseline; margin-bottom: 8px;">'
-			f'<strong>Run {run_idx}</strong> '
-			f'<span style="color: {status_color}; font-size: 12px;">'
-			f'{_e(run.get("status", ""))} · {run.get("total_ms", 0):.2f}ms · '
-			f'{started}</span></div>'
-			f'<div style="font-size: 12px; color: #6b7280; margin-bottom: 8px;">'
-			f'<em>Picks:</em> {picks_summary or "—"}</div>'
+			'<div class="phase2-run">'
+			'<div class="phase2-run-head">'
+			f'<strong>Run {run_idx}</strong>'
+			'<span class="meta">'
+			f'<span class="status-badge status-{status}">{status}</span>'
+			f'{total_ms:.2f}ms &middot; {started}'
+			'</span>'
+			'</div>'
+			f'<div class="picks"><em>Picks:</em> {picks_summary or "-"}</div>'
 		)
-
 		for fn in run.get("functions", []):
 			html.append(_render_phase2_function_table(fn))
 		html.append('</div>')
 
 	if diffs:
 		html.append(
-			'<h3 style="margin-top: 24px;">Cross-Run Comparison</h3>'
-			'<div style="font-size: 13px; color: #4b5563; margin-bottom: 8px;">'
+			'<h3 class="frontend-h3">Cross-Run Comparison</h3>'
+			'<p class="section-intro">'
 			'For functions profiled in two or more runs, the table below shows '
 			'a line-by-line delta between the most recent two runs (aligned by '
-			'content hash so file edits between runs don\'t break the diff).'
-			'</div>'
+			"content hash so file edits between runs don't break the diff)."
+			'</p>'
 		)
 		for path, diff_meta in diffs.items():
 			label = (
@@ -1448,15 +1648,17 @@ def _render_phase2_panel(session_doc: Any) -> str:
 				f"Run {diff_meta['curr_run_idx'] + 1}"
 			)
 			html.append(
-				f'<div style="margin: 16px 0;">'
-				f'<div style="font-family: ui-monospace, Menlo, monospace; '
-				f'font-weight: 600; margin-bottom: 4px;">{_e(label)}</div>'
+				'<div class="phase2-func">'
+				f'<div class="fn-name">{_e(label)}</div>'
 			)
 			html.append(_render_phase2_diff_table(diff_meta["rows"]))
 			html.append('</div>')
 
 	html.append('</details>')
 	return "".join(html)
+
+
+_render_phase2_panel = _render_line_drilldown_panel
 
 
 def render_raw(session_doc: Any, recordings: list[dict]) -> str:
@@ -1476,10 +1678,23 @@ def render_raw(session_doc: Any, recordings: list[dict]) -> str:
 
 
 def _action_to_dict(child: Any) -> dict:
-	"""Flatten a Optimus Action child row to a plain dict."""
+	"""Flatten a Optimus Action child row to a plain dict.
+
+	v0.7.x J.12.1: normalise legacy ``event_type = "Background Job"`` to
+	the new ``"RQ Job"`` label at read time so reports rendered from
+	sessions captured before the J.12 rename still surface the RQ-Jobs
+	section. New recordings already carry the new label.
+	"""
+	_event_type = child.event_type or ""
+	if _event_type == "Background Job":
+		_event_type = "RQ Job"
+	_label = child.action_label or ""
+	# Same normalisation for the analyzer-baked label prefix.
+	if _label.startswith("Job: "):
+		_label = "RQ " + _label
 	return {
-		"action_label": child.action_label or "",
-		"event_type": child.event_type or "",
+		"action_label": _label,
+		"event_type": _event_type,
 		"http_method": child.http_method or "",
 		"path": child.path or "",
 		"recording_uuid": child.recording_uuid or "",
@@ -1495,9 +1710,9 @@ def _action_to_dict(child: Any) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# v0.6.0: "Background jobs" report section — render-time only (the pipeline is
+# v0.6.0: "RQ Jobs" report section — render-time only (the pipeline is
 # frozen). Derived purely from the persisted Optimus Action rows that have
-# event_type == "Background Job" (one per captured job recording), enriched
+# event_type == "RQ Job" (one per captured job recording), enriched
 # with the live recording's SQL when it's still in Redis.
 # ---------------------------------------------------------------------------
 
@@ -1512,18 +1727,22 @@ def _clean_job_method(action_label, path, recording) -> str:
 	``cmd``, then a generic placeholder."""
 	label = (action_label or "").strip()
 	if label:
-		prefix = "Job: "
-		return (label[len(prefix):].strip() or label) if label.startswith(prefix) else label
+		# Accept both the new ``"RQ Job: <method>"`` prefix and the legacy
+		# ``"Job: <method>"`` from sessions captured before the J.12 rename.
+		for prefix in ("RQ Job: ", "Job: "):
+			if label.startswith(prefix):
+				return label[len(prefix):].strip() or label
+		return label
 	p = (path or "").strip()
 	if p:
 		return p
 	if recording:
-		return (recording.get("cmd") or recording.get("path") or "").strip() or "Background Job"
-	return "Background Job"
+		return (recording.get("cmd") or recording.get("path") or "").strip() or "RQ Job"
+	return "RQ Job"
 
 
 def build_background_jobs(actions, recordings_by_uuid, findings=None) -> dict:
-	"""Build the "Background jobs" section payload from the (already
+	"""Build the "RQ Jobs" section payload from the (already
 	min-duration-filtered) action dicts.
 
 	``actions`` items are ``_action_to_dict`` output plus an ``idx`` key
@@ -1546,7 +1765,7 @@ def build_background_jobs(actions, recordings_by_uuid, findings=None) -> dict:
 
 	jobs: list[dict] = []
 	for a in (actions or []):
-		if a.get("event_type") != "Background Job":
+		if a.get("event_type") != "RQ Job":
 			continue
 		uuid = a.get("recording_uuid") or ""
 		rec = recordings_by_uuid.get(uuid) if recordings_by_uuid else None
@@ -1790,8 +2009,8 @@ def _find_node_in_tree(tree: dict, basename: str, function: str) -> dict | None:
 
 	The basename match (rather than full path) survives bench-relative vs
 	absolute path differences between where the analyzer ran and where the
-	render is happening — same trick ``_build_phase2_callsite_index`` uses
-	(``renderer.py:552``).
+	render is happening - same trick ``_build_line_drilldown_callsite_index``
+	uses.
 	"""
 	if not isinstance(tree, dict):
 		return None
@@ -2145,11 +2364,64 @@ def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 	    key omitted when the function isn't a registered ``doc_events`` hook.
 	"""
 	recordings_by_uuid = recordings_by_uuid or {}
+	# Build a per-action finding index so the fallback path (below) can
+	# infer doctype from a related finding's controller-path callsite when
+	# the recording's form_dict isn't available (Redis TTL expired).
+	_findings_by_action_idx: dict[int, list] = {}
+	for _f in (findings or []):
+		if not isinstance(_f, dict):
+			continue
+		_ref = (_f.get("action_ref") or "").strip()
+		if _ref.isdigit():
+			_findings_by_action_idx.setdefault(int(_ref), []).append(_f)
 	for a in (actions or []):
 		if not isinstance(a, dict):
 			continue
 		rec = recordings_by_uuid.get(a.get("recording_uuid") or "")
-		a["target_doc"] = _extract_target_doc(rec.get("form_dict") if isinstance(rec, dict) else None)
+		td = _extract_target_doc(rec.get("form_dict") if isinstance(rec, dict) else None)
+		# v0.7.x J.13: fallback when the recording isn't available
+		# (Redis TTL expired between record-time and regenerate-time) —
+		# infer the action's DocType from any related finding's callsite
+		# filepath via the controller-path mapping
+		# (e.g. ``erpnext/.../sales_invoice/sales_invoice.py`` → "Sales Invoice").
+		# Bench-side reports for old sessions get the DocType suffix
+		# without needing the recording or a fresh capture.
+		if not td:
+			for _rf in _findings_by_action_idx.get(a.get("idx"), []):
+				_detail = _rf.get("technical_detail") or {}
+				_cs = _detail.get("callsite") if isinstance(_detail, dict) else None
+				_fname = _cs.get("filename") if isinstance(_cs, dict) else None
+				_inferred = _doctype_from_controller_path(_fname or "")
+				if _inferred:
+					td = {"doctype": _inferred, "name": None}
+					break
+		a["target_doc"] = td
+		# v0.7.x J.8: enrich the action_label with the DocType suffix so
+		# every downstream consumer (TLDR composer, action-plan composer,
+		# per-action table cell, waterfall row, queries-per-action heading,
+		# related-finding inline link) shows the doctype inline without
+		# requiring template edits. Idempotent: the `" (" not in label`
+		# guard means re-renders pass through untouched.
+		_td_doctype = (a.get("target_doc") or {}).get("doctype") if isinstance(a.get("target_doc"), dict) else None
+		_a_label = a.get("action_label") or ""
+		if _td_doctype and _a_label and " (" not in _a_label:
+			a["action_label"] = f"{_a_label} ({_td_doctype})"
+		# v0.7.x J.9: same suffix on the URL path so the per-action
+		# `.action-meta` line ("POST /api/method/...") and the
+		# queries-per-action heading carry the doctype too. Idempotent on
+		# `" (" not in path` for re-renders.
+		_a_path = a.get("path") or ""
+		if _td_doctype and _a_path and " (" not in _a_path:
+			a["path"] = f"{_a_path} ({_td_doctype})"
+		# v0.7.x J.11: enrich the entry-callsite `function` so the small
+		# `.action-meta` line under each action row reads
+		# `…/save.py:16 · savedocs (Sales Invoice)` — keeps every filepath
+		# surface in the report consistently tagged with its DocType.
+		_ec = a.get("entry_callsite")
+		if _td_doctype and isinstance(_ec, dict):
+			_ec_fn = _ec.get("function") or ""
+			if _ec_fn and " (" not in _ec_fn:
+				_ec["function"] = f"{_ec_fn} ({_td_doctype})"
 	by_idx = {a.get("idx"): a for a in (actions or []) if isinstance(a, dict)}
 	hook_index = _doc_event_hook_index()
 	for f in (findings or []):
@@ -2165,6 +2437,26 @@ def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 			td = act.get("target_doc") if isinstance(act, dict) else None
 		if td:
 			detail["target_doc"] = td
+			# v0.7.x J.7: inject the DocType inline at the end of the
+			# italicised action-label phrase so the reader sees
+			# "During *frappe.desk.form.save.savedocs:Save (Sales Invoice)*"
+			# instead of "During *frappe.desk.form.save.savedocs:Save*" —
+			# keeps the technical label and the doctype emphasised together
+			# inside one self-contained italic phrase. Guards on the
+			# `"During *…*"` prose shape so self-referential / non-action
+			# descriptions pass through untouched.
+			_doctype = td.get("doctype") if isinstance(td, dict) else None
+			if _doctype:
+				_desc = f.get("customer_description") or ""
+				if _desc.startswith("During *"):
+					_close_idx = _desc.find("*", len("During *"))
+					if _close_idx > 0:
+						_action_label = _desc[len("During *"):_close_idx]
+						_original_chunk = f"*{_action_label}*"
+						_new_chunk = f"*{_action_label} ({_doctype})*"
+						f["customer_description"] = _desc.replace(
+							_original_chunk, _new_chunk, 1
+						)
 		hevs = _finding_hook_events(detail, hook_index, action_doctype=(td or {}).get("doctype"))
 		if hevs:
 			detail["hook_events"] = hevs
@@ -2510,7 +2802,7 @@ def _read_source_snippet(
 def _action_dotted_entry(action) -> str | None:
 	"""Derive an action's dotted entry-point path, or ``None``.
 
-	- Background Job: ``action["path"]`` is already the job method (Frappe's
+	- RQ Job: ``action["path"]`` is already the job method (Frappe's
 	  recorder stores ``frappe.job.method`` there — e.g.
 	  ``ugly_code.python.common.bg_recheck_users``).
 	- HTTP Request whose path is ``/api/method/<dotted>``: the ``<dotted>``
@@ -2524,7 +2816,7 @@ def _action_dotted_entry(action) -> str | None:
 	path = (action.get("path") or "").strip()
 	if not path:
 		return None
-	if event_type == "Background Job":
+	if event_type == "RQ Job":
 		return path.split("?", 1)[0].strip() or None
 	if event_type == "HTTP Request" and path.startswith("/api/method/"):
 		rest = path[len("/api/method/"):]
@@ -2824,6 +3116,595 @@ def _read_source_window(
 # away knowing (1) is the session slow, (2) what's the biggest problem,
 # (3) how much of the time it accounts for. Surfaces the top 3 most-
 # impactful actionable findings as plain-English bullets.
+#
+# v0.7.x: ``_build_executive_summary`` stays as the data layer (pace,
+# top-3 bullets, infra_note — feeds the upcoming Action plan section);
+# the *headline* portion of the original "At a glance" card was
+# replaced template-side by ``_compose_tldr`` below — a hero block
+# composing one sentence keyed on the single highest-impact finding.
+
+
+# Mapping from analyzer finding_type to a short category slug used by
+# _compose_tldr for branch selection. Anything not in the map falls
+# through to the verbatim-title branch — safe default.
+_CATEGORY_FOR_FINDING_TYPE: dict[str, str] = {
+	"N+1 Query": "n_plus_one",
+	"Framework N+1": "n_plus_one",
+	"Hook Bottleneck": "slow_hook",
+	"Slow Hot Path": "slow_path",
+	"Hot Line": "hot_line",
+	"Slow Query": "slow_query",
+	"Missing Index": "missing_index",
+	"Full Table Scan": "full_table_scan",
+	"Redundant Call": "redundant_call",
+	"Repeated Hot Frame": "repeated_hot_frame",
+	"Filesort": "filesort",
+	"Temporary Table": "temp_table",
+	"Low Filter Ratio": "low_filter",
+}
+
+# Ascending order for sorted() — High first. NOT the same as the
+# `> max` _SEVERITY_RANK constant defined earlier in this module
+# (which uses {High:3, Medium:2, Low:1} for max-of comparisons).
+# Named distinctly to avoid the shadowing collision that broke
+# `_build_doc_event_breakdown`'s severity-max merge.
+_TLDR_SEVERITY_ORDER = {"High": 0, "Medium": 1, "Low": 2}
+
+
+def _category_for(finding_type: str | None) -> str:
+	"""Map a finding_type string to a TL;DR category slug, or 'other'."""
+	return _CATEGORY_FOR_FINDING_TYPE.get(finding_type or "", "other")
+
+
+# Verb-led action titles per finding category. Strings are short
+# imperative phrases — the user reads the title alone and knows what
+# to do next. Fallback: the finding's own title (verbatim).
+_ACTION_VERB_FOR_FINDING_TYPE: dict[str, str] = {
+	"N+1 Query": "Eliminate the N+1 query",
+	"Framework N+1": "Eliminate the N+1 query (framework code)",
+	"Hook Bottleneck": "Speed up the doc-event hook",
+	"Slow Hot Path": "Optimise the hot call path",
+	"Hot Line": "Tune the single hottest line",
+	"Missing Index": "Add a database index",
+	"Slow Query": "Speed up the slow query",
+	"Full Table Scan": "Eliminate the full-table scan",
+	"Filesort": "Avoid the filesort",
+	"Temporary Table": "Avoid the temporary table",
+	"Low Filter Ratio": "Narrow the WHERE clause",
+	"Redundant Call": "Cache the repeated call",
+	"Repeated Hot Frame": "Investigate the recurring hot frame",
+}
+
+
+def _action_verb_for(finding_type: str | None) -> str | None:
+	"""Return a short verb-led action title for a finding_type, or
+	None when the verb isn't known (callers fall back to the finding's
+	own title)."""
+	return _ACTION_VERB_FOR_FINDING_TYPE.get(finding_type or "")
+
+
+def _build_action_plan(
+	findings: list[dict],
+	large_duration_threshold_ms: float = 1000.0,
+	max_steps: int = 3,
+) -> list[dict]:
+	"""Top-N action plan steps from the highest-impact findings.
+
+	Returns a list of dicts shaped for the template's
+	`.action-step` row::
+
+	    {"n": int, "title": str, "desc": str, "gain_ms": float,
+	     "gain_label": str, "callsite": "file:lineno" or None}
+
+	Sort: severity DESC, then estimated_impact_ms DESC. Findings with
+	zero impact are still eligible (they may not have a measurable
+	cost but still warrant attention). Empty input → empty list, and
+	the template hides the section.
+
+	The Action plan is conceptually the same top-3 as the old exec-
+	summary bullets; this function replaces that data layer.
+	"""
+	if not findings:
+		return []
+
+	def _sort_key(f: dict):
+		return (
+			_TLDR_SEVERITY_ORDER.get(f.get("severity") or "", 9),
+			-float(f.get("estimated_impact_ms") or 0),
+		)
+	ranked = sorted(findings, key=_sort_key)[:max_steps]
+
+	out: list[dict] = []
+	for i, f in enumerate(ranked, start=1):
+		ftype = f.get("finding_type") or ""
+		verb = _action_verb_for(ftype)
+		title = verb or (f.get("title") or "Investigate this finding")
+		desc = (f.get("customer_description") or "").strip()
+		if not desc:
+			# Fall back to the finding's title prose when no
+			# customer description is available — better than empty.
+			desc = (f.get("title") or "").strip()
+		callsite = None
+		detail = f.get("technical_detail") or {}
+		cs = detail.get("callsite") if isinstance(detail, dict) else None
+		if isinstance(cs, dict):
+			fname = cs.get("filename")
+			lineno = cs.get("lineno")
+			if fname and lineno:
+				callsite = f"{fname}:{lineno}"
+		# v0.7.x J.11: append the DocType suffix to the action-plan step
+		# callsite so the `.callsite` line under each step reads
+		# `ugly_code/python/common.py:13 (Sales Invoice)`. The
+		# detail.target_doc was attached by _attach_action_context earlier
+		# in the render flow; falls back to bare callsite when no doctype.
+		_td_dt = None
+		_td_obj = (detail.get("target_doc") if isinstance(detail, dict) else None) or {}
+		if isinstance(_td_obj, dict):
+			_td_dt = _td_obj.get("doctype")
+		if _td_dt and callsite and " (" not in callsite:
+			callsite = f"{callsite} ({_td_dt})"
+		out.append({
+			"n": i,
+			"title": title,
+			"desc": desc,
+			"gain_ms": float(f.get("estimated_impact_ms") or 0),
+			"gain_label": "est. saving",
+			"callsite": callsite,
+			"finding_type": ftype,
+		})
+	return out
+
+
+def _build_waterfall(
+	actions: list[dict],
+	findings: list[dict],
+	large_duration_threshold_ms: float = 1000.0,
+	max_rows: int = 8,
+) -> list[dict]:
+	"""Top-N actions by duration, formatted as a horizontal-bar
+	waterfall.
+
+	Returns a list of dicts::
+
+	    {"name": str, "duration_ms": float, "pct": float,
+	     "hot": bool, "bg": bool}
+
+	`pct` is scaled to the displayed slice's max duration — so the
+	longest row always renders at 100% and shorter rows are visible.
+	Scaling to the session total would make sub-second actions
+	invisible.
+
+	`hot` = the action has any High-severity linked finding (via
+	`action_ref`). `bg` = the action is a background job (event_type
+	== "RQ Job").
+
+	When ``actions`` is empty, returns an empty list and the template
+	hides the section.
+	"""
+	if not actions:
+		return []
+
+	# Build action_ref → high-severity-count once.
+	high_refs: set[str] = set()
+	for f in (findings or []):
+		if (f.get("severity") or "") == "High":
+			ref = str(f.get("action_ref") or "").strip()
+			if ref:
+				high_refs.add(ref)
+
+	def _duration(a: dict) -> float:
+		return float(a.get("duration_ms") or 0)
+
+	sorted_actions = sorted(
+		(a for a in actions if _duration(a) > 0),
+		key=_duration,
+		reverse=True,
+	)[:max_rows]
+	if not sorted_actions:
+		return []
+
+	max_ms = _duration(sorted_actions[0]) or 1.0
+
+	out: list[dict] = []
+	for a in sorted_actions:
+		dur = _duration(a)
+		idx = str(a.get("idx", "")).strip()
+		is_bg = (a.get("event_type") or "") == "RQ Job"
+		is_hot = idx in high_refs
+		# Name: action_label or the dotted path.
+		name = (
+			a.get("action_label")
+			or a.get("path")
+			or a.get("method")
+			or "?"
+		)
+		out.append({
+			"name": str(name),
+			"duration_ms": dur,
+			"pct": round((dur / max_ms) * 100.0, 1) if max_ms else 0.0,
+			"hot": is_hot,
+			"bg": is_bg,
+		})
+	return out
+
+
+_ORM_DOCTYPE_PATTERNS = [
+	# frappe.get_doc("User", ...) / frappe.get_cached_doc("User", ...) /
+	# frappe.db.get_value("User", ...) / frappe.get_all("User", ...) / frappe.db.exists("User", ...) etc.
+	re.compile(r"""frappe\.(?:db\.)?(?:get_doc|get_cached_doc|get_value|get_all|get_list|exists|get_single)\s*\(\s*['"]([A-Z][A-Za-z _]+)['"]"""),
+]
+
+
+def _doctype_from_orm_call(src_line: str | None) -> str | None:
+	"""Pull a DocType name out of common Frappe ORM call literals.
+
+	``frappe.get_doc("User", ...)`` -> ``"User"``. Returns None when the
+	line isn't a recognised ORM call. Used by ``_compose_tldr`` to write
+	"a User document fetched 100 times" instead of a generic "a document".
+	"""
+	if not src_line:
+		return None
+	s = str(src_line)
+	for pat in _ORM_DOCTYPE_PATTERNS:
+		m = pat.search(s)
+		if m:
+			return m.group(1).strip() or None
+	return None
+
+
+def _action_verb_from_label(action_label: str | None) -> str | None:
+	"""``"frappe.desk.form.save.savedocs:Submit"`` -> ``"Submit"``.
+
+	Returns the part after the final colon when present; ``None`` otherwise.
+	Used by ``_compose_tldr`` to write "Sales Invoice Submit" naturally.
+	"""
+	if not action_label or ":" not in action_label:
+		return None
+	tail = action_label.rsplit(":", 1)[-1].strip()
+	# Strip any J.8/J.9 doctype suffix "(Sales Invoice)" off the verb.
+	if " (" in tail:
+		tail = tail.split(" (", 1)[0].strip()
+	return tail or None
+
+
+def _savings_phrase(pct: float) -> str:
+	"""Fuzzy round of an impact percentage into a human phrase.
+
+	``pct`` is impact_ms / action_duration_ms (range 0..1). Returns
+	"by roughly half" / "by roughly two-thirds" / "by roughly a third"
+	near common fractions; falls back to "by roughly N%" outside those
+	bands so the prose stays accurate for awkward ratios.
+	"""
+	if pct is None or pct <= 0:
+		return ""
+	if pct >= 0.65:
+		return "by roughly two-thirds"
+	if 0.40 <= pct < 0.65:
+		return "by roughly half"
+	if 0.20 <= pct < 0.40:
+		return "by roughly a third"
+	return f"by roughly {pct * 100:.0f}%"
+
+
+_CALL_TREE_MAX_DEPTH = 12  # truncate ultra-deep stacks for sanity
+
+
+def _render_call_tree_node(node, parent_ms, depth=0):
+	"""Phase K.5: recursive nested-``<details>`` emit for a single
+	call_tree node. Auto-expands the first ``depth`` levels; deeper
+	branches start collapsed so the panel doesn't unfurl into thousands
+	of frames on first paint.
+	"""
+	if not isinstance(node, dict):
+		return ""
+	fn = node.get("function") or "<?>"
+	file = node.get("filename") or ""
+	lineno = node.get("lineno") or ""
+	cum_ms = float(node.get("cumulative_ms") or 0)
+	self_ms = float(node.get("self_ms") or 0)
+	children = node.get("children") or []
+
+	pct = (cum_ms / parent_ms * 100.0) if parent_ms else 0.0
+	cls = "call-tree-node"
+	if parent_ms and cum_ms / parent_ms >= 0.5:
+		cls += " call-tree-hot"
+
+	open_attr = " open" if depth < 1 else ""
+	meta_lineno = f":{lineno}" if lineno else ""
+	pct_label = f" &middot; {pct:.0f}%" if parent_ms else ""
+	self_label = ""
+	if self_ms and cum_ms - self_ms > 1:
+		self_label = f" &middot; self {self_ms:.0f}ms"
+
+	out = [
+		f'<details class="{cls}"{open_attr}>',
+		'<summary>',
+		f'<span class="frame-name">{_e(fn)}</span>',
+		f'<span class="frame-meta">{_e(file)}{meta_lineno} &middot; '
+		f'{cum_ms:.0f}ms{pct_label}{self_label}</span>',
+		'</summary>',
+	]
+	if children and depth < _CALL_TREE_MAX_DEPTH:
+		out.append('<div class="call-tree-children">')
+		children_sorted = sorted(
+			children,
+			key=lambda c: float((c or {}).get("cumulative_ms") or 0),
+			reverse=True,
+		)
+		for c in children_sorted:
+			out.append(_render_call_tree_node(c, cum_ms, depth + 1))
+		out.append('</div>')
+	elif children:
+		# Truncation note for very deep trees.
+		out.append(
+			'<div class="call-tree-children call-tree-truncated">'
+			f'<em>... {len(children)} child frame(s) hidden (depth limit reached) ...</em>'
+			'</div>'
+		)
+	out.append('</details>')
+	return "".join(out)
+
+
+def _render_call_tree_panel(actions):
+	"""Phase K.5: render the call-tree panel sourced from the slowest
+	action's ``call_tree_json``. Empty string when no action carries
+	a tree (the template's ``{% if %}`` guard hides the section).
+	"""
+	if not actions:
+		return ""
+	# Pick the action with the largest duration_ms that also has a tree.
+	candidates = [a for a in actions if isinstance(a, dict) and a.get("call_tree_json")]
+	if not candidates:
+		return ""
+	top = max(candidates, key=lambda a: float(a.get("duration_ms") or 0))
+	try:
+		tree = json.loads(top.get("call_tree_json") or "{}")
+	except Exception:
+		return ""
+	if not isinstance(tree, dict):
+		return ""
+	root_children = tree.get("children") or []
+	if not root_children:
+		return ""
+
+	total_ms = float(tree.get("cumulative_ms") or 0) or float(top.get("duration_ms") or 0)
+	action_label = top.get("action_label") or ""
+
+	parts = [
+		'<details class="section" id="call-tree">',
+		'<summary>',
+		'<div class="section-head">',
+		'<h2>Call tree (top action)</h2>',
+		f'<span class="section-tag">{_e(action_label)}</span>',
+		'</div>',
+		'</summary>',
+		'<p class="section-intro">'
+		'Hierarchical breakdown of where wall-clock time went inside the slowest '
+		'action. Click any frame to expand its children. Numbers are cumulative time '
+		'(including children) and percentage of the parent. Branches consuming '
+		'&ge;50% of their parent are highlighted as hot.'
+		'</p>',
+		'<div class="call-tree">',
+	]
+	root_children_sorted = sorted(
+		root_children,
+		key=lambda c: float((c or {}).get("cumulative_ms") or 0),
+		reverse=True,
+	)
+	for c in root_children_sorted:
+		parts.append(_render_call_tree_node(c, total_ms, depth=0))
+	parts.append('</div>')
+	parts.append('</details>')
+	return "".join(parts)
+
+
+def _compose_tldr(
+	findings: list[dict],
+	session_doc: Any,
+	large_duration_threshold_ms: float = 1000.0,
+	actions: list[dict] | None = None,
+) -> dict:
+	"""Compose the TL;DR hero block.
+
+	Picks the single highest-impact finding (severity desc, then impact
+	desc), looks up its category, and builds a one-sentence headline
+	with the impact / loop-count / hook-name highlighted via
+	``<span class="hot">…</span>``. The sub-line is session totals.
+
+	Returns a dict the template renders verbatim:
+	``{"label": str, "headline_markup": Markup, "sub_markup": Markup}``.
+
+	When ``findings`` is empty, returns the clean-session branch
+	(no <span class="hot"> — nothing's wrong, no signal red needed).
+
+	The Markup-aware composition mirrors the recently-fixed
+	executive-summary headline: f-strings would flatten Markup back
+	to str and Jinja would HTML-escape the spans, so we use
+	``Markup.format(...)`` — it escapes plain-string args and passes
+	Markup args through untouched.
+	"""
+	def _fmt(v):
+		return _format_duration_ms(v, large_duration_threshold_ms)
+
+	total_ms = float(getattr(session_doc, "total_duration_ms", 0) or 0)
+	total_queries = int(getattr(session_doc, "total_queries", 0) or 0)
+	total_actions = int(getattr(session_doc, "total_requests", 0) or 0)
+
+	if not findings:
+		# Clean-session branch — no signal red.
+		return {
+			"label": "Clean session",
+			"headline_markup": Markup(
+				"Nothing to fix in this session - total {duration} across "
+				"{actions} operation{plural}, all under threshold."
+			).format(
+				duration=_fmt(total_ms),
+				actions=total_actions,
+				plural="s" if total_actions != 1 else "",
+			),
+			"sub_markup": Markup(
+				"Session total {duration} &middot; {actions} operations "
+				"&middot; {queries} DB queries."
+			).format(
+				duration=_fmt(total_ms),
+				actions=total_actions,
+				queries=total_queries,
+			),
+		}
+
+	# Sort by severity DESC then impact_ms DESC — be defensive even
+	# though the upstream sort usually already has this order.
+	def _sort_key(f: dict):
+		return (
+			_TLDR_SEVERITY_ORDER.get(f.get("severity") or "", 9),
+			-float(f.get("estimated_impact_ms") or 0),
+		)
+	top = sorted(findings, key=_sort_key)[0]
+
+	finding_type = top.get("finding_type") or ""
+	category = _category_for(finding_type)
+	impact_ms = float(top.get("estimated_impact_ms") or 0)
+	affected = int(top.get("affected_count") or 0)
+	title = top.get("title") or ""
+	severity = top.get("severity") or "?"
+
+	impact_html = _fmt(impact_ms)
+
+	# v0.7.x J.15: rich Hot Line branch — narrative two-sentence
+	# headline that names the target DocType being fetched, the loop
+	# count, the action it's slowing, and the expected savings.
+	# Falls through to a slimmer sentence when any of those are missing.
+	if category == "hot_line" and affected:
+		_detail = (top.get("technical_detail") or {})
+		_cs = _detail.get("callsite") or {}
+		_target_doctype = None
+		# Find the hot line in the source snippet and parse a DocType
+		# literal off it.
+		_target_lineno = _cs.get("lineno") if isinstance(_cs, dict) else None
+		for _sl in (_cs.get("source_snippet") or []):
+			if isinstance(_sl, dict) and _sl.get("lineno") == _target_lineno:
+				_target_doctype = _doctype_from_orm_call(_sl.get("content"))
+				break
+		# Find the action this finding belongs to + compute savings.
+		_action_label_human = None
+		_savings = None
+		_ref = (top.get("action_ref") or "").strip()
+		if _ref.isdigit() and actions:
+			_idx = int(_ref)
+			for _a in actions:
+				if isinstance(_a, dict) and _a.get("idx") == _idx:
+					_a_dt = (_a.get("target_doc") or {}).get("doctype") if isinstance(_a.get("target_doc"), dict) else None
+					_verb = _action_verb_from_label(_a.get("action_label"))
+					if _a_dt and _verb:
+						_action_label_human = f"{_a_dt} {_verb}"
+					elif _verb:
+						_action_label_human = _verb
+					_a_ms = float(_a.get("duration_ms") or 0)
+					if _a_ms > 0:
+						_savings = _savings_phrase(impact_ms / _a_ms)
+					break
+		if _target_doctype and _action_label_human and _savings:
+			headline = Markup(
+				"One line of code is responsible for "
+				"<span class=\"hot\">~{impact}</span> of this session "
+				"&mdash; a <strong>{target}</strong> document fetched "
+				"<span class=\"hot\">{n} times inside a loop</span> that "
+				"should only run once. Fix it and the "
+				"<strong>{label}</strong> drops {savings}."
+			).format(
+				impact=impact_html,
+				target=_target_doctype,
+				n=affected,
+				label=_action_label_human,
+				savings=_savings,
+			)
+		else:
+			# Slimmer fallback when ORM target / action context isn't
+			# available (e.g. legacy data, framework call).
+			headline = Markup(
+				"One line of code is responsible for "
+				"<span class=\"hot\">~{impact}</span> of this session "
+				"&mdash; same line ran <span class=\"hot\">{n} times "
+				"inside a loop</span>. Tune that line and most of the "
+				"cost goes away."
+			).format(impact=impact_html, n=affected)
+	elif category == "n_plus_one" and affected:
+		headline = Markup(
+			"One line of code is responsible for <span class=\"hot\">~"
+			"{impact}</span> of this session &mdash; same query ran "
+			"<span class=\"hot\">{n}× inside a loop</span>. "
+			"Removing the redundant round-trips is the single biggest "
+			"win here."
+		).format(impact=impact_html, n=affected)
+	elif category == "slow_hook":
+		headline = Markup(
+			"<span class=\"hot\">{impact}</span> is spent inside a "
+			"doc-event hook — the slowest hook this session. {title}"
+		).format(impact=impact_html, title=title)
+	elif category in ("slow_query", "missing_index", "full_table_scan"):
+		headline = Markup(
+			"A single query took <span class=\"hot\">{impact}</span> "
+			"— {title}"
+		).format(impact=impact_html, title=title)
+	elif category == "redundant_call":
+		if affected:
+			headline = Markup(
+				"Same call repeated <span class=\"hot\">{n}×</span> "
+				"— {impact} of this session. {title}"
+			).format(n=affected, impact=impact_html, title=title)
+		else:
+			headline = Markup(
+				"<span class=\"hot\">{impact}</span> in redundant work — "
+				"{title}"
+			).format(impact=impact_html, title=title)
+	else:
+		# Fallback — verbatim title with the impact called out.
+		headline = Markup(
+			"<span class=\"hot\">{impact}</span> &middot; {title}"
+		).format(impact=impact_html, title=title)
+
+	same_sev_count = sum(
+		1 for f in findings if (f.get("severity") or "") == severity
+	)
+	# v0.7.x J.15: when every finding of the top severity points at the
+	# same callsite filename, append "all in <file>" to the sub-line so
+	# the reader sees the single hot file at a glance. Multi-file or
+	# missing-callsite cases fall through with no suffix.
+	_sev_filenames = set()
+	for _f in findings:
+		if (_f.get("severity") or "") != severity:
+			continue
+		_d = _f.get("technical_detail")
+		if not isinstance(_d, dict):
+			continue
+		_c = _d.get("callsite")
+		if isinstance(_c, dict):
+			_fname = _c.get("filename")
+			if _fname:
+				_sev_filenames.add(_fname)
+	_all_in = ""
+	if len(_sev_filenames) == 1:
+		_only = next(iter(_sev_filenames))
+		_all_in = Markup(", all in <code>{file}</code>").format(file=_only)
+	sub = Markup(
+		"Session total {duration} &middot; {actions} operations "
+		"&middot; {queries:,} DB queries &middot; "
+		"{n} {severity_lc}-severity finding{plural}{all_in}."
+	).format(
+		duration=_fmt(total_ms),
+		actions=total_actions,
+		queries=total_queries,
+		n=same_sev_count,
+		severity_lc=severity.lower(),
+		plural="s" if same_sev_count != 1 else "",
+		all_in=_all_in,
+	)
+
+	return {
+		"label": "The headline",
+		"headline_markup": headline,
+		"sub_markup": sub,
+	}
 
 
 def _build_executive_summary(
@@ -3349,8 +4230,17 @@ def build_donut_svg(slices: list) -> str:
 	return "".join(parts)
 
 
-def build_hot_frames_table(rows: list) -> list:
-	"""Build the hot-frames leaderboard rows."""
+def build_hot_frames_table(rows: list, is_hot: bool = False) -> list:
+	"""Build the hot-frames leaderboard rows.
+
+	``is_hot`` (Phase E): caller-controlled flag attached to each
+	emitted dict so the template can apply `tr.is-hot` styling on the
+	user-code rows (yellow tint) and leave the framework rows
+	unmarked. The renderer always splits hot frames into user-vs-
+	framework lists before calling this builder, so the flag is a
+	per-list constant — True for the user-code table, False for the
+	framework sibling.
+	"""
 	out = []
 	for row in rows or []:
 		display = redact_frame_name(
@@ -3362,5 +4252,6 @@ def build_hot_frames_table(rows: list) -> list:
 			"occurrences": row.get("occurrences", 0),
 			"distinct_actions": row.get("distinct_actions", 0),
 			"action_refs": row.get("action_refs", []),
+			"is_hot": is_hot,
 		})
 	return out

--- a/optimus/report_context.py
+++ b/optimus/report_context.py
@@ -1,0 +1,1011 @@
+# Copyright (c) 2026, Optimus contributors
+# For license information, please see license.txt
+
+"""Phase J adapter — transform our flat render-context into the 19-key
+contract shape per ``template_variable_contract.md`` (in the reference
+design package).
+
+This module is the adapter half of the reference architecture: ``renderer.py``
+keeps producing its existing 45-key flat context, and ``build_report_context``
+turns that into the canonical nested-dict shape the reference template
+expects. Phase J.1 (this module) exposes the contract data under a
+``report_data`` namespace so template references can migrate section-by-
+section in Phase J.2 without breaking. Phase J.3 will unpack the namespace
+and drop the legacy duplicates.
+"""
+
+from __future__ import annotations
+
+import html as _html
+import json as _json
+from typing import Any
+
+from markupsafe import Markup
+
+# ---------------------------------------------------------------------------
+# Helpers — small pure functions called by sub-builders below
+# ---------------------------------------------------------------------------
+
+
+def _web_vital_class(value, good_threshold, poor_threshold) -> str:
+	"""Map a web-vital value to its rating class per web.dev thresholds.
+
+	Returns ``vital-good`` / ``vital-meh`` / ``vital-poor`` / ``vital-none``
+	(the four CSS classes the template uses to colour the cell).
+	"""
+	if value is None or value == 0:
+		return "vital-none"
+	if value < good_threshold:
+		return "vital-good"
+	if value > poor_threshold:
+		return "vital-poor"
+	return "vital-meh"
+
+
+def _bar_kind_for(duration_ms) -> str | None:
+	"""Per-action / per-job bar colour key.
+
+	``duration ≥ 1000ms`` → ``None`` (red, contract's default).
+	``300 ≤ duration < 1000`` → ``"warn"`` (amber).
+	``duration < 300`` → ``"ok"`` (green).
+	"""
+	if duration_ms is None:
+		return "ok"
+	if duration_ms >= 1000:
+		return None
+	if duration_ms >= 300:
+		return "warn"
+	return "ok"
+
+
+def _is_user_code(function_or_path, ignored_apps: tuple[str, ...] = ()) -> bool:
+	"""``True`` if the function/path does not start with any ignored-app prefix.
+
+	Used to highlight hot-frames rows that live in user code (vs framework
+	internals where the user can't act).
+	"""
+	if not function_or_path:
+		return False
+	text = str(function_or_path)
+	for prefix in ignored_apps or ():
+		if text.startswith(prefix + "/") or text.startswith(prefix + "."):
+			return False
+	return True
+
+
+def _ms_display(ms) -> str:
+	"""Format milliseconds for display per the contract's mixed-unit style:
+	below 1000ms → integer ms; at-or-above → seconds with 2 decimals."""
+	if ms is None:
+		return ""
+	if ms < 1000:
+		return f"{ms:.0f} ms"
+	return f"{ms / 1000:.2f} s"
+
+
+# ---------------------------------------------------------------------------
+# Sub-builders — one per contract key, in contract order
+# ---------------------------------------------------------------------------
+
+
+def _build_session(session_doc, ctx) -> dict:
+	"""Contract ``session`` = {id, recorded_by, started_at, ended_at, timezone, generated_at}."""
+	fmt_dt = ctx.get("fmt_dt") or (lambda v: str(v) if v else "")
+	return {
+		"id": getattr(session_doc, "session_uuid", None) or getattr(session_doc, "name", "") or "",
+		"recorded_by": getattr(session_doc, "user", "") or "",
+		"started_at": fmt_dt(getattr(session_doc, "started_at", None)),
+		"ended_at": fmt_dt(
+			getattr(session_doc, "stopped_at", None) or getattr(session_doc, "ended_at", None)
+		),
+		"timezone": ctx.get("server_tz") or "",
+		"generated_at": ctx.get("generated_at") or "",
+	}
+
+
+def _build_tldr(tldr) -> dict:
+	"""Contract ``tldr`` = {headline_html, subline_html}.
+
+	Our internal tldr has ``headline_markup`` / ``sub_markup`` (Markup
+	objects). Stringify and rename.
+	"""
+	if not tldr:
+		return {"headline_html": "", "subline_html": ""}
+	return {
+		"headline_html": str(tldr.get("headline_markup") or tldr.get("headline_html") or ""),
+		"subline_html": str(tldr.get("sub_markup") or tldr.get("subline_html") or ""),
+	}
+
+
+def _build_kpis(session_doc, ctx) -> list[dict]:
+	"""Contract ``kpis`` = exactly 4 items: total time, queries, ops, findings.
+
+	Labels and sub-line wording mirror the pre-J.2 template literally so the
+	migration is a binding-only change (no tested-text surface moves). The
+	severity breakdown comes from ``ctx.severity_counts`` (computed in
+	``renderer.render``) and the danger thresholds from ``render_config``.
+	"""
+	fmt_ms = ctx.get("fmt_ms") or (lambda v, **kw: f"{v:.0f}ms")
+	total_ms = getattr(session_doc, "total_duration_ms", 0) or 0
+	total_query_ms = getattr(session_doc, "total_query_time_ms", 0) or 0
+	total_queries = getattr(session_doc, "total_queries", 0) or 0
+	total_requests = getattr(session_doc, "total_requests", 0) or 0
+
+	render_config = ctx.get("render_config") or {}
+	threshold_ms = render_config.get("large_duration_threshold_ms") or 1000
+
+	all_findings = ctx.get("all_findings") or ctx.get("findings") or []
+	total_findings = len(all_findings)
+	severity_counts = ctx.get("severity_counts") or {}
+	high = severity_counts.get("High", 0) or 0
+	medium = severity_counts.get("Medium", 0) or 0
+	low = severity_counts.get("Low", 0) or 0
+
+	# "X high · Y medium · Z low" — only non-zero buckets, separator-joined.
+	sev_parts = []
+	if high:
+		sev_parts.append(f"{high} high")
+	if medium:
+		sev_parts.append(f"{medium} medium")
+	if low:
+		sev_parts.append(f"{low} low")
+	findings_sub = " · ".join(sev_parts) if sev_parts else "none detected"
+
+	server_ms = total_ms - total_query_ms
+	# Markup-aware concat — fmt_ms returns Markup for ≥1s values
+	# (`<span class="time-high">…</span>`). f-string would coerce to plain
+	# str and Jinja autoescape would HTML-encode the span.
+	total_time_sub = (
+		fmt_ms(server_ms) + Markup(" server · ") + fmt_ms(total_query_ms) + Markup(" DB")
+	)
+
+	ops_plural = "s" if total_requests != 1 else ""
+
+	return [
+		{
+			"label": "Total time",
+			"value": fmt_ms(total_ms),
+			"unit": "",
+			"sub": total_time_sub,
+			"is_danger": total_ms >= threshold_ms,
+		},
+		{
+			"label": "Database queries",
+			"value": str(total_queries),
+			"unit": "",
+			"sub": f"across {total_requests} operation{ops_plural}",
+			"is_danger": False,
+		},
+		{
+			"label": "Operations",
+			"value": str(total_requests),
+			"unit": "",
+			"sub": "page loads · saves · jobs",
+			"is_danger": False,
+		},
+		{
+			"label": "Issues found",
+			"value": str(total_findings),
+			"unit": "",
+			"sub": findings_sub if total_findings else "none detected",
+			"is_danger": high > 0,
+		},
+	]
+
+
+def _build_repro(notes_html) -> dict | None:
+	"""Contract ``repro`` = {title, steps}. Defer parsing to J.2.
+
+	For J.1 we expose the sanitized markup as ``raw_html`` plus empty
+	``title``/``steps``. The template migration in J.2 will decide whether
+	to parse the ``<ol><li>`` into the structured fields or render the
+	raw markup; the contract permits either.
+	"""
+	if not notes_html:
+		return None
+	return {"title": "", "steps": [], "raw_html": notes_html}
+
+
+def _build_summary(summary_html) -> dict | None:
+	"""Contract ``summary`` = {paragraphs_html: [...]}.
+
+	Our existing summary is one HTML chunk (``<ul>`` of bullets). Wrap in
+	a single-paragraph list — the contract permits HTML inside each entry.
+	"""
+	if not summary_html:
+		return None
+	return {"paragraphs_html": [summary_html]}
+
+
+def _build_smoking_code_html(snippet, target_lineno) -> str:
+	"""Wrap a ``source_snippet`` list in contract-shaped HTML.
+
+	Skips blank context lines (PEP-8 spacers); the target line is always
+	rendered, wrapped in ``<span class="hot-line">``. Matches the Phase
+	I.5 contract from the smoking-gun panel.
+	"""
+	if not snippet:
+		return ""
+	parts = []
+	for sl in snippet:
+		lineno = sl.get("lineno")
+		content = sl.get("content", "") or ""
+		if not content.strip() and lineno != target_lineno:
+			continue
+		escaped = _html.escape(content)
+		if lineno == target_lineno:
+			parts.append(f'<span class="hot-line"><span class="ln">{lineno}</span>{escaped}</span>')
+		else:
+			parts.append(f'<span class="ln">{lineno}</span>{escaped}')
+	return "\n".join(parts)
+
+
+def _build_findings(findings, ctx) -> list[dict]:
+	"""Contract ``findings`` = per-finding {severity, title_html, file_line,
+	impact_display, impact_sub, smoking_label, smoking_code_html,
+	smoking_footnote_html, chain, ai_fix}.
+	"""
+	severity_map = {"high": "high", "medium": "med", "low": "low"}
+	result = []
+	for f in findings or []:
+		detail = f.get("technical_detail") or {}
+		callsite = detail.get("callsite") or {}
+		impact_ms = f.get("estimated_impact_ms") or 0
+		affected = f.get("affected_count") or 0
+		severity_raw = (f.get("severity") or "").lower()
+		severity = severity_map.get(severity_raw, severity_raw or "low")
+
+		file_line_parts = []
+		if callsite.get("filename"):
+			file_line_parts.append(f"{callsite['filename']}:{callsite.get('lineno', '')}")
+		if callsite.get("function"):
+			file_line_parts.append(f"· {callsite['function']}")
+		file_line = " ".join(file_line_parts)
+
+		impact_sub_parts = []
+		if affected:
+			impact_sub_parts.append(f"{affected}× hits")
+		finding_type = f.get("finding_type") or ""
+		if finding_type:
+			impact_sub_parts.append(finding_type.lower())
+		impact_sub = " · ".join(impact_sub_parts)
+
+		chain = []
+		chain_steps = detail.get("call_chain") or detail.get("drilldown_chain") or []
+		for step in chain_steps:
+			label = f"{step.get('function') or step.get('qualname', '')}"
+			if step.get("lineno"):
+				label = f"{label}:{step['lineno']}"
+			chain.append({"label": label, "terminal": False})
+		if chain:
+			chain[-1]["terminal"] = True
+
+		ai_fix = f.get("llm_fix")
+		ai_fix_dict = None
+		if ai_fix:
+			ai_fix_dict = {
+				"model": ai_fix.get("model", ""),
+				"diagnosis_html": ai_fix.get("diagnosis_html", "") or ai_fix.get("description_html", ""),
+				"patch_html": ai_fix.get("patch_html", "") or ai_fix.get("code_html", ""),
+				"rationale_html": ai_fix.get("rationale_html", "") or ai_fix.get("why_html", ""),
+				"verify_html": ai_fix.get("verify_html", "") or ai_fix.get("verify", ""),
+			}
+
+		entry = dict(f)  # preserve all original finding fields
+		entry.update({
+			"severity": severity,
+			"title_html": f.get("title", "") or "",
+			"file_line": file_line,
+			"impact_display": _ms_display(impact_ms) if impact_ms else "",
+			"impact_sub": impact_sub,
+			"smoking_label": "The hot line",
+			"smoking_code_html": _build_smoking_code_html(
+				callsite.get("source_snippet", []), callsite.get("lineno")
+			),
+			"smoking_footnote_html": None,
+			"chain": chain,
+			"ai_fix": ai_fix_dict,
+		})
+		result.append(entry)
+	return result
+
+
+def _build_line_drilldown_runs(session_doc) -> list[dict]:
+	"""Contract ``line_drilldown_runs`` (J.16 renamed from
+	``phase2_runs``) = list of {number, status, total_ms_display,
+	timestamp, picks, functions}.
+	"""
+	runs = getattr(session_doc, "phase_2_runs", None) or []
+	result = []
+	number = 0
+	for run in runs:
+		status = getattr(run, "status", "") or ""
+		if status != "Ready":
+			continue
+		number += 1
+		total_ms = getattr(run, "total_ms", 0) or 0
+		picks_json = getattr(run, "picks_json", "") or "[]"
+		try:
+			picks_list = _json.loads(picks_json) if picks_json else []
+		except (ValueError, TypeError):
+			picks_list = []
+		results_json = getattr(run, "results_json", "") or "[]"
+		try:
+			functions_raw = _json.loads(results_json) if results_json else []
+		except (ValueError, TypeError):
+			functions_raw = []
+
+		pick_source_by_path = {
+			p.get("dotted_path", ""): p.get("source", "curated") for p in picks_list
+		}
+
+		functions = []
+		for fn in functions_raw:
+			dotted = fn.get("dotted_path", "")
+			source = pick_source_by_path.get(dotted, "curated")
+			indent = 1 if source == "auto_expand" else 0
+			raw_lines = fn.get("lines") or []
+			hot_idx = None
+			if raw_lines:
+				hot_idx = max(range(len(raw_lines)), key=lambda i: raw_lines[i].get("total_ms", 0))
+				if raw_lines[hot_idx].get("total_ms", 0) <= 0:
+					hot_idx = None
+			lines = []
+			for i, line in enumerate(raw_lines):
+				per_hit_us = line.get("per_hit_us", 0) or 0
+				lines.append({
+					"lineno": line.get("lineno", 0),
+					"hits": line.get("hits", 0),
+					"total_display": f"{line.get('total_ms', 0):.2f} ms",
+					"per_hit_display": (
+						f"{per_hit_us / 1000:.4f} ms" if per_hit_us else "0.00 ms"
+					),
+					"source": line.get("content", ""),
+					"is_hot": i == hot_idx,
+				})
+			functions.append({
+				"indent": indent,
+				"qualified_name": dotted,
+				"path": fn.get("file", ""),
+				"lines": lines,
+			})
+
+		result.append({
+			"number": number,
+			"status": status,
+			"total_ms_display": f"{total_ms:.2f} ms",
+			"timestamp": str(getattr(run, "started_at", "") or ""),
+			"picks": [p.get("dotted_path", "") for p in picks_list],
+			"functions": functions,
+		})
+	return result
+
+
+def _build_action_plan(action_plan, fmt_ms=None) -> list[dict]:
+	"""Contract ``action_plan`` = {number, title_html, description_html,
+	savings_display, savings_label}.
+
+	We also expose ``callsite`` (a non-contract field) so the template can
+	render a one-line ``file:line`` anchor under each step; the contract
+	folds this into ``description_html`` but our markup keeps it separate.
+	"""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	result = []
+	for step in action_plan or []:
+		gain_ms = step.get("gain_ms", 0) or 0
+		result.append({
+			"number": step.get("n", 0),
+			"title_html": step.get("title", "") or "",
+			"description_html": step.get("desc", "") or "",
+			# Use Markup so the `<span class="time-high">…</span>` that
+			# ``_format_duration_ms`` returns for ≥1s values isn't escaped
+			# when the template renders it. f-string would coerce Markup to
+			# plain str and lose the safe-flag.
+			"savings_display": Markup("−") + fmt(gain_ms) if gain_ms else "",
+			"savings_label": step.get("gain_label", "") or "",
+			"callsite": step.get("callsite") or "",
+		})
+	return result
+
+
+def _build_waterfall(waterfall_rows, fmt_ms=None) -> list[dict]:
+	"""Contract ``waterfall`` = {name, width_pct, duration_display, kind, is_hot_text}."""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	result = []
+	for row in waterfall_rows or []:
+		is_hot = bool(row.get("hot", False))
+		is_bg = bool(row.get("bg", False))
+		result.append({
+			"name": row.get("name", "") or "",
+			"width_pct": row.get("pct", 0),
+			"duration_display": fmt(row.get("duration_ms", 0)),
+			"kind": "hot" if is_hot else ("bg" if is_bg else "normal"),
+			"is_hot_text": is_hot,
+		})
+	return result
+
+
+def _build_actions(actions, findings, fmt_ms=None) -> list[dict]:
+	"""Contract ``actions`` = {number, name, meta, kind, duration_display,
+	duration_pct, duration_is_hot, bar_kind, queries, db_time_display,
+	finding_inline_html}.
+
+	J.2.3: We *spread the original action dict* so the existing
+	``action_row`` macro (which reads ``action_label``, ``http_method``,
+	``path``, ``entry_callsite``, ``target_doc``, ``related_findings`` and
+	more) keeps working unchanged. Contract fields are added on top — they
+	never collide with the legacy keys.
+	"""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	findings_by_ref: dict[str, list] = {}
+	for f in findings or []:
+		ref = str(f.get("action_ref") or "")
+		if ref:
+			findings_by_ref.setdefault(ref, []).append(f)
+
+	max_ms = max((a.get("duration_ms", 0) for a in (actions or [])), default=1) or 1
+
+	result = []
+	for idx, action in enumerate(actions or []):
+		duration_ms = action.get("duration_ms", 0) or 0
+		event_type = action.get("event_type", "")
+		kind = "bg" if event_type == "RQ Job" else "http"
+
+		meta_parts = []
+		if action.get("http_method"):
+			meta_parts.append(action["http_method"])
+		if action.get("path"):
+			meta_parts.append(action["path"])
+		meta = " · ".join(meta_parts)
+
+		ref_findings = findings_by_ref.get(str(idx + 1)) or findings_by_ref.get(str(idx), [])
+		finding_inline_html = None
+		if ref_findings:
+			f0 = ref_findings[0]
+			finding_inline_html = (
+				f"⚠ <strong>{len(ref_findings)} finding linked:</strong> "
+				f"{_html.escape(f0.get('title', '') or '')}"
+			)
+
+		entry = dict(action)  # preserve original keys
+		entry.update({
+			"number": idx + 1,
+			"name": action.get("action_label", "") or "",
+			"meta": meta,
+			"kind": kind,
+			"duration_display": fmt(duration_ms),
+			"duration_pct": (duration_ms / max_ms) * 100 if max_ms else 0,
+			"duration_is_hot": duration_ms >= 1000,
+			"bar_kind": _bar_kind_for(duration_ms),
+			"queries": action.get("queries_count", 0) or 0,
+			"db_time_display": fmt(action.get("query_time_ms", 0) or 0),
+			"finding_inline_html": finding_inline_html,
+		})
+		result.append(entry)
+	return result
+
+
+def _build_background_jobs(jobs, fmt_ms=None) -> list[dict]:
+	"""Contract ``background_jobs`` = list of {number, name, meta,
+	duration_display, duration_pct, duration_is_hot, bar_kind, queries,
+	db_time_display, finding_count}.
+
+	J.2.3: spreads the original job dict (preserves ``method``,
+	``entry_callsite``, ``related_findings``, ``top_queries``, etc.) so the
+	existing ``bg_job_row`` macro reads from the same fields it used to.
+	"""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	jobs = jobs or []
+	max_ms = max((j.get("duration_ms", 0) for j in jobs), default=1) or 1
+	result = []
+	for idx, job in enumerate(jobs):
+		duration_ms = job.get("duration_ms", 0) or 0
+		callsite = job.get("entry_callsite") or {}
+		meta = ""
+		if callsite.get("filename"):
+			meta = f"{callsite['filename']}:{callsite.get('lineno', '')}"
+		entry = dict(job)  # preserve original keys
+		entry.update({
+			"number": idx + 1,
+			"name": job.get("method", "") or "",
+			"meta": meta,
+			"duration_display": fmt(duration_ms),
+			"duration_pct": (duration_ms / max_ms) * 100 if max_ms else 0,
+			"duration_is_hot": duration_ms >= 1000,
+			"bar_kind": _bar_kind_for(duration_ms),
+			"queries": job.get("queries_count", 0) or 0,
+			"db_time_display": fmt(job.get("query_time_ms", 0) or 0),
+			"finding_count": job.get("findings_count", 0) or 0,
+		})
+		result.append(entry)
+	return result
+
+
+def _build_doc_events(doc_event_breakdown, fmt_ms=None) -> list[dict]:
+	"""Contract ``doc_events`` = list of {name, summary, methods}.
+
+	We extend the contract with ``is_save_target`` / ``touched_during`` on
+	each doctype and ``vscode_link`` / ``count`` on each hook so our
+	existing markup (which surfaces those distinctions) keeps working
+	without going back to ``doc_event_breakdown``. ``summary`` stays
+	contract-conformant for tooling that reads it.
+	"""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	result = []
+	for entry in (doc_event_breakdown or {}).get("doctypes", []) or []:
+		methods_out = []
+		for ev in entry.get("events", []) or []:
+			hooks = []
+			for m in ev.get("methods", []) or []:
+				hooks.append({
+					"name": m.get("function", "") or "",
+					"path": f"{m.get('filename', '')}:{m.get('lineno', '')}",
+					"vscode_link": m.get("_abs"),
+					"lineno": m.get("lineno", 0),
+					"filename": m.get("filename", ""),
+					"kind": m.get("kind", "doc_events hook"),
+					"time_display": fmt(m.get("ms", 0) or 0),
+					"count": m.get("count", 1) or 1,
+				})
+			methods_out.append({
+				"name": ev.get("event", "") or "",
+				"time_display": fmt(ev.get("total_ms", 0) or 0),
+				"hooks": hooks,
+			})
+		method_count = entry.get("method_count", 0) or 0
+		total_ms = entry.get("total_ms", 0) or 0
+		# Markup-aware so the `<span class="time-high">…</span>` that
+		# ``fmt`` returns for ≥1s totals survives autoescape intact.
+		summary = Markup(
+			f"{method_count} hot method{'s' if method_count != 1 else ''} · ~"
+		) + fmt(total_ms)
+		result.append({
+			"name": entry.get("doctype", "") or "",
+			"summary": summary,
+			"is_save_target": bool(entry.get("is_save_target", False)),
+			"touched_during": entry.get("touched_during") or [],
+			"method_count": method_count,
+			"total_ms_display": fmt(total_ms),
+			"methods": methods_out,
+		})
+	return result
+
+
+def _build_resource(infra_summary, infra_timeline) -> dict | None:
+	"""Contract ``resource`` = {cards: list of 4 KPI cards}.
+
+	Cards: CPU avg/peak, RSS delta, Swap peak, Load peak. Each has
+	{label, value, unit, sub_html, value_kind, sub_is_warn}.
+	"""
+	infra_summary = infra_summary or {}
+	if not infra_summary and not infra_timeline:
+		return None
+
+	cards = []
+
+	cpu_avg = infra_summary.get("cpu_avg")
+	cpu_peak = infra_summary.get("cpu_peak")
+	if cpu_avg is not None or cpu_peak is not None:
+		peak = cpu_peak or 0
+		value_kind = "danger" if peak >= 80 else ("warn" if peak >= 50 else "normal")
+		cards.append({
+			"label": "CPU avg / peak",
+			"value": f"{cpu_avg or 0:.0f}",
+			"unit": "%",
+			"sub_html": f"peak {peak:.0f}%",
+			"value_kind": value_kind,
+			"sub_is_warn": peak >= 50,
+		})
+
+	rss_delta = infra_summary.get("rss_delta")
+	if rss_delta is not None:
+		delta_mb = rss_delta / (1024 * 1024)
+		cards.append({
+			"label": "RSS delta",
+			"value": f"{delta_mb:+.0f}",
+			"unit": "MB",
+			"sub_html": "process memory change",
+			"value_kind": "warn" if abs(delta_mb) > 200 else "normal",
+			"sub_is_warn": False,
+		})
+
+	swap_peak_mb = infra_summary.get("swap_peak_mb")
+	if swap_peak_mb is not None:
+		cards.append({
+			"label": "Swap peak",
+			"value": f"{swap_peak_mb:.0f}",
+			"unit": "MB",
+			"sub_html": "swap in use" if swap_peak_mb > 0 else "no swap activity",
+			"value_kind": "warn" if swap_peak_mb > 0 else "normal",
+			"sub_is_warn": swap_peak_mb > 0,
+		})
+
+	load_peak = infra_summary.get("load_peak")
+	if load_peak is not None:
+		cards.append({
+			"label": "Load peak",
+			"value": f"{load_peak:.2f}",
+			"unit": "",
+			"sub_html": "",
+			"value_kind": "warn" if load_peak >= 2 else "normal",
+			"sub_is_warn": False,
+		})
+
+	if not cards:
+		return None
+	# J.2.4 non-contract additions: keep the raw summary + timeline reachable
+	# under ``report_data.resource`` so the existing per-action infra table
+	# and the inline rc-card markup migrate as a straight key rename.
+	# J.13: normalise the timeline's snapshotted action labels — the
+	# rows were stamped by infra_pressure.analyze at analyse-time and
+	# carry the pre-J.12 ``"Job: <method>"`` prefix on bg jobs. Rewrite
+	# at render time so the Server Resource per-action timeline reads
+	# ``RQ Job: …`` consistent with the rest of the report.
+	_normalised_timeline = []
+	for _row in (infra_timeline or []):
+		_lab = (_row or {}).get("action_label") or ""
+		if _lab.startswith("Job: "):
+			_row = dict(_row)
+			_row["action_label"] = "RQ " + _lab
+		_normalised_timeline.append(_row)
+	return {
+		"cards": cards,
+		"summary": infra_summary or {},
+		"timeline": _normalised_timeline,
+	}
+
+
+def _build_frontend(ctx) -> dict | None:
+	"""Contract ``frontend`` = {kpis, xhrs, web_vitals}.
+
+	Bundles the four flat ``frontend_*`` keys in our existing context.
+	"""
+	vitals_by_page = ctx.get("frontend_vitals_by_page") or {}
+	xhrs = ctx.get("frontend_xhr_matched") or []
+	summary = ctx.get("frontend_summary") or {}
+
+	if not vitals_by_page and not xhrs and not summary:
+		return None
+
+	# web_vitals — per-page row with computed *_class fields
+	web_vitals = []
+	for page, v in vitals_by_page.items():
+		fcp = v.get("fcp_ms")
+		lcp = v.get("lcp_ms")
+		cls = v.get("cls")
+		ttfb = v.get("ttfb_ms")
+		dcl = v.get("dom_content_loaded_ms")
+		web_vitals.append({
+			"url": page,
+			"fcp_display": f"{fcp:.0f} ms" if fcp else "—",
+			"fcp_class": _web_vital_class(fcp, 1800, 3000),
+			"lcp_display": f"{lcp:.0f} ms" if lcp else "—",
+			"lcp_class": _web_vital_class(lcp, 2500, 4000),
+			"cls_display": f"{cls:.3f}" if cls is not None else "—",
+			"cls_class": _web_vital_class(cls, 0.1, 0.25) if cls is not None else "vital-none",
+			"ttfb_display": f"{ttfb:.0f} ms" if ttfb else "—",
+			"ttfb_class": _web_vital_class(ttfb, 800, 1800),
+			"dcl_display": f"{dcl:.0f} ms" if dcl else "—",
+			"dcl_class": _web_vital_class(dcl, 1500, 3000),
+		})
+
+	# xhrs — display-formatted
+	xhrs_out = []
+	for x in xhrs:
+		backend_ms = x.get("backend_ms", 0) or 0
+		xhr_ms = x.get("xhr_ms", 0) or 0
+		network_ms = x.get("network_delta_ms", 0) or 0
+		size_bytes = x.get("response_size_bytes", 0) or 0
+		xhrs_out.append({
+			"name": x.get("action_label", "") or "",
+			"meta": x.get("url", "") or "",
+			"backend_display": _ms_display(backend_ms),
+			"browser_display": _ms_display(xhr_ms),
+			"network_display": f"{network_ms:.0f} ms",
+			"status": x.get("status", 0) or 0,
+			"size_display": (
+				f"{size_bytes / 1024:.1f} KB" if size_bytes >= 1024 else f"{size_bytes} B"
+			),
+			"backend_is_hot": backend_ms >= 1000,
+			"browser_is_hot": xhr_ms >= 1000,
+		})
+
+	# kpis — 4-item summary
+	kpis = []
+	if summary:
+		total_xhrs = summary.get("total_xhrs", 0) or 0
+		total_xhr_ms = summary.get("total_xhr_ms", 0) or 0
+		total_backend_ms = summary.get("total_backend_ms", 0) or 0
+		net_overhead = summary.get("network_overhead_ms", 0) or 0
+		slowest = summary.get("slowest_xhr") or {}
+		slowest_sub = (
+			f"slowest {slowest.get('duration_ms', 0) or 0:.0f} ms" if slowest else ""
+		)
+		kpis = [
+			{
+				"label": "XHRs",
+				"value": str(total_xhrs),
+				"unit": "",
+				"sub_html": "",
+				"value_kind": "normal",
+				"sub_is_warn": False,
+			},
+			{
+				"label": "XHR total",
+				"value": f"{total_xhr_ms:.0f}",
+				"unit": "ms",
+				"sub_html": "",
+				"value_kind": "normal",
+				"sub_is_warn": False,
+			},
+			{
+				"label": "Backend total",
+				"value": f"{total_backend_ms:.0f}",
+				"unit": "ms",
+				"sub_html": "",
+				"value_kind": "normal",
+				"sub_is_warn": False,
+			},
+			{
+				"label": "Network overhead",
+				"value": f"{net_overhead:.0f}",
+				"unit": "ms",
+				"sub_html": slowest_sub,
+				"value_kind": "warn" if net_overhead > 500 else "normal",
+				"sub_is_warn": False,
+			},
+		]
+
+	# J.2.4 non-contract additions: pass-through the raw summary +
+	# xhr_matched + orphans so the existing rc-card markup, XHR-table
+	# columns, and orphans details-block migrate as a straight key rename.
+	return {
+		"kpis": kpis,
+		"xhrs": xhrs_out,
+		"web_vitals": web_vitals,
+		"summary": summary or {},
+		"xhr_matched": xhrs or [],
+		"orphans": ctx.get("frontend_orphans") or [],
+	}
+
+
+def _build_hot_frames(hot_frames_rows, ignored_apps, fmt_ms=None) -> list[dict]:
+	"""Contract ``hot_frames`` = list of {name, total_time_display,
+	is_hot_time, occurrences, distinct_actions, is_user_code}.
+
+	J.2.5: spreads the original row dict so the existing ``hot_frame_row``
+	macro keeps reading ``display_name`` / ``total_ms`` / ``is_hot``.
+	"""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	ignored = tuple(ignored_apps or ())
+	result = []
+	for row in hot_frames_rows or []:
+		name = row.get("display_name") or row.get("function", "") or ""
+		total_ms = row.get("total_ms", 0) or 0
+		path_part = name.split("::", 1)[0] if "::" in name else name
+		entry = dict(row)  # preserve original keys
+		entry.update({
+			"name": name,
+			"total_time_display": fmt(total_ms),
+			"is_hot_time": bool(row.get("is_hot", False)) or total_ms >= 1000,
+			"occurrences": row.get("occurrences", 0) or 0,
+			"distinct_actions": row.get("distinct_actions", 0) or 0,
+			"is_user_code": _is_user_code(path_part, ignored),
+		})
+		result.append(entry)
+	return result
+
+
+def _build_slow_queries(top_queries, fmt_ms=None) -> list[dict]:
+	"""Contract ``slow_queries`` = list of {sql_excerpt, total_time_display,
+	call_count, avg_display, callsite}.
+
+	J.2.5: spreads the original query dict so ``top_query_row`` keeps
+	reading ``duration_ms`` / ``callsite`` / ``normalized_query``. Empty
+	list → contract template renders the empty-state card.
+	"""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	result = []
+	for q in top_queries or []:
+		total_ms = q.get("duration_ms") or q.get("total_ms", 0) or 0
+		count = q.get("count") or q.get("call_count", 0) or 0
+		avg = (total_ms / count) if count else 0
+		entry = dict(q)
+		entry.update({
+			"sql_excerpt": q.get("normalized_query") or q.get("sql", "") or "",
+			"total_time_display": fmt(total_ms),
+			"call_count": count,
+			"avg_display": f"{avg:.2f} ms",
+			"callsite": q.get("callsite") or "",
+		})
+		result.append(entry)
+	return result
+
+
+def _build_db(table_breakdown, fmt_ms=None) -> dict | None:
+	"""Contract ``db`` = {tables, index_recommendations}.
+
+	``tables`` per-entry {name, time_display, queries, reads, writes,
+	is_hot, note_html}; ``index_recommendations`` per-entry {table_name,
+	stats, recommendation_html, sql, has_writes, verdict_text}.
+
+	J.2.5: spreads each table dict so the existing index-recommendation
+	block (which reads ``read_time_ms``, ``write_time_ms``,
+	``index_candidates``, ``is_meta_table``, ``framework_cols_filtered``,
+	``ai_index``, ``recommended_index``) keeps working without going
+	back to ``table_breakdown``.
+	"""
+	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
+	if not table_breakdown:
+		return None
+
+	tables = []
+	index_recs = []
+	for t in table_breakdown:
+		is_hot = bool(t.get("is_write_hot", False)) or (t.get("queries", 0) or 0) >= 100
+		entry = dict(t)  # preserve original keys
+		entry.update({
+			"name": t.get("table", "") or "",
+			"time_display": fmt(t.get("duration_ms", 0) or 0),
+			"queries": t.get("queries", 0) or 0,
+			"reads": t.get("read_count", 0) or 0,
+			"writes": t.get("write_count", 0) or 0,
+			"is_hot": is_hot,
+			"note_html": None,
+		})
+		tables.append(entry)
+
+		rec = t.get("recommended_index")
+		if rec and isinstance(rec, dict) and rec.get("columns"):
+			cols = rec.get("columns", []) or []
+			cols_display = ", ".join(cols)
+			doctype = rec.get("doctype") or t.get("table", "").replace("tab", "")
+			cols_sql = ", ".join(repr(c) for c in cols)
+			stats = (
+				f"{t.get('read_count', 0) or 0} reads · "
+				f"{t.get('write_count', 0) or 0} writes · "
+				f"{t.get('duration_ms', 0) or 0:.0f} ms"
+			)
+			index_recs.append({
+				"table_name": t.get("table", "") or "",
+				"stats": stats,
+				"recommendation_html": f"Most-used filter: <code>({cols_display})</code>",
+				"sql": f'frappe.db.add_index("{doctype}", [{cols_sql}])',
+				"has_writes": (t.get("write_count", 0) or 0) > 0,
+				"verdict_text": None,
+			})
+
+	return {"tables": tables, "index_recommendations": index_recs}
+
+
+def _build_footer(render_config) -> dict:
+	"""Contract ``footer`` = {framework, settings}.
+
+	``settings`` lists every render-time toggle that affects the report. The
+	contract example shows 3 toggles; our config has 6 — we include all of
+	them so the legacy footer's full disclosure carries over post-migration.
+	"""
+	rc = render_config or {}
+	tracked = rc.get("tracked_apps") or ()
+	ignored = rc.get("ignored_apps") or ()
+	parts = [
+		f"hide_framework_tables={'on' if rc.get('hide_framework_tables') else 'off'}",
+		f"tracked_apps={', '.join(tracked) if tracked else '(none)'}",
+		f"ignored_apps={', '.join(ignored) if ignored else '(none)'}",
+		f"ai_suggest_findings={'on' if rc.get('ai_suggest_findings') else 'off'}",
+		f"ai_suggest_indexes={'on' if rc.get('ai_suggest_indexes') else 'off'}",
+		f"min_action_duration_ms={int(rc.get('min_action_duration_ms') or 0)}",
+		f"large_duration_threshold_ms={int(rc.get('large_duration_threshold_ms') or 0)}",
+	]
+	return {
+		"framework": "Frappe v16",
+		"settings": " · ".join(parts),
+	}
+
+
+# ---------------------------------------------------------------------------
+# Main adapter
+# ---------------------------------------------------------------------------
+
+
+def build_report_context(session_doc: Any, ctx: dict) -> dict:
+	"""Return the contract-shaped context dict per template_variable_contract.md.
+
+	Reads from ``ctx`` (the already-built render context dict) so the
+	adapter is a pure transformation and does not duplicate analysis work.
+	``session_doc`` is the OptimusSession document used for fields not
+	carried in ``ctx`` (phase-2 child table, user, etc.).
+
+	Phase J.1: this function's output is exposed under a ``report_data``
+	namespace key in the render context so template references can migrate
+	section-by-section in J.2 without breaking. J.3 will unpack the
+	namespace and drop legacy keys.
+	"""
+	return {
+		"session": _build_session(session_doc, ctx),
+		"tldr": _build_tldr(ctx.get("tldr")),
+		"kpis": _build_kpis(session_doc, ctx),
+		"repro": _build_repro(ctx.get("notes_html")),
+		"summary": _build_summary(ctx.get("summary_html")),
+		"findings": _build_findings(ctx.get("findings", []), ctx),
+		# J.2.7 pragmatic additions: the Findings section iterates app-
+		# bucketed views and feeds the legacy ``finding_card`` macro which
+		# reads OLD-shape finding dicts (severity="High" Title-case,
+		# untransformed technical_detail, etc.). Pass these through verbatim
+		# so the macros keep working; the contract ``findings`` list above
+		# uses the new shape and is available for a future macro rewrite.
+		"findings_by_app": ctx.get("findings_by_app") or [],
+		"observational_findings_by_app": ctx.get("observational_findings_by_app") or [],
+		"line_drilldown_runs": _build_line_drilldown_runs(session_doc),
+		# J.2.6 pragmatic addition (renamed in J.16): the server-side
+		# _render_line_drilldown_panel produces ~100 lines of editorial
+		# markup including the cross-run diff that the structured
+		# ``line_drilldown_runs`` list above doesn't yet expose. The
+		# template renders this directly; a future iteration can replace
+		# it by iterating ``line_drilldown_runs`` and a structured diff
+		# representation.
+		"line_drilldown_html": ctx.get("line_drilldown_html") or "",
+		"action_plan": _build_action_plan(ctx.get("action_plan", []), ctx.get("fmt_ms")),
+		"waterfall": _build_waterfall(ctx.get("waterfall_rows", []), ctx.get("fmt_ms")),
+		"actions": _build_actions(
+			ctx.get("actions", []), ctx.get("findings", []), ctx.get("fmt_ms")
+		),
+		# J.2.3 non-contract addition — pragmatic extension so the framework
+		# sub-block keeps rendering. May be folded into ``actions`` with an
+		# ``is_framework`` flag in J.3.
+		"actions_framework": _build_actions(
+			ctx.get("actions_framework", []), ctx.get("findings", []), ctx.get("fmt_ms")
+		),
+		"background_jobs": _build_background_jobs(
+			(ctx.get("background_jobs") or {}).get("jobs", []) or [], ctx.get("fmt_ms")
+		),
+		# J.2.3 non-contract addition — see actions_framework note above.
+		"background_jobs_framework": _build_background_jobs(
+			(ctx.get("background_jobs") or {}).get("jobs_framework", []) or [], ctx.get("fmt_ms")
+		),
+		"doc_events": _build_doc_events(ctx.get("doc_event_breakdown") or {}, ctx.get("fmt_ms")),
+		"resource": _build_resource(
+			ctx.get("infra_summary") or {}, ctx.get("infra_timeline") or []
+		),
+		"frontend": _build_frontend(ctx),
+		"hot_frames": _build_hot_frames(
+			ctx.get("hot_frames_rows", []), ctx.get("ignored_apps") or (), ctx.get("fmt_ms")
+		),
+		# J.2.5 non-contract addition for framework split.
+		"hot_frames_framework": _build_hot_frames(
+			ctx.get("hot_frames_rows_framework", []), ctx.get("ignored_apps") or (), ctx.get("fmt_ms")
+		),
+		"slow_queries": _build_slow_queries(ctx.get("top_queries", []), ctx.get("fmt_ms")),
+		# J.2.5 non-contract addition for framework split.
+		"slow_queries_framework": _build_slow_queries(ctx.get("top_queries_framework", []), ctx.get("fmt_ms")),
+		"db": _build_db(ctx.get("table_breakdown", []), ctx.get("fmt_ms")),
+		"how_to_read_items": None,
+		"footer": _build_footer(ctx.get("render_config")),
+		# J.3.1 non-contract additions — the remaining two passthroughs
+		# the template needs before the legacy top-level keys can be
+		# dropped from renderer.py's context dict.
+		"large_duration_threshold_ms": (
+			(ctx.get("render_config") or {}).get("large_duration_threshold_ms") or 1000
+		),
+		"background_jobs_summary": _build_background_jobs_summary(ctx.get("background_jobs") or {}),
+	}
+
+
+def _build_background_jobs_summary(background_jobs) -> dict:
+	"""Aggregate fields the BG-jobs section heading + bg_job_row macro need.
+
+	The legacy ``background_jobs`` dict carries ``count`` / ``total_ms`` /
+	``total_queries`` / ``any_findings_counted`` / ``framework_count``
+	alongside the ``jobs`` / ``jobs_framework`` lists. After J.3 these
+	aggregates are the only legacy-dict-shaped data the template still
+	reads; expose them under a dedicated namespace so the rest of the
+	dict can be dropped.
+	"""
+	bj = background_jobs or {}
+	return {
+		"count": bj.get("count", 0) or 0,
+		"total_ms": bj.get("total_ms", 0) or 0,
+		"total_queries": bj.get("total_queries", 0) or 0,
+		"any_findings_counted": bool(bj.get("any_findings_counted", False)),
+		"framework_count": bj.get("framework_count", 0) or 0,
+	}

--- a/optimus/templates/report.html
+++ b/optimus/templates/report.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width,initial-scale=1">
-<title>Profiler Report — {{ session.title or session.session_uuid }}</title>
+<title>Profiler Report - {{ session.title or session.session_uuid }}</title>
 <style>
   /* ---------- Reset & base ---------- */
   *, *::before, *::after { box-sizing: border-box; }
@@ -46,57 +46,10 @@
   .muted { color: #6b7280; }
   .small { font-size: 0.85rem; }
 
-  /* ---------- Header card ---------- */
-  .report-header {
-    background: white;
-    border-radius: 8px;
-    box-shadow: 0 1px 3px rgba(0,0,0,0.05);
-    padding: 24px 28px;
-    margin-bottom: 24px;
-  }
-  .report-header .meta {
-    margin-top: 6px;
-    color: #6b7280;
-    font-size: 0.9rem;
-  }
-  /* The header metadata as a compact key/value table — overrides the
-     full-width / bordered / hover-highlighted global table styling. */
-  .report-header .meta-table {
-    width: auto;
-    margin: 6px 0 0;
-  }
-  .report-header .meta-table td {
-    padding: 2px 16px 2px 0;
-    border: none;
-    vertical-align: top;
-  }
-  .report-header .meta-table td:first-child {
-    color: #6b7280;
-    font-weight: 500;
-    white-space: nowrap;
-  }
-  .report-header .meta-table td:last-child {
-    color: #374151;
-  }
-  .report-header .meta-table tr:hover td {
-    background: transparent;
-  }
-  /* ---------- Stat cards ---------- */
-  .stats {
-    display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 12px;
-    margin-bottom: 24px;
-  }
-  .stat {
-    background: white;
-    border-radius: 8px;
-    padding: 12px 14px;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-  }
-  .stat .label { font-size: 0.72rem; text-transform: uppercase; color: #6b7280; letter-spacing: 0.5px; font-weight: 600; }
-  .stat .value { font-size: 1.4rem; font-weight: 700; color: #111827; margin-top: 2px; }
-  .stat .sub   { font-size: 0.78rem; color: #6b7280; margin-top: 1px; }
+  /* v0.7.x Phase H: `.report-header` / `.stats` / `.stat` were
+     superseded by `.masthead` (Phase A) and `.kpis` / `.kpi` +
+     `.resource-grid` / `.resource-card` (Phase A/G/H). The orphaned
+     rules have been removed. */
 
   /* ---------- Section card ---------- */
   .section {
@@ -108,7 +61,7 @@
   }
   .section > h2:first-child { margin-top: 0; }
 
-  /* v0.5.2: collapsible <details> sections. Native HTML5 — no JS
+  /* v0.5.2: collapsible <details> sections. Native HTML5 - no JS
      required, fully keyboard + screen-reader accessible. Default
      expanded for primary sections (via `open` attribute in the
      template); nested sub-sections (e.g., framework-level
@@ -165,7 +118,7 @@
     color: #2563eb;
   }
 
-  /* v0.5.2: per-app bucket header — the <h3> inside a subsection
+  /* v0.5.2: per-app bucket header - the <h3> inside a subsection
      <summary> renders as "myapp · 3 findings · ~420ms". The app name
      is the primary emphasis; count + impact are muted so they read
      as secondary metadata without competing for attention. */
@@ -204,7 +157,7 @@
     margin-left: 4px;
   }
 
-  /* v0.5.2 round 4: clickable callsite → editor. Subtle style — looks
+  /* v0.5.2 round 4: clickable callsite → editor. Subtle style - looks
      like the plain <code> block but with a dotted underline that
      signals interactivity, and a hover color lift. We don't use the
      default-link blue because the callsite is already inline code
@@ -221,13 +174,13 @@
   a.callsite-link:hover code {
     color: #1d4ed8;
   }
-  /* Print mode: drop the editor-link decoration — a PDF reader can't
+  /* Print mode: drop the editor-link decoration - a PDF reader can't
      click vscode:// handlers. */
   @media print {
     a.callsite-link { border-bottom: none; }
   }
 
-  /* v0.5.3: Truncation banner — sits above the exec-summary when the
+  /* v0.5.3: Truncation banner - sits above the exec-summary when the
      per-recording cap was exceeded. Red-bordered, full-width, with
      bold header so nobody can claim they didn't see it. Mirrors the
      pattern APM tools use for "data sampled at X%" warnings. */
@@ -255,69 +208,9 @@
     color: #991b1b;
   }
 
-  /* v0.5.2 round 3: Executive summary card. The visual weight signals
-     "read this first" — colored left border flags session pace
-     (green / amber / red), generous padding, bullets styled like an
-     agenda. A non-developer should get the punch without scrolling. */
-  .exec-summary {
-    background: white;
-    border-radius: 8px;
-    border-left: 6px solid #10b981;
-    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
-    padding: 14px 18px;
-    margin-bottom: 16px;
-  }
-  .exec-summary.pace-moderate { border-left-color: #f59e0b; }
-  .exec-summary.pace-slow { border-left-color: #dc2626; }
-  .exec-summary h2 { margin: 0 0 8px 0; border: 0; padding: 0; }
-  .exec-headline {
-    font-size: 1.05rem;
-    color: #111827;
-    margin: 0 0 12px 0;
-  }
-  .exec-bullets { margin-top: 8px; }
-  .exec-bullets ol {
-    margin: 8px 0 0 0;
-    padding-left: 24px;
-  }
-  .exec-bullets li {
-    padding: 6px 0;
-    color: #374151;
-    line-height: 1.5;
-  }
-  .exec-bullet-severity {
-    display: inline-block;
-    padding: 1px 8px;
-    border-radius: 3px;
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.3px;
-    margin-right: 8px;
-    vertical-align: middle;
-  }
-  .exec-bullet-severity.severity-high {
-    background: #fee2e2; color: #991b1b;
-  }
-  .exec-bullet-severity.severity-medium {
-    background: #fef3c7; color: #92400e;
-  }
-  .exec-bullet-severity.severity-low {
-    background: #dbeafe; color: #1e40af;
-  }
-  .exec-bullet-text { font-weight: 500; }
-  .exec-bullet-impact {
-    color: #6b7280;
-    margin-left: 8px;
-    font-variant-numeric: tabular-nums;
-  }
-  .exec-infra {
-    margin: 10px 0 0 0;
-    padding-top: 10px;
-    border-top: 1px dashed #e5e7eb;
-    color: #374151;
-    font-size: 0.9rem;
-  }
+  /* v0.7.x Phase H: the v0.5.2 "Executive summary" card (.exec-*)
+     was replaced by the .tldr hero in Phase B; its orphaned rules
+     have been removed. */
 
   /* ---------- Tables ---------- */
   table {
@@ -356,9 +249,9 @@
     overflow: hidden;
   }
   /* Width scheme:
-     #/Copies  (very narrow — single-digit or short number)
-     Duration  (narrow — e.g. "1374ms")
-     Callsite  (medium — allow ~25% for path, with word-break)
+     #/Copies  (very narrow - single-digit or short number)
+     Duration  (narrow - e.g. "1374ms")
+     Callsite  (medium - allow ~25% for path, with word-break)
      Query     (takes the rest) */
   table.query-table col.col-index     { width: 44px; }
   table.query-table col.col-copies    { width: 64px; }
@@ -435,27 +328,10 @@
   .finding.severity-medium { border-left-color: #d97706; background: #fffbeb; }
   .finding.severity-low    { border-left-color: #2563eb; background: #eff6ff; }
 
-  .finding-header {
-    display: grid;
-    grid-template-columns: auto 1fr auto;
-    align-items: center;
-    gap: 10px;
-    margin-bottom: 4px;
-  }
-  .finding-header .finding-impact { justify-self: end; white-space: nowrap; }
-  .severity-badge {
-    display: inline-block;
-    padding: 2px 10px;
-    border-radius: 12px;
-    font-size: 0.7rem;
-    font-weight: 700;
-    text-transform: uppercase;
-    letter-spacing: 0.5px;
-  }
-  .severity-badge.high   { background: #dc2626; color: white; }
-  .severity-badge.medium { background: #d97706; color: white; }
-  .severity-badge.low    { background: #2563eb; color: white; }
-  /* v0.7.x: emphasise timing values that cross the 1s threshold —
+  /* v0.7.x Phase H: `.finding-header` + `.severity-badge` were
+     replaced by `.finding-top` + `.severity-pill` in the Phase D
+     finding-card rewrite. Orphaned rules removed. */
+  /* v0.7.x: emphasise timing values that cross the 1s threshold -
      fmt_ms emits this span around the seconds-formatted output. The
      amber + bold draws the eye to slow rows without screaming. Same
      palette as the existing severity-medium / warning indicators. */
@@ -483,7 +359,7 @@
   }
   .finding-detail .label:first-child { margin-top: 0; }
 
-  /* v0.6.0 — AI-suggested fix block (on-demand; rendered when present) */
+  /* v0.6.0 - AI-suggested fix block (on-demand; rendered when present) */
   .ai-fix {
     margin-top: 8px;
     padding: 8px 10px;
@@ -542,13 +418,19 @@
   }
 
   /* ---------- Footer ---------- */
+  /* FOOTER - Phase G polish. Quiet bottom-rule, design-token palette. */
   .footer {
+    margin-top: 48px; padding-top: 22px;
+    border-top: 1px solid var(--rule);
     text-align: center;
-    color: #6b7280;
-    font-size: 0.85rem;
-    margin: 32px 0 16px 0;
-    padding-top: 16px;
-    border-top: 1px solid #e5e7eb;
+    font-size: 11px; color: var(--ink-mute);
+    line-height: 1.7;
+  }
+  .footer p { margin: 4px 0; }
+  .footer .warn-line { color: var(--accent); font-weight: 600; margin-top: 6px; }
+  .footer code {
+    font-family: var(--mono); font-size: 10.5px;
+    color: var(--ink-soft);
   }
 
   .empty {
@@ -566,7 +448,7 @@
     /* v0.5.2 round 4: force-expand every collapsible section for PDF
        / print output. Without this, wkhtmltopdf (and Chrome's print
        engine) only render disclosure-element content when the
-       element has the open attribute — so the Observations subsection
+       element has the open attribute - so the Observations subsection
        and any collapsed app buckets disappear entirely from the
        exported PDF. The print-media
        override keeps parity between what the reader sees in the
@@ -585,15 +467,1038 @@
   }
 
   @media (max-width: 700px) {
-    .stats { grid-template-columns: repeat(2, 1fr); }
     .container { padding: 12px; }
   }
 
-  /* v0.4.0 — donut: SVG for print, conic-gradient for screen */
-  .svg-donut { display: none; }
+  /* v0.7.x Phase H: the v0.4.0 donut chart (`.conic-donut` /
+     `.svg-donut`) was folded into the Total-time stat card before
+     v0.7.x and its rules survived as orphans - removed. */
+
+  /* ===================================================================
+     v0.7.x report redesign - Phase A foundation
+     -----------------------------------------------------------------
+     Design tokens + new prelude components (masthead / KPI strip /
+     nav pills). The existing .container / .section / .finding / etc.
+     rules above stay in place for now; later phases migrate the rest
+     of the template onto this token system. No remote fonts - the
+     --display / --sans / --mono stacks fall through to system fonts
+     to preserve the self-contained-HTML acceptance test.
+     =================================================================== */
+
+  :root {
+    --bg: #fafaf7;
+    --bg-paper: #ffffff;
+    --bg-tint: #f5f3ec;
+    --ink: #1a1a1a;
+    --ink-soft: #4a4a4a;
+    --ink-mute: #8a8580;
+    --rule: #e8e3d8;
+    --rule-strong: #d8d2c2;
+    --accent: #c5392b;
+    --accent-soft: #fde8e5;
+    --warn: #b8761e;
+    --warn-soft: #fcf2dd;
+    --ok: #2d6a3c;
+    --ok-soft: #e3f0e6;
+    --info: #2f5d8a;
+    --info-soft: #e3edf6;
+    --hot: #fef3c7;
+    --hot-strong: #fbbf24;
+    --display: 'Fraunces', 'Iowan Old Style', Georgia, serif;
+    --sans: 'Inter', -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, sans-serif;
+    --mono: 'JetBrains Mono', 'SF Mono', Menlo, Consolas, monospace;
+  }
+
+  /* TL;DR HERO - replaces the "At a glance" exec-summary card */
+  .tldr {
+    background: var(--ink); color: var(--bg);
+    padding: 30px 34px; border-radius: 4px; margin-bottom: 28px;
+    position: relative; overflow: hidden;
+  }
+  .tldr::before {
+    content: ''; position: absolute; top: 0; right: 0;
+    width: 240px; height: 100%;
+    background: radial-gradient(circle at 80% 50%, rgba(197,57,43,0.25), transparent 70%);
+    pointer-events: none;
+  }
+  .tldr-label {
+    font-size: 11px; letter-spacing: 0.2em; text-transform: uppercase;
+    color: rgba(255,255,255,0.55); font-weight: 600; margin-bottom: 12px;
+  }
+  .tldr-headline {
+    font-family: var(--display); font-size: 26px; line-height: 1.3;
+    font-weight: 500; margin: 0 0 14px; letter-spacing: -0.005em;
+    max-width: 880px; color: var(--bg);
+  }
+  .tldr-headline .hot { color: #ff8a7d; font-style: italic; }
+  .tldr-headline code {
+    font-family: var(--mono); font-size: 0.85em;
+    background: rgba(255,255,255,0.08); padding: 1px 6px;
+    border-radius: 2px; color: var(--bg);
+  }
+  .tldr-sub {
+    font-size: 13px; color: rgba(255,255,255,0.75);
+    max-width: 720px; margin: 0; line-height: 1.6;
+  }
+  .tldr-sub code {
+    font-family: var(--mono); font-size: 0.92em;
+    background: rgba(255,255,255,0.08); padding: 1px 5px;
+    border-radius: 2px; color: rgba(255,255,255,0.85);
+  }
+
+  /* MASTHEAD - replaces .report-header */
+  .masthead {
+    border-bottom: 2px solid var(--ink);
+    padding-bottom: 20px;
+    margin-bottom: 32px;
+    display: grid;
+    grid-template-columns: 1fr auto;
+    align-items: end;
+    gap: 24px;
+  }
+  .masthead-eyebrow {
+    font-size: 11px; letter-spacing: 0.18em; text-transform: uppercase;
+    color: var(--ink-mute); margin-bottom: 6px; font-weight: 600;
+  }
+  .masthead h1 {
+    font-family: var(--display); font-weight: 600; font-size: 44px;
+    line-height: 1.05; letter-spacing: -0.02em; margin: 0;
+    border-bottom: none; padding-bottom: 0;
+    color: var(--ink);
+  }
+  .masthead h1 em { font-style: italic; font-weight: 400; color: var(--accent); }
+  .masthead-meta {
+    text-align: right; font-size: 12px; color: var(--ink-soft); line-height: 1.7;
+  }
+  .masthead-meta b { color: var(--ink); font-weight: 600; }
+  .masthead-meta .badge {
+    display: inline-block; padding: 2px 8px; background: var(--ink);
+    color: var(--bg); font-family: var(--mono); font-size: 10px;
+    letter-spacing: 0.05em; border-radius: 2px; margin-bottom: 4px;
+  }
+
+  /* KPI strip - replaces .stats / .stat */
+  .kpis {
+    display: grid; grid-template-columns: repeat(4, 1fr); gap: 0;
+    margin-bottom: 24px;
+    border-top: 1px solid var(--rule); border-bottom: 1px solid var(--rule);
+    background: var(--bg-paper);
+  }
+  .kpi { padding: 18px 22px; border-right: 1px solid var(--rule); position: relative; }
+  .kpi:last-child { border-right: none; }
+  .kpi-label {
+    font-size: 10px; letter-spacing: 0.15em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 600; margin-bottom: 8px;
+  }
+  .kpi-value {
+    font-family: var(--display); font-size: 34px; line-height: 1;
+    font-weight: 600; letter-spacing: -0.02em; color: var(--ink);
+  }
+  .kpi-value.danger { color: var(--accent); }
+  .kpi-unit { font-size: 14px; color: var(--ink-mute); font-weight: 400; margin-left: 2px; }
+  .kpi-sub { font-size: 12px; color: var(--ink-soft); margin-top: 6px; line-height: 1.45; }
+
+  /* NAV PILLS - replaces the Jump-to .section.small block. Phase K.2:
+     sticky-top so the jump-to nav stays accessible when the reader
+     scrolls into deep tables. */
+  nav.nav-pills {
+    display: flex; gap: 6px; flex-wrap: wrap; margin-bottom: 16px;
+    padding: 10px 14px; background: var(--bg-paper);
+    border: 1px solid var(--rule); border-radius: 4px;
+    position: sticky; top: 0; z-index: 50;
+    box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  }
+  nav.nav-pills .jump-label {
+    font-size: 10px; letter-spacing: 0.15em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 700; align-self: center;
+    margin-right: 8px;
+  }
+  nav.nav-pills a {
+    padding: 4px 10px; font-size: 11.5px; letter-spacing: 0.04em;
+    text-decoration: none; color: var(--ink-soft); border-radius: 3px;
+    transition: background 0.15s, color 0.15s; font-weight: 500;
+  }
+  nav.nav-pills a:hover { background: var(--ink); color: var(--bg); }
+  @media print { nav.nav-pills { position: static; box-shadow: none; } }
+
+  /* Responsive - masthead stacks, KPI strip becomes 2x2 */
+  @media (max-width: 760px) {
+    .masthead { grid-template-columns: 1fr; }
+    .masthead-meta { text-align: left; }
+    .masthead h1 { font-size: 32px; }
+    .kpis { grid-template-columns: repeat(2, 1fr); }
+    .kpi:nth-child(2) { border-right: none; }
+    .kpi:nth-child(-n+2) { border-bottom: 1px solid var(--rule); }
+  }
+
+  /* SECTION HEAD - used by new redesign sections (action plan,
+     waterfall, …). Pre-existing collapsible-section markup
+     ("details.section") keeps its styling above; this is for the
+     editorial-style `section[id]` + `div.section-head` pattern
+     introduced by the Phase C+ redesign. */
+  section[id] { margin-bottom: 48px; scroll-margin-top: 20px; }
+  .section-head {
+    display: flex; align-items: baseline; gap: 16px;
+    margin-bottom: 18px; padding-bottom: 10px;
+    border-bottom: 1px solid var(--rule);
+  }
+  .section-head h2 {
+    font-family: var(--display); font-size: 26px; font-weight: 600;
+    letter-spacing: -0.01em; margin: 0; flex: 1;
+    border-bottom: none; padding-bottom: 0; color: var(--ink);
+  }
+  .section-head .section-tag {
+    font-size: 11px; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 600;
+  }
+  .section-intro {
+    font-size: 14px; color: var(--ink-soft); max-width: 720px;
+    margin: 0 0 20px; line-height: 1.65;
+  }
+
+  /* ACTION PLAN - Phase C */
+  .action-plan {
+    background: linear-gradient(180deg, var(--bg-paper) 0%, var(--bg-tint) 100%);
+    border: 1px solid var(--rule); border-radius: 6px;
+    padding: 22px 26px;
+  }
+  .action-plan h3 {
+    font-family: var(--display); font-size: 22px; font-weight: 600;
+    margin: 0 0 4px; letter-spacing: -0.01em;
+    border-bottom: none; padding-bottom: 0;
+  }
+  .action-plan p.lead {
+    font-size: 13px; color: var(--ink-soft); margin: 0 0 18px;
+  }
+  .action-step {
+    display: grid; grid-template-columns: 36px 1fr auto;
+    gap: 14px; padding: 14px 0;
+    border-top: 1px solid var(--rule); align-items: start;
+  }
+  .action-step:first-of-type { border-top: 1px solid var(--ink); }
+  .action-step .num {
+    font-family: var(--display); font-size: 28px; font-weight: 600;
+    font-style: italic; color: var(--accent); line-height: 1;
+    letter-spacing: -0.02em;
+  }
+  .action-step .title {
+    font-family: var(--display); font-size: 17px; font-weight: 600;
+    margin: 0 0 4px; line-height: 1.3;
+  }
+  .action-step .desc {
+    font-size: 13px; color: var(--ink-soft); margin: 0; line-height: 1.55;
+  }
+  .action-step .desc code, .action-step .callsite code {
+    font-family: var(--mono); font-size: 11.5px;
+    background: var(--bg-paper); padding: 1px 5px; border-radius: 2px;
+    color: var(--ink);
+  }
+  .action-step .callsite {
+    font-size: 11.5px; color: var(--ink-mute); margin-top: 4px;
+  }
+  .action-step .gain { text-align: right; white-space: nowrap; }
+  .action-step .gain .num-big {
+    font-family: var(--display); font-size: 20px; font-weight: 600;
+    color: var(--ok); display: block; line-height: 1;
+  }
+  .action-step .gain .gain-label {
+    font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+    color: var(--ink-mute); margin-top: 4px; font-weight: 600;
+    display: block;
+  }
+
+  /* WATERFALL - Phase C */
+  .waterfall {
+    background: var(--bg-paper); border: 1px solid var(--rule);
+    border-radius: 6px; padding: 18px 20px;
+  }
+  .waterfall-row {
+    display: grid; grid-template-columns: 240px 1fr 88px;
+    gap: 12px; align-items: center; padding: 6px 0; font-size: 12.5px;
+  }
+  .waterfall-row + .waterfall-row { border-top: 1px solid var(--rule); }
+  .waterfall-name {
+    font-family: var(--mono); font-size: 11.5px; color: var(--ink);
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  .waterfall-track {
+    height: 18px; background: var(--bg-tint);
+    border-radius: 3px; position: relative; overflow: hidden;
+  }
+  .waterfall-bar {
+    position: absolute; height: 100%; background: var(--info);
+    border-radius: 3px; left: 0; top: 0;
+  }
+  .waterfall-bar.hot { background: var(--accent); }
+  .waterfall-bar.bg  { background: var(--warn); }
+  .waterfall-time {
+    font-family: var(--mono); font-size: 12px; text-align: right;
+    color: var(--ink-soft); font-variant-numeric: tabular-nums;
+  }
+  .waterfall-time.hot { color: var(--accent); font-weight: 600; }
+
+  /* Responsive - Phase C: stack the waterfall + action plan rows. */
+  @media (max-width: 760px) {
+    .waterfall-row { grid-template-columns: 1fr; gap: 4px; }
+    .action-step { grid-template-columns: 30px 1fr; }
+    .action-step .gain {
+      grid-column: 1 / -1; text-align: left; margin-top: 4px;
+    }
+  }
+
+  /* FINDING CARD - Phase D rewrite.
+     Editorial card: paper white background, 1px rule border, 6px
+     radius. Severity colour moves from a left rail to a small pill
+     in the top-left. Title is serif 18px. Impact is large red serif
+     pushed to the right. Body holds the smoking-gun + call chain +
+     fix box. The old `.finding-header` / `.severity-badge` /
+     `.smoking-gun` / `.ai-fix` rules above are orphaned but left in
+     place - clean up in a later phase. */
+  .finding {
+    background: var(--bg-paper);
+    border: 1px solid var(--rule);
+    border-radius: 6px;
+    margin-bottom: 18px;
+    overflow: hidden;
+    border-left: 1px solid var(--rule);  /* override the old severity-coloured left rail */
+  }
+  .finding.severity-high,
+  .finding.severity-medium,
+  .finding.severity-low {
+    background: var(--bg-paper);
+    border-left: 1px solid var(--rule);
+  }
+  .finding-top {
+    padding: 16px 20px 14px;
+    border-bottom: 1px solid var(--rule);
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    gap: 16px;
+    align-items: start;
+  }
+  .severity-pill {
+    display: inline-flex; align-items: center; gap: 6px;
+    padding: 3px 10px; font-size: 10px; letter-spacing: 0.1em;
+    text-transform: uppercase; font-weight: 700;
+    border-radius: 2px; height: fit-content;
+  }
+  .severity-pill.high { background: var(--accent-soft); color: var(--accent); }
+  .severity-pill.medium { background: var(--warn-soft); color: var(--warn); }
+  .severity-pill.low { background: var(--info-soft); color: var(--info); }
+  .severity-pill::before {
+    content: ''; width: 6px; height: 6px; border-radius: 50%;
+    background: currentColor;
+  }
+  h3.finding-title, .finding-top .finding-title {
+    font-family: var(--display); font-size: 18px; font-weight: 600;
+    line-height: 1.35; color: var(--ink); margin: 0;
+    letter-spacing: -0.005em;
+    border-bottom: none; padding-bottom: 0;
+  }
+  .finding-meta {
+    font-size: 12px; color: var(--ink-mute);
+    margin-top: 4px; font-family: var(--mono);
+    word-break: break-all;
+  }
+  .finding-meta a { color: inherit; text-decoration: none; border-bottom: 1px dotted var(--rule-strong); }
+  .finding-meta a:hover { color: var(--accent); border-bottom-color: var(--accent); }
+  .finding-top .finding-impact {
+    text-align: right; white-space: nowrap;
+  }
+  .finding-top .finding-impact .big {
+    font-family: var(--display); font-size: 22px; font-weight: 600;
+    color: var(--accent); letter-spacing: -0.01em;
+    display: block; line-height: 1;
+  }
+  .finding-top .finding-impact .small {
+    font-size: 11px; color: var(--ink-mute); margin-top: 4px;
+    font-family: var(--sans);
+  }
+  .finding-body { padding: 16px 20px; }
+
+  /* SMOKING block - yellow-tinted left-rail card with the dark
+     code-block inside. Replaces the old `.smoking-gun` panel. */
+  .smoking {
+    background: var(--bg-tint);
+    border-left: 3px solid var(--accent);
+    padding: 12px 14px; margin: 0 0 14px;
+    border-radius: 0 4px 4px 0;
+  }
+  .smoking-label {
+    font-size: 10px; letter-spacing: 0.15em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 600; margin-bottom: 8px;
+  }
+  .code-block {
+    font-family: var(--mono); font-size: 12.5px;
+    background: #f6f8fa; color: #1f2328;
+    padding: 12px 16px; border-radius: 4px;
+    overflow-x: auto; line-height: 1.6;
+    margin: 0;
+    white-space: pre;
+    border: 1px solid #d0d7de;
+  }
+  .code-block .line { display: block; margin: 0 -16px; padding: 0 16px; }
+  .code-block .ln {
+    color: #8c959f; margin-right: 14px; user-select: none;
+    display: inline-block; width: 32px; text-align: right;
+  }
+  .code-block .hot-line {
+    display: block;
+    background: #fff8c5;
+    margin: 0 -16px; padding: 0 16px;
+  }
+  .code-block .added { color: #1a7f37; }
+  .code-block .removed { color: #cf222e; text-decoration: line-through; opacity: 0.8; }
+
+  /* GitHub Light token palette for Pygments-highlighted Python snippets.
+     Pygments classes (with our ``tok-`` prefix) - applied to both the
+     smoking-gun .code-block and the Line-Level Drilldown .line-prof
+     table's source column. The hot-line yellow wrapper sits OUTSIDE
+     these per-token spans so the highlight composes correctly. */
+  .code-block .tok-k, .code-block .tok-kn, .code-block .tok-kc,
+  .code-block .tok-kd, .code-block .tok-kr,
+  .code-block .tok-ow,
+  .line-prof .tok-k, .line-prof .tok-kn, .line-prof .tok-kc,
+  .line-prof .tok-kd, .line-prof .tok-kr,
+  .line-prof .tok-ow                       { color: #cf222e; }
+  .code-block .tok-bp,
+  .line-prof .tok-bp                       { color: #cf222e; font-style: italic; }
+  .code-block .tok-nb,
+  .line-prof .tok-nb                       { color: #0550ae; }
+  .code-block .tok-nf, .code-block .tok-nd, .code-block .tok-fm,
+  .line-prof .tok-nf, .line-prof .tok-nd, .line-prof .tok-fm   { color: #8250df; }
+  .code-block .tok-nc,
+  .line-prof .tok-nc                       { color: #953800; }
+  .code-block .tok-n,
+  .line-prof .tok-n                        { color: #1f2328; }
+  .code-block .tok-s, .code-block .tok-s1, .code-block .tok-s2,
+  .code-block .tok-sb,
+  .line-prof .tok-s, .line-prof .tok-s1, .line-prof .tok-s2,
+  .line-prof .tok-sb                       { color: #0a3069; }
+  .code-block .tok-sa,
+  .line-prof .tok-sa                       { color: #cf222e; }
+  .code-block .tok-se,
+  .line-prof .tok-se                       { color: #0550ae; }
+  .code-block .tok-si,
+  .line-prof .tok-si                       { color: #1f2328; }
+  .code-block .tok-m, .code-block .tok-mi, .code-block .tok-mf,
+  .code-block .tok-mh, .code-block .tok-mo,
+  .line-prof .tok-m, .line-prof .tok-mi, .line-prof .tok-mf,
+  .line-prof .tok-mh, .line-prof .tok-mo   { color: #0550ae; }
+  .code-block .tok-c, .code-block .tok-c1, .code-block .tok-ch,
+  .code-block .tok-cm,
+  .line-prof .tok-c, .line-prof .tok-c1, .line-prof .tok-ch,
+  .line-prof .tok-cm                       { color: #6e7781; font-style: italic; }
+  .code-block .tok-o, .code-block .tok-p,
+  .line-prof .tok-o, .line-prof .tok-p     { color: #1f2328; }
+
+  /* CHAIN - call-chain pill track. Replaces the dashed-border-top
+     Phase 2 / drill-down callouts inside the old smoking-gun panel. */
+  .chain {
+    margin-top: 12px; padding-top: 12px;
+    border-top: 1px dashed var(--rule);
+  }
+  .chain-label {
+    font-size: 10px; letter-spacing: 0.15em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 600; margin-bottom: 8px;
+  }
+  .chain-track {
+    display: flex; flex-wrap: wrap; gap: 6px; align-items: center;
+    font-family: var(--mono); font-size: 12px;
+  }
+  .chain-track .step {
+    padding: 3px 8px; background: var(--bg-paper);
+    border: 1px solid var(--rule);
+    border-radius: 3px; color: var(--ink-soft);
+  }
+  .chain-track .step.terminal {
+    background: var(--accent); color: white;
+    border-color: var(--accent);
+  }
+  .chain-track .arrow { color: var(--ink-mute); font-size: 11px; }
+  .chain-foot {
+    font-size: 11px; color: var(--ink-mute); margin-top: 6px;
+    font-family: var(--sans);
+  }
+
+  /* PHASE 2 hottest-line callout - when present and the finding
+     isn't itself a Hot Line. Sits inside the smoking-gun block. */
+  .phase2-line {
+    margin-top: 8px; padding-top: 8px;
+    border-top: 1px dashed var(--rule);
+    font-size: 12px; color: var(--ink-soft);
+  }
+  .phase2-line strong { color: var(--info); font-weight: 600; }
+  .phase2-line code {
+    font-family: var(--mono); font-size: 11.5px;
+    background: var(--hot); color: var(--ink);
+    padding: 1px 6px; border-radius: 2px; margin-left: 6px;
+  }
+
+  /* CALL-TREE - Phase K.5: nested collapsible groups per stack
+     frame. Indented children, hot-frame highlight when a node consumes
+     >=50% of its parent. Pure HTML + CSS, no JS. */
+  .call-tree {
+    font-family: var(--mono); font-size: 12px;
+    background: var(--bg-paper);
+    border: 1px solid var(--rule);
+    border-radius: 4px; padding: 4px 0;
+  }
+  details.call-tree-node {
+    border: none; margin: 0; padding: 0;
+  }
+  details.call-tree-node > summary {
+    cursor: pointer; padding: 4px 12px 4px 28px;
+    list-style: none; user-select: none;
+    display: flex; gap: 14px; align-items: baseline;
+    position: relative;
+    border-radius: 0;
+    transition: background 0.1s;
+  }
+  details.call-tree-node > summary:hover { background: var(--bg-tint); }
+  details.call-tree-node > summary::-webkit-details-marker { display: none; }
+  details.call-tree-node > summary::before {
+    content: "\25B8";
+    position: absolute; left: 10px; top: 4px;
+    color: var(--ink-mute); font-size: 10px;
+    transition: transform 0.1s;
+  }
+  details.call-tree-node[open] > summary::before {
+    transform: rotate(90deg);
+  }
+  details.call-tree-node .frame-name {
+    color: var(--ink); font-weight: 600;
+    flex: 0 0 auto;
+  }
+  details.call-tree-node .frame-meta {
+    color: var(--ink-mute); font-size: 11px;
+    font-family: var(--mono); flex: 1 1 auto;
+    text-align: left;
+    overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+  }
+  details.call-tree-node.call-tree-hot > summary {
+    background: var(--hot);
+  }
+  details.call-tree-node.call-tree-hot > summary:hover {
+    background: var(--hot-strong);
+  }
+  details.call-tree-node.call-tree-hot > summary .frame-name {
+    color: var(--accent);
+  }
+  .call-tree-children {
+    padding-left: 16px;
+    border-left: 1px dashed var(--rule);
+    margin-left: 18px;
+  }
+  .call-tree-truncated {
+    padding: 4px 12px;
+    color: var(--ink-mute); font-size: 11px;
+    font-style: italic;
+  }
   @media print {
-    .conic-donut { display: none !important; }
-    .svg-donut { display: block !important; }
+    details.call-tree-node:not([open]) > summary::after {
+      content: " (collapsed)";
+      font-size: 9px; color: var(--ink-mute);
+    }
+  }
+
+  /* FIX-BOX - AI-suggested fix. Replaces the old `.ai-fix` panel. */
+  .fix-box {
+    border: 1px solid var(--rule); border-radius: 4px;
+    margin-top: 14px; overflow: hidden;
+  }
+  .fix-head {
+    background: var(--bg-tint); padding: 8px 14px;
+    font-size: 11px; letter-spacing: 0.1em; text-transform: uppercase;
+    font-weight: 600; color: var(--ink-soft);
+    border-bottom: 1px solid var(--rule);
+    display: flex; justify-content: space-between; align-items: center;
+  }
+  .fix-head .ai-tag {
+    background: var(--ink); color: var(--bg);
+    padding: 2px 7px; border-radius: 2px;
+    font-size: 9px; letter-spacing: 0.08em;
+    font-family: var(--mono);
+  }
+  .fix-body { padding: 14px 16px; font-size: 13.5px; line-height: 1.65; color: var(--ink); }
+  .fix-body p { margin: 0 0 10px; }
+  .fix-body p:last-child { margin-bottom: 0; }
+  .fix-body strong { color: var(--ink); }
+  .fix-body code {
+    font-family: var(--mono); font-size: 12px;
+    background: var(--bg-tint); padding: 1px 5px; border-radius: 2px;
+  }
+  .fix-body pre {
+    background: #ffffff; border: 1px solid var(--rule);
+    border-radius: 4px; padding: 8px 10px;
+    overflow-x: auto; white-space: pre-wrap; word-break: break-word;
+  }
+  .fix-body pre.dh { padding: 6px 0; border: none; background: var(--bg-tint); }
+  .fix-body pre.dh .dh-line {
+    display: block; padding: 0 10px;
+    white-space: pre-wrap; word-break: break-word;
+  }
+  .fix-body pre.dh .dh-add { background: #e6ffec; color: #116329; }
+  .fix-body pre.dh .dh-del { background: #ffebe9; color: #a40e26; }
+  .fix-body pre.dh .dh-meta { background: #f2effd; color: #6639ba; }
+  .fix-caution {
+    font-size: 12px; color: var(--warn);
+    background: var(--warn-soft);
+    border: 1px solid var(--rule);
+    border-radius: 4px; padding: 6px 10px;
+    margin: 8px 14px 0; display: block;
+  }
+  .fix-foot {
+    font-size: 11px; color: var(--ink-mute);
+    padding: 8px 14px; border-top: 1px dashed var(--rule);
+    background: var(--bg-paper);
+  }
+
+  /* SUB-FINDINGS - root-cause grouped peers inside a primary card.
+     Indented child list; thin left-rule; smaller pills. */
+  .sub-findings {
+    margin: 14px 0 0 0; padding: 12px 0 0 14px;
+    border-top: 1px dashed var(--rule);
+    border-left: 2px solid var(--rule);
+    margin-left: 0;
+  }
+  .sub-findings-label {
+    font-size: 11px; color: var(--ink-mute);
+    margin: 0 0 8px; line-height: 1.5;
+  }
+  .sub-finding-row {
+    padding: 6px 0; font-size: 12.5px;
+  }
+  .sub-finding-row + .sub-finding-row {
+    border-top: 1px solid var(--rule);
+  }
+  .sub-finding-row summary {
+    cursor: pointer; display: flex; gap: 8px;
+    align-items: center; list-style: none;
+  }
+  .sub-finding-row summary::-webkit-details-marker { display: none; }
+  .sub-finding-row .sub-title {
+    flex: 1; font-weight: 500; color: var(--ink);
+  }
+  .sub-finding-row .sub-impact {
+    font-size: 11px; color: var(--ink-mute);
+    font-family: var(--mono);
+  }
+  .sub-finding-row .sub-desc {
+    margin-top: 6px; color: var(--ink-soft);
+    white-space: pre-wrap; font-size: 12.5px;
+  }
+
+  /* DATA TABLES - Phase E.
+     Editorial table style applied to per-action breakdown, background
+     jobs, hot frames, top queries, and XHR timing. The existing
+     `.tbl-clip` overflow class keeps long URLs/paths wrapping inside
+     cells; `.data` adds typography, dividers, and the inline-bar +
+     row-finding patterns. */
+  table.data {
+    width: 100%; border-collapse: collapse;
+    background: var(--bg-paper);
+    border: 1px solid var(--rule); border-radius: 6px;
+    overflow: hidden; font-size: 13px;
+    margin: 12px 0;
+  }
+  table.data thead th {
+    background: var(--bg-tint);
+    padding: 10px 14px; text-align: left;
+    font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+    font-weight: 700; color: var(--ink-soft);
+    border-bottom: 1px solid var(--rule);
+    white-space: nowrap;
+  }
+  table.data thead th.num { text-align: right; }
+  table.data tbody td {
+    padding: 12px 14px; border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+  }
+  table.data tbody tr:last-child td { border-bottom: none; }
+  table.data tbody tr:hover { background: var(--bg-tint); }
+  table.data td.num {
+    text-align: right;
+    font-variant-numeric: tabular-nums;
+    font-feature-settings: 'tnum';
+    font-family: var(--mono); font-size: 12.5px;
+  }
+  table.data .action-name {
+    font-weight: 600; color: var(--ink);
+    font-family: var(--mono); font-size: 12.5px;
+    word-break: break-all;
+  }
+  table.data .action-meta {
+    font-size: 11px; color: var(--ink-mute);
+    margin-top: 3px; font-family: var(--mono);
+    word-break: break-all;
+  }
+  table.data .action-meta a {
+    color: inherit; text-decoration: none;
+    border-bottom: 1px dotted var(--rule-strong);
+  }
+  table.data .action-meta a:hover {
+    color: var(--accent); border-bottom-color: var(--accent);
+  }
+  table.data .type-tag {
+    display: inline-block; padding: 2px 7px;
+    border-radius: 2px;
+    font-size: 10px; letter-spacing: 0.05em; font-weight: 600;
+    background: var(--info-soft); color: var(--info);
+    text-transform: uppercase;
+    font-family: var(--sans);
+  }
+  table.data .type-tag.bg {
+    background: var(--warn-soft); color: var(--warn);
+  }
+
+  /* BAR CELL - inline duration bar in the Duration column. */
+  .bar-cell { position: relative; min-width: 110px; }
+  .bar-cell .bar-track {
+    height: 4px; background: var(--rule); border-radius: 2px;
+    margin-top: 4px; overflow: hidden;
+  }
+  .bar-cell .bar-fill {
+    height: 100%; background: var(--accent); border-radius: 2px;
+  }
+  .bar-cell .bar-fill.ok { background: var(--ok); }
+  .bar-cell .bar-fill.warn { background: var(--warn); }
+  .hot-value { color: var(--accent); font-weight: 600; }
+
+  /* ROW-FINDING - colspan sub-row surfaced under an action that
+     has High-severity linked findings. Red-tinted background, red
+     text, prominent. */
+  .row-finding {
+    background: var(--accent-soft) !important;
+    padding: 12px 16px !important;
+    font-size: 12px; color: var(--accent);
+  }
+  .row-finding strong { font-weight: 600; }
+
+  /* HOT-FRAMES - user-code rows get a yellow-tinted background to
+     stand out from the framework rows the developer can't patch. */
+  .hot-frames-table tr.is-hot td {
+    background: rgba(254, 243, 199, 0.4);
+  }
+
+  /* EMPTY-STATE - green "✓ Clear" card shown when slowest-queries
+     (or any future section) has no rows. */
+  .empty-state {
+    background: var(--bg-paper);
+    border: 1px dashed var(--rule-strong);
+    border-radius: 6px;
+    padding: 32px 28px;
+    text-align: center;
+    color: var(--ink-soft);
+    margin: 12px 0;
+  }
+  .empty-state .empty-icon {
+    font-family: var(--display); font-size: 32px; font-style: italic;
+    color: var(--ok); margin-bottom: 8px; font-weight: 500;
+    display: block;
+  }
+  .empty-state p {
+    margin: 0 auto; max-width: 540px;
+    font-size: 14px; line-height: 1.6;
+  }
+
+  /* PHASE 2 PANEL - Phase F.
+     Editorial layout for the line-profiler drilldown: bordered run
+     cards, bordered function blocks with progressive indent for
+     auto-expanded descendants, compact line-prof tables with a tint
+     on hot rows. Replaces the old inline-styled markup the builder
+     used to emit. */
+  .phase2-run {
+    margin: 16px 0; padding: 14px 16px;
+    background: var(--bg-paper);
+    border: 1px solid var(--rule); border-radius: 6px;
+  }
+  .phase2-run + .phase2-run { margin-top: 12px; }
+  .phase2-run-head {
+    display: flex; justify-content: space-between; align-items: baseline;
+    margin-bottom: 8px; gap: 12px;
+  }
+  .phase2-run-head strong {
+    font-family: var(--display); font-size: 16px; font-weight: 600;
+  }
+  .phase2-run-head .meta {
+    font-size: 12px; color: var(--ink-soft);
+    font-family: var(--mono); font-variant-numeric: tabular-nums;
+  }
+  .phase2-run-head .status-badge {
+    display: inline-block; padding: 1px 7px; border-radius: 2px;
+    font-size: 10px; letter-spacing: 0.05em; font-weight: 600;
+    text-transform: uppercase; margin-right: 6px;
+  }
+  .phase2-run-head .status-Ready { background: var(--ok-soft); color: var(--ok); }
+  .phase2-run-head .status-Recording { background: var(--info-soft); color: var(--info); }
+  .phase2-run-head .status-Analyzing { background: var(--warn-soft); color: var(--warn); }
+  .phase2-run-head .status-Failed { background: var(--accent-soft); color: var(--accent); }
+  .picks {
+    font-size: 12px; color: var(--ink-mute);
+    margin-bottom: 8px; font-family: var(--mono);
+    word-break: break-all;
+  }
+  .picks em { font-style: italic; }
+  .phase2-func {
+    margin: 12px 0; padding: 10px 12px;
+    border: 1px solid var(--rule); border-radius: 4px;
+    background: var(--bg-paper);
+  }
+  .phase2-func.indent-1 { margin-left: 24px; }
+  .phase2-func.indent-2 { margin-left: 48px; }
+  .phase2-func.indent-3 { margin-left: 72px; }
+  .phase2-func .fn-name {
+    font-family: var(--mono); font-weight: 600; font-size: 13px;
+    color: var(--ink); margin-bottom: 4px; word-break: break-all;
+  }
+  .phase2-func .fn-name .arrow {
+    color: var(--ink-mute); margin-right: 6px;
+  }
+  .phase2-func .fn-path {
+    color: var(--ink-mute); font-size: 11px;
+    margin-bottom: 8px; font-family: var(--mono);
+    word-break: break-all;
+  }
+  table.line-prof {
+    width: 100%; border-collapse: collapse;
+    font-family: var(--mono); font-size: 12px;
+  }
+  table.line-prof thead th {
+    background: var(--bg-tint);
+    padding: 4px 8px; text-align: right;
+    font-size: 10px; letter-spacing: 0.1em; text-transform: uppercase;
+    font-weight: 700; color: var(--ink-soft);
+    border-bottom: 1px solid var(--rule);
+    font-family: var(--sans); white-space: nowrap;
+  }
+  table.line-prof thead th:last-child { text-align: left; }
+  table.line-prof tbody td {
+    padding: 2px 8px; border-bottom: 1px solid var(--rule);
+    vertical-align: top;
+    font-variant-numeric: tabular-nums;
+  }
+  table.line-prof tbody tr:last-child td { border-bottom: none; }
+  table.line-prof tbody td.ln {
+    color: var(--ink-mute); text-align: right;
+    user-select: none; width: 1%; white-space: nowrap;
+  }
+  table.line-prof tbody td.num { text-align: right; }
+  table.line-prof tbody td.src code {
+    white-space: pre; font-family: var(--mono); font-size: 12px;
+  }
+  table.line-prof tbody tr.hot {
+    background: var(--hot);
+  }
+  table.line-prof tbody tr.hot td.num { color: var(--accent); font-weight: 600; }
+  table.line-prof tbody tr.added td { background: rgba(45, 106, 60, 0.12); }
+  table.line-prof tbody tr.removed td { background: rgba(197, 57, 43, 0.12); }
+
+  /* DOC-EVENT LIFECYCLE - Phase F. */
+  .doctype-block {
+    background: var(--bg-paper);
+    border: 1px solid var(--rule); border-radius: 6px;
+    padding: 16px 20px; margin-bottom: 14px;
+  }
+  .doctype-block .dt-head {
+    font-family: var(--display); font-weight: 600; font-size: 17px;
+    color: var(--ink); margin-bottom: 4px;
+  }
+  .doctype-block .dt-meta {
+    font-size: 12px; color: var(--ink-mute);
+    font-weight: 400; margin-left: 6px;
+  }
+  .doctype-block .event-section {
+    margin-top: 10px; padding-top: 8px;
+    border-top: 1px dashed var(--rule);
+  }
+  .doctype-block .event-name {
+    font-family: var(--display); font-size: 13px; font-weight: 600;
+    color: var(--ink-soft);
+  }
+  .doctype-block .event-time {
+    font-family: var(--mono); font-size: 12px;
+    color: var(--ink-mute); margin-left: 6px;
+  }
+  .doctype-block .method-row {
+    display: grid; grid-template-columns: 1fr auto;
+    gap: 12px; padding: 6px 0 6px 14px;
+  }
+  .doctype-block .method-name {
+    font-family: var(--mono); font-weight: 500; font-size: 12.5px;
+    color: var(--ink); word-break: break-all;
+  }
+  .doctype-block .method-name a {
+    color: inherit; text-decoration: none;
+    border-bottom: 1px dotted var(--rule-strong);
+  }
+  .doctype-block .method-meta {
+    font-family: var(--mono); font-size: 11px;
+    color: var(--ink-mute); margin-left: 6px;
+  }
+  .doctype-block .method-tag {
+    display: inline-block; padding: 1px 6px;
+    background: var(--info-soft); color: var(--info);
+    font-size: 10px; letter-spacing: 0.05em;
+    border-radius: 2px; font-family: var(--sans);
+    margin-left: 6px; font-weight: 600;
+  }
+  .doctype-block .method-time {
+    font-family: var(--mono); font-size: 12.5px;
+    color: var(--accent); font-weight: 600; white-space: nowrap;
+  }
+
+  /* WEB VITALS - Phase F. Per-cell rating classes. */
+  .vitals-table .vital-good { color: var(--ok); font-weight: 600; }
+  .vitals-table .vital-meh  { color: var(--warn); font-weight: 600; }
+  .vitals-table .vital-poor { color: var(--accent); font-weight: 600; }
+  .vitals-table .vital-none { color: var(--ink-mute); }
+
+  /* HOW-TO-READ APPENDIX - Phase F. Italic-serif heading + + / -
+     chevron + muted bullet list. */
+  details.how-to {
+    background: var(--bg-tint);
+    border: 1px solid var(--rule); border-radius: 6px;
+    padding: 14px 20px; margin-top: 48px;
+  }
+  details.how-to summary {
+    font-family: var(--display); font-size: 17px; font-weight: 600;
+    cursor: pointer; padding: 4px 0; outline: none;
+    list-style: none; display: flex; align-items: center; gap: 8px;
+    color: var(--ink);
+  }
+  details.how-to summary::-webkit-details-marker { display: none; }
+  details.how-to summary::before {
+    content: '+'; font-family: var(--mono); color: var(--accent);
+    font-size: 18px;
+  }
+  details.how-to[open] summary::before { content: '−'; }
+  details.how-to summary h2 {
+    display: inline; font: inherit; margin: 0; padding: 0;
+    border-bottom: none; letter-spacing: 0;
+  }
+  details.how-to ul {
+    margin: 16px 0 4px 0; padding-left: 18px;
+    font-size: 13.5px; line-height: 1.75; color: var(--ink-soft);
+  }
+  details.how-to ul li { margin-bottom: 6px; }
+  details.how-to ul li strong { color: var(--ink); font-weight: 600; }
+  details.how-to ul li code {
+    font-family: var(--mono); font-size: 12px;
+    background: var(--bg-paper); padding: 1px 5px; border-radius: 2px;
+  }
+  details.how-to ul li em { font-style: italic; color: var(--ink-soft); }
+
+  /* RESOURCE CARDS - Phase G. Four KPIs at the top of the Server
+     Resource panel; replaces the old .stats/.stat blocks reused
+     there earlier. */
+  .resource-grid {
+    display: grid; grid-template-columns: repeat(4, 1fr);
+    gap: 14px; margin-bottom: 20px;
+  }
+  .resource-card {
+    background: var(--bg-paper); border: 1px solid var(--rule);
+    border-radius: 6px; padding: 16px 18px;
+  }
+  .resource-card .rc-label {
+    font-size: 10px; letter-spacing: 0.12em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 600; margin-bottom: 8px;
+  }
+  .resource-card .rc-value {
+    font-family: var(--display); font-size: 26px; font-weight: 600;
+    line-height: 1; letter-spacing: -0.01em; color: var(--ink);
+  }
+  .resource-card .rc-unit {
+    font-size: 12px; color: var(--ink-mute);
+    margin-left: 2px; font-weight: 400;
+  }
+  .resource-card .rc-sub {
+    font-size: 11px; color: var(--ink-soft); margin-top: 6px;
+  }
+  @media (max-width: 760px) {
+    .resource-grid { grid-template-columns: repeat(2, 1fr); }
+  }
+
+  /* INDEX-REC CARDS - Phase I. One card per database table that has
+     an actionable recommendation (composite index, candidate columns,
+     meta-table note, framework-cols-only, or no-indexable-column).
+     Lifted out of the time-per-table data table where they used to
+     ride as colspan sub-rows. */
+  .index-recs { margin-top: 24px; }
+  .index-recs-head {
+    font-family: var(--display); font-size: 16px; font-weight: 600;
+    margin: 0 0 10px; color: var(--ink);
+    letter-spacing: -0.005em;
+  }
+  .index-rec {
+    background: var(--bg-paper); border: 1px solid var(--rule);
+    border-radius: 6px; padding: 16px 20px; margin-bottom: 12px;
+  }
+  .index-rec-head {
+    display: flex; justify-content: space-between;
+    align-items: baseline; gap: 12px; margin-bottom: 8px;
+    flex-wrap: wrap;
+  }
+  .index-rec-table {
+    font-family: var(--mono); font-size: 14px; font-weight: 600;
+    color: var(--ink); word-break: break-all;
+  }
+  .index-rec-stats {
+    font-size: 11px; color: var(--ink-mute);
+    font-family: var(--mono); white-space: nowrap;
+  }
+  .index-rec-stats .stat-num { color: var(--ink); font-weight: 600; }
+  .index-rec-label {
+    font-size: 10px; letter-spacing: 0.15em; text-transform: uppercase;
+    color: var(--ink-mute); font-weight: 600; margin-bottom: 6px;
+  }
+  .index-rec p {
+    margin: 6px 0; font-size: 13px; color: var(--ink-soft);
+    line-height: 1.55;
+  }
+  .index-rec p code {
+    font-family: var(--mono); font-size: 12px;
+    background: var(--bg-tint); padding: 1px 5px;
+    border-radius: 2px; color: var(--ink);
+  }
+  .index-rec .warn-text {
+    color: var(--warn); font-size: 12px;
+    padding: 6px 10px; background: var(--warn-soft);
+    border-radius: 3px; margin: 8px 0;
+  }
+  .index-rec .note-text {
+    font-size: 12px; color: var(--ink-mute);
+    margin-top: 6px; line-height: 1.55;
+  }
+  .index-rec .note-text code {
+    font-family: var(--mono); font-size: 11.5px;
+    background: var(--bg-tint); padding: 1px 5px;
+    border-radius: 2px;
+  }
+  .sql-snip {
+    font-family: var(--mono); font-size: 12px;
+    background: #1a1a1a; color: #f4ecd6;
+    padding: 10px 14px; border-radius: 4px;
+    overflow-x: auto; margin: 8px 0; line-height: 1.5;
+    white-space: pre-wrap; word-break: break-word;
+  }
+
+  /* Print - drop the nav pills (they're useless on paper), invert
+     the TL;DR hero so it survives on white paper. */
+  @media print {
+    nav.nav-pills { display: none; }
+    .tldr {
+      background: var(--bg-paper); color: var(--ink);
+      border: 1px solid var(--rule);
+    }
+    .tldr::before { display: none; }
+    .tldr-label { color: var(--ink-mute); }
+    .tldr-headline { color: var(--ink); }
+    .tldr-headline .hot { color: var(--accent); }
+    .tldr-sub { color: var(--ink-soft); }
+    .tldr-headline code, .tldr-sub code {
+      background: var(--bg-tint); color: var(--ink);
+    }
   }
 </style>
 </head>
@@ -604,176 +1509,148 @@
    per-app bucket loop stays readable. `show_fix_hint_label` toggles
    "How to fix" (actionable Findings) vs "Context" (Observations). #}
 {% macro finding_card(f, show_fix_hint_label="How to fix", hide_ai_fix=False, hide_source_snippet=False) %}
+  {# v0.7.x redesign Phase D: editorial finding card.
+
+     - `.finding-top` 3-zone grid: severity pill | title + meta | impact.
+     - `.finding-body` wraps the smoking-gun (dark code block) + call
+       chain (pill track, last step red) + technical details + AI fix
+       box.
+     - Old `.finding-header` / `.severity-badge` / `.smoking-gun` /
+       `.ai-fix` class names became orphaned; their CSS is still in the
+       stylesheet for backward-compat with anything that might inline
+       the macro elsewhere, but the macro itself emits the new shape.
+
+     Data shapes (f.technical_detail / f.llm_fix / f.sub_findings) are
+     unchanged from Phase B/C. #}
   <div class="finding severity-{{ f.severity | lower }}">
-    <div class="finding-header">
-      <span class="severity-badge {{ f.severity | lower }}">{{ f.severity }}</span>
-      <span class="finding-title">{{ f.title }}</span>
-      <span class="finding-impact">~{{ fmt_ms(f.estimated_impact_ms) }}{% if f.affected_count > 1 %} &middot; {{ f.affected_count }}×{% endif %}</span>
-    </div>
-    {# v0.6.0 Round 3: customer_description dropped from rendering — it
-       repeated what the title + smoking-gun block already convey, reading
-       as redundant prose. The data is still produced by analyzers and
-       persisted on the Optimus Finding row, so API consumers still have
-       access to it. #}
 
     {% set detail = f.technical_detail or {} %}
     {% set callsite = detail.callsite or {} %}
 
-    {# v0.6.0 smoking-gun block — file:line + ±1 source snippet + phase-2
-       hot-line callout (when the same function was instrumented). Hoisted
-       above the technical-detail block so the developer sees the offending
-       line directly under the title. The vscode://file link uses the
-       callsite's absolute path (``_abs``) when we have one. For SQL red-flag
-       findings (Missing Index, Full Table Scan, …) the callsite is a
-       *representative* one — the hottest user-app frame that ran the query —
-       flagged with ``is_representative``.
-
-       v0.7.x: callers that embed finding_card in narrow contexts (per-action
-       row, BG-job row) pass ``hide_source_snippet=True`` to drop the entire
-       smoking-gun block — the row itself already shows the file:line as an
-       inline anchor under the action/job label, making this styled panel
-       redundant clutter. The canonical Findings section keeps the default
-       (False) so the full smoking-gun (header + source snippet + drill-down)
-       still renders there. #}
-    {% if callsite.filename and callsite.lineno and not hide_source_snippet %}
-    {% set _link = callsite._abs or (callsite.filename if callsite.filename and callsite.filename.startswith("/") else None) %}
-    <div class="smoking-gun" style="margin: 6px 0; padding: 6px 8px; background: #f9fafb; border-left: 3px solid #2563eb; border-radius: 0 4px 4px 0;">
-      <div style="margin-bottom: 6px;">
-        {% if callsite.is_representative %}<span class="muted">Most-called from:</span> {% endif %}
-        {% if _link %}
-          <a class="callsite-link"
-             href="vscode://file{{ _link }}:{{ callsite.lineno }}"
-             title="Open in VS Code / Cursor">
-            <code>{{ callsite.filename }}:{{ callsite.lineno }}{% if callsite.function %} <span class="muted">({{ callsite.function }})</span>{% endif %}</code>
-          </a>
-        {% else %}
-          <code>{{ callsite.filename }}:{{ callsite.lineno }}{% if callsite.function %} <span class="muted">({{ callsite.function }})</span>{% endif %}</code>
-        {% endif %}
-        {% if callsite.is_representative %}<div class="small muted" style="margin-top: 3px;">Representative callsite &mdash; this query runs from several places; this is the hottest one.</div>{% endif %}
-        {# v0.7.x: when phase-2 re-targeted this callsite from a wrapper
-           onto its actual hot leaf, show the original wrapper as a
-           breadcrumb so the reader sees the entry point too. #}
-        {% if callsite.original_wrapper %}
-        <div class="small muted" style="margin-top: 3px;">
-          Time entered through <code>{{ callsite.original_wrapper.function }}</code>{% if callsite.original_wrapper.lineno %} at line {{ callsite.original_wrapper.lineno }}{% endif %} &mdash; pinned here to the actual hot line.
-        </div>
-        {% endif %}
-      </div>
-
-      {% if callsite.source_snippet %}
-        <table style="border-collapse: collapse; font-family: ui-monospace, Menlo, monospace; font-size: 12px; width: 100%; margin: 0;">
-          {% for sl in callsite.source_snippet %}
-          <tr{% if sl.lineno == callsite.lineno %} style="background: #fef3c7;"{% endif %}>
-            <td style="padding: 1px 8px; color: #6b7280; text-align: right; user-select: none; width: 1%; white-space: nowrap;">{{ sl.lineno }}</td>
-            <td style="padding: 1px 8px;"><code style="white-space: pre;">{{ sl.content }}</code></td>
-          </tr>
-          {% endfor %}
-        </table>
-      {% endif %}
-
-      {# Hot Line findings ARE the phase-2 hot line — re-stating
-         "Phase 2: hottest line N" inside their own card would read as
-         self-referential. Suppress for that finding type only.
-
-         For other finding types (including those whose callsite was
-         retargeted to the drill-down's deepest user-code frame via
-         ``original_wrapper``), the Phase 2 callout adds value: the
-         smoking-gun snippet now anchors on the deepest function's
-         ``def`` line, while this callout pinpoints the actually-hot
-         line *inside* that function (a different lineno). #}
-      {% if f.finding_type != "Hot Line" %}
-        {# v0.7.x: when the smoking-gun was retargeted to the call site
-           of a deeper leaf, callsite.function is the PARENT (where the
-           call line lives) but the Phase 2 hot line belongs to the
-           LEAF. Use phase2_lookup_filename / phase2_lookup_function
-           when present so the cross-link still resolves; otherwise
-           fall back to the callsite itself. #}
-        {% set _p2_file = callsite.phase2_lookup_filename or callsite.filename %}
-        {% set _p2_fn = callsite.phase2_lookup_function or callsite.function %}
-        {% set p2_hot = phase2_for_callsite(_p2_file, _p2_fn) %}
-        {% if p2_hot %}
-        <div style="margin-top: 4px; font-size: 12px; padding-top: 4px; border-top: 1px dashed #d1d5db;">
-          <strong style="color: #1d4ed8;">Phase 2:</strong>
-          hottest line {{ p2_hot.lineno }} &mdash; {{ fmt_ms(p2_hot.total_ms) }}{% if p2_hot.hits %} / {{ p2_hot.hits }} hit{{ "s" if p2_hot.hits != 1 else "" }}{% endif %}
-          {% if p2_hot.content %}
-          <code style="margin-left: 6px; padding: 1px 6px; background: #fef3c7; border-radius: 2px;">{{ p2_hot.content | trim }}</code>
+    <div class="finding-top">
+      <span class="severity-pill {{ f.severity | lower }}">{{ f.severity }}</span>
+      <div>
+        <h3 class="finding-title">{{ f.title }}</h3>
+        {% if callsite.filename and callsite.lineno %}
+        {% set _link = callsite._abs or (callsite.filename if callsite.filename and callsite.filename.startswith("/") else None) %}
+        <div class="finding-meta">
+          {% if callsite.is_representative %}<span class="muted">most-called from</span> {% endif %}
+          {% if _link %}
+            <a class="callsite-link" href="vscode://file{{ _link }}:{{ callsite.lineno }}" title="Open in VS Code / Cursor">{{ callsite.filename }}:{{ callsite.lineno }}{% if callsite.function %} &middot; {{ callsite.function }}{% endif %}</a>
+          {% else %}
+            {{ callsite.filename }}:{{ callsite.lineno }}{% if callsite.function %} &middot; {{ callsite.function }}{% endif %}
           {% endif %}
         </div>
         {% endif %}
+      </div>
+      <div class="finding-impact">
+        <span class="big">~{{ fmt_ms(f.estimated_impact_ms) }}</span>
+        {% if f.affected_count and f.affected_count > 1 %}
+        <div class="small">{{ f.affected_count }}× hits</div>
+        {% endif %}
+      </div>
+    </div>
+
+    <div class="finding-body">
+
+    {# v0.6.0 Round 3: customer_description dropped from rendering -
+       it repeats the title + smoking-gun block, reading as redundant
+       prose. Data still persisted for API consumers. #}
+
+    {# v0.7.x redesign Phase D: smoking-gun block. The file:line
+       callsite header moved into `.finding-meta` under the title; this
+       block is now purely the dark code-block + chain pills + Phase 2
+       crosslink + target-doc breadcrumb.
+
+       Callers embedding the macro in narrow contexts (per-action row,
+       BG-job row) pass ``hide_source_snippet=True`` to drop the entire
+       block. #}
+    {% if callsite.filename and callsite.lineno and not hide_source_snippet %}
+    <div class="smoking">
+      {% if callsite.is_representative %}
+      <div class="smoking-label">most-called from this callsite - this query runs from several places; the hottest one shown.</div>
       {% endif %}
-      {# v0.7.x: Phase-2 call-chain breadcrumb. Present on a Hot Line
-         finding when auto_expand instrumented a chain of functions and
-         the deepest leaf is what's being shown. The chain reads outer →
-         leaf (last step is the leaf finding's own location), so a reader
-         can see at a glance which wrapper(s) the time entered through. #}
+      {% if callsite.original_wrapper %}
+      <div class="smoking-label">Time entered through <code>{{ callsite.original_wrapper.function }}</code>{% if callsite.original_wrapper.lineno %} at line {{ callsite.original_wrapper.lineno }}{% endif %} - pinned here to the actual hot line.</div>
+      {% endif %}
+
+      {% if callsite.source_snippet %}
+      {# Drop blank context lines (PEP-8 spacers); always keep the target.
+         The `-` whitespace-control on else / endif strips the literal `\n`
+         after each emitted </span> - those newlines render as visible
+         blank lines inside <pre> on top of the `display: block` span,
+         doubling every source line's height. #}
+      <pre class="code-block">{% for sl in callsite.source_snippet -%}
+{% if (sl.content | trim) or sl.lineno == callsite.lineno %}{% if sl.lineno == callsite.lineno %}<span class="hot-line"><span class="ln">{{ sl.lineno }}</span>{% if sl.content_html %}{{ sl.content_html | safe }}{% else %}{{ sl.content }}{% endif %}</span>
+{%- else %}<span class="line"><span class="ln">{{ sl.lineno }}</span>{% if sl.content_html %}{{ sl.content_html | safe }}{% else %}{{ sl.content }}{% endif %}</span>
+{%- endif %}{% endif %}{%- endfor %}</pre>
+      {% endif %}
+
+      {# Phase 2 hottest-line callout - when the finding isn't itself
+         a Hot Line. Demoted to a one-liner below the snippet. #}
+      {% if f.finding_type != "Hot Line" %}
+        {% set _p2_file = callsite.phase2_lookup_filename or callsite.filename %}
+        {% set _p2_fn = callsite.phase2_lookup_function or callsite.function %}
+        {% set p2_hot = line_drilldown_for_callsite(_p2_file, _p2_fn) %}
+        {% if p2_hot %}
+        <div class="phase2-line">
+          <strong>Line-Level Drilldown:</strong>
+          hottest line {{ p2_hot.lineno }} - {{ fmt_ms(p2_hot.total_ms) }}{% if p2_hot.hits %} / {{ p2_hot.hits }} hit{{ "s" if p2_hot.hits != 1 else "" }}{% endif %}
+          {% if p2_hot.content %}<code>{{ p2_hot.content | trim }}</code>{% endif %}
+        </div>
+        {% endif %}
+      {% endif %}
+
+      {# Call chain (Phase 2 instrumented chain). Pills, terminal red. #}
       {% set _phase2_chain = (f.technical_detail or {}).get("call_chain") if f.technical_detail else None %}
       {% if _phase2_chain and _phase2_chain | length > 1 %}
-      <div style="margin-top: 4px; font-size: 12px; padding-top: 4px; border-top: 1px dashed #d1d5db;">
-        <strong style="color: #1d4ed8;">Call chain:</strong>
-        <span style="color: #374151;">
-        {% for step in _phase2_chain %}<code>{{ step.qualname }}:{{ step.lineno }}</code>{% if not loop.last %} <span class="muted">&rarr;</span> {% endif %}{% endfor %}
-        </span>
-        <span class="muted">&middot; deepest line is where the cost is incurred</span>
+      <div class="chain">
+        <div class="chain-label">Call chain</div>
+        <div class="chain-track">
+          {% for step in _phase2_chain %}<span class="step{% if loop.last %} terminal{% endif %}">{{ step.qualname }}:{{ step.lineno }}</span>{% if not loop.last %}<span class="arrow">&rarr;</span>{% endif %}{% endfor %}
+        </div>
+        <div class="chain-foot">deepest line is where the cost is incurred</div>
       </div>
       {% endif %}
-      {# v0.7.x: Phase-1 fallback hint. Present on a Hot Line finding
-         when the leaf's hot line still looks like a call into code we
-         didn't instrument; points the developer at the next user-code
-         descendant from phase-1's tree so they can re-pick it. #}
+
+      {# Phase-1 fallback hint. Hot Line findings whose hot line is a
+         call into uninstrumented framework code. #}
       {% set _phase1_hint = (f.technical_detail or {}).get("phase1_hint") if f.technical_detail else None %}
       {% if _phase1_hint %}
-      <div style="margin-top: 4px; font-size: 12px; padding-top: 4px; border-top: 1px dashed #d1d5db; color: #374151;">
-        <strong style="color: #1d4ed8;">Hint:</strong>
+      <div class="phase2-line">
+        <strong>Hint:</strong>
         time flows into <code>{{ _phase1_hint.next_hot_callee }}</code>
         ({{ fmt_ms(_phase1_hint.phase1_cumulative_ms) }} in phase&nbsp;1).
-        <span class="muted">Pick this function for a line-level breakdown.</span>
+        Pick this function for a line-level breakdown.
       </div>
       {% endif %}
-      {# v0.6.x: deterministic call-tree drill-down. Walks from the finding's
-         origin function down to the deepest user-code frame. Complements the
-         AI fix block below — gives non-LLM users the same actionable trail.
 
-         v0.7.x: when the chain is empty (key present but list is []), render
-         a placeholder explaining why — the origin function calls framework
-         code directly, so there's no deeper user-code frame to descend into.
-         When the key is absent entirely (no callsite/action/tree, e.g. SQL
-         red-flag findings), render nothing at all. #}
+      {# Drill-down chain. Renders as a pill track ending in red
+         (terminal = deepest user-code frame). Empty chain renders
+         the placeholder. #}
       {% set _drilldown = (f.technical_detail or {}).get("drilldown_chain") if f.technical_detail else None %}
-      {# v0.7.x: the drill-down chain is rooted at the **original**
-         wrapper frame (the finding's entry point), so the narrative
-         heading must name that wrapper — not the retargeted callsite
-         function. When the smoking gun was relocated to a deeper user-
-         code frame, ``callsite.original_wrapper.function`` holds the
-         wrapper's name; otherwise the current ``callsite.function`` is
-         the wrapper. #}
       {% set _drill_root_fn = callsite.original_wrapper.function if callsite.original_wrapper else callsite.function %}
       {% if _drilldown %}
-      <div style="margin-top: 4px; font-size: 12px; padding-top: 4px; border-top: 1px dashed #d1d5db;">
-        <strong style="color: #1d4ed8;">Drill-down:</strong>
-        time inside <code>{{ _drill_root_fn }}</code> walked through &mdash;
-        <div style="margin-top: 4px;">
-        {% for level in _drilldown %}
-          <div style="padding: 1px 0 1px {{ (loop.index0 + 1) * 12 }}px; color: #374151;">
-            <span class="muted">&#x21B3;</span>
-            <code>{{ level.filename }}:{{ level.lineno }}</code>
-            <span class="muted">({{ level.function }})</span>
-            &mdash; {{ fmt_ms(level.cumulative_ms) }}{% if level.pct_of_origin %} <span class="muted">&middot; {{ level.pct_of_origin }}% of parent</span>{% endif %}
-          </div>
-        {% endfor %}
+      <div class="chain">
+        <div class="chain-label">Drill-down</div>
+        <div class="chain-track">
+          <span class="step">{{ _drill_root_fn }}</span>
+          {% for level in _drilldown %}<span class="arrow">&rarr;</span><span class="step{% if loop.last %} terminal{% endif %}">{{ level.function }}:{{ level.lineno }}</span>{% endfor %}
         </div>
+        <div class="chain-foot">time inside <code>{{ _drill_root_fn }}</code> walked through</div>
       </div>
       {% elif _drilldown is not none %}
-      <div style="margin-top: 4px; font-size: 12px; padding-top: 4px; border-top: 1px dashed #d1d5db; color: #6b7280;">
-        <strong style="color: #1d4ed8;">Drill-down:</strong>
-        no deeper user-code frame &mdash; <code>{{ _drill_root_fn }}</code> calls framework code directly. Check the N+1 Query or related findings for inner-loop details.
+      <div class="chain">
+        <div class="chain-label">Drill-down</div>
+        <div class="chain-foot">no deeper user-code frame - <code>{{ _drill_root_fn }}</code> calls framework code directly. Check the N+1 Query or related findings for inner-loop details.</div>
       </div>
       {% endif %}
-      {# v0.6.x: hoisted from .finding-detail — the target document + the
-         doc-event lifecycle hook breadcrumb live at the same visual level
-         as the Phase 2 / Drill-down callouts inside the smoking-gun box,
-         so all three context cues stay together. #}
+
+      {# Target document + doc-event lifecycle hook breadcrumb.
+         Stays inside the smoking block, sitting at the same visual
+         level as the chain callouts. #}
       {% if detail.target_doc or detail.hook_events %}
-      <div style="margin-top: 4px; font-size: 12px; padding-top: 4px; border-top: 1px dashed #d1d5db; color: #374151;">
+      <div class="phase2-line">
         {% if detail.target_doc %}<span class="muted">Document:</span> <strong>{{ detail.target_doc.doctype }}</strong>{% if detail.target_doc.name %} <code>{{ detail.target_doc.name }}</code>{% endif %}{% endif %}{% if detail.target_doc and detail.hook_events %} &middot; {% endif %}{% if detail.hook_events %}<span class="muted">Doc-event hook:</span> {% for he in detail.hook_events %}<code>{{ he.doctype }} &#9656; {{ he.event }}</code>{% if not loop.last %}, {% endif %}{% endfor %}{% endif %}
       </div>
       {% endif %}
@@ -781,11 +1658,11 @@
     {% endif %}
 
     {# v0.7.x: keep this OR list in sync with the inner {% if %} branches
-       below — it's a conservative early exit so the styled ``.finding-detail``
+       below - it's a conservative early exit so the styled ``.finding-detail``
        container (white background + border + padding) doesn't render as an
        empty box for finding types whose technical_detail carries no rows
        that this block displays (Slow Hot Path / Hook Bottleneck / Hot Line
-       / Function Not Invoked — their meaningful content lives in the
+       / Function Not Invoked - their meaningful content lives in the
        smoking-gun block above, not here). #}
     {% set _has_detail_rows = (
          detail.normalized_query
@@ -856,7 +1733,7 @@
 
       {# v0.5.3: projected post-fix timing. Analyzers (explain_flags
          + n_plus_one) set projected_avg_time_ms / projected_total_ms
-         when there's a credible estimate — see base.project_post_fix_ms
+         when there's a credible estimate - see base.project_post_fix_ms
          for the per-finding-type heuristics. #}
       {% if detail.projected_avg_time_ms is defined and detail.projected_avg_time_ms %}
         <p class="small projected-after-fix">
@@ -869,54 +1746,55 @@
     </div>
     {% endif %}
 
-    {# v0.6.0: AI-suggested fix. Populated on demand via the "Suggest a
-       fix (AI)" action on the Optimus Session form, then carried into
-       the report on the next regenerate. suggestion_html is already
-       Markdown-rendered + bleach-sanitized by renderer._finding_to_dict,
-       so |safe is valid here (and there are no external assets in it, so
-       the offline-report guarantee holds). #}
+    {# v0.6.0: AI-suggested fix. v0.7.x Phase D: restyled as `.fix-box`
+       (editorial card with `.fix-head` + `AI · model` tag, `.fix-body`
+       with the existing markdown-rendered HTML, `.fix-foot` with the
+       review-disclaimer). suggestion_html is already Markdown-rendered
+       + bleach-sanitized; |safe is valid. #}
     {% if f.llm_fix and f.llm_fix.suggestion_html and not hide_ai_fix %}
-    <div class="ai-fix">
-      <div class="ai-fix-header">Suggested fix (AI{% if f.llm_fix.model %} &mdash; {{ f.llm_fix.model }}{% endif %})</div>
+    <div class="fix-box">
+      <div class="fix-head">
+        <span>Suggested fix</span>
+        <span class="ai-tag">AI{% if f.llm_fix.model %} &middot; {{ f.llm_fix.model }}{% endif %}</span>
+      </div>
       {% if not f.llm_fix.source_available %}
-      <div class="ai-fix-caution">The profiler couldn&rsquo;t show the AI this finding&rsquo;s source code (or SQL) &mdash; treat the suggestion below as directional guidance, not a verified code fix.</div>
+      <div class="fix-caution">The profiler couldn&rsquo;t show the AI this finding&rsquo;s source code (or SQL) - treat the suggestion below as directional guidance, not a verified code fix.</div>
       {% endif %}
-      <div class="ai-fix-body">{{ f.llm_fix.suggestion_html | safe }}</div>
-      <div class="ai-fix-foot">Machine-generated{% if f.llm_fix.generated_at %} &middot; {{ fmt_dt(f.llm_fix.generated_at) }}{% endif %} &mdash; review before applying.</div>
+      <div class="fix-body">{{ f.llm_fix.suggestion_html | safe }}</div>
+      <div class="fix-foot">Machine-generated{% if f.llm_fix.generated_at %} &middot; {{ fmt_dt(f.llm_fix.generated_at) }}{% endif %} - review before applying.</div>
     </div>
     {% endif %}
 
-    {# v0.7.x: related findings grouped by root cause. When several
-       analyzers flag the same deepest user-code anchor — e.g. a Hot
-       Line, a Redundant doc fetch, and a Redundant permission check
-       all landing on the same get_doc-in-a-loop site — they collapse
-       into THIS card and appear as small collapsible rows beneath the
-       primary card's AI fix block. One fix at the top resolves all
-       of them; the sub-rows preserve the per-angle context for
-       readers who want to verify each. #}
+    {# v0.7.x: related findings grouped by root cause. v0.7.x Phase D:
+       restyled as `.sub-findings` with a left-rule indent and
+       `.severity-pill`-based rows. Each row uses a collapsible
+       disclosure element so readers can expand the description per
+       finding. #}
     {% if f.sub_findings %}
-    <div class="grouped-findings" style="margin: 10px 0 0 12px; border-left: 2px solid #e5e7eb; padding: 0 0 0 10px;">
-      <div class="small muted" style="margin-bottom: 6px;">
-        Related on the same root cause &mdash; {{ f.sub_findings | length }} other finding{{ "s" if f.sub_findings | length != 1 else "" }}, one fix resolves all of them.
-      </div>
+    <div class="sub-findings">
+      <p class="sub-findings-label">
+        Related on the same root cause - {{ f.sub_findings | length }} other finding{{ "s" if f.sub_findings | length != 1 else "" }}; one fix resolves all of them.
+      </p>
       {% for s in f.sub_findings %}
-      <details style="margin: 4px 0; padding: 6px 10px; background: #f9fafb; border-left: 3px solid #d1d5db; border-radius: 0 4px 4px 0;">
-        <summary style="cursor: pointer; display: flex; gap: 8px; align-items: center;">
-          <span class="severity-badge {{ s.severity | lower }}">{{ s.severity }}</span>
-          <span style="flex: 1; font-weight: 500; font-size: 0.92rem;">{{ s.title }}</span>
-          {% if s.estimated_impact_ms %}<span class="small muted">~{{ fmt_ms(s.estimated_impact_ms) }}{% if s.affected_count %} &middot; {{ s.affected_count }}{% endif %}</span>{% endif %}
+      <details class="sub-finding-row">
+        <summary>
+          <span class="severity-pill {{ s.severity | lower }}">{{ s.severity }}</span>
+          <span class="sub-title">{{ s.title }}</span>
+          {% if s.estimated_impact_ms %}<span class="sub-impact">~{{ fmt_ms(s.estimated_impact_ms) }}{% if s.affected_count %} &middot; {{ s.affected_count }}{% endif %}</span>{% endif %}
         </summary>
         {% if s.customer_description %}
-        <div class="small" style="margin-top: 6px; color: #374151; white-space: pre-wrap;">{{ s.customer_description }}</div>
+        <div class="sub-desc">{{ s.customer_description }}</div>
         {% endif %}
       </details>
       {% endfor %}
     </div>
     {% endif %}
-  </div>
+
+    </div>{# /.finding-body #}
+  </div>{# /.finding #}
 {% endmacro %}
 
-{# v0.5.2: per-app bucket header — "myapp (3 findings, ~420ms)". #}
+{# v0.5.2: per-app bucket header - "myapp (3 findings, ~420ms)". #}
 {% macro app_bucket_header(bucket) %}
   <span class="app-bucket-name">{{ bucket.app }}</span>
   <span class="app-bucket-meta small muted">
@@ -927,8 +1805,8 @@
   </span>
 {% endmacro %}
 
-{# v0.6.x: entry-point source-location block — shown under each row in the
-   per-action breakdown and the Background Jobs section. ``cs`` is renderer's
+{# v0.6.x: entry-point source-location block - shown under each row in the
+   per-action breakdown and the RQ Jobs section. ``cs`` is renderer's
    _action_entry_callsite() output: {filename (bench-relative display path),
    _abs (absolute path, for the editor link), lineno, function, source_snippet}.
    Mirrors the finding_card smoking-gun visual (mono table, line-number gutter,
@@ -945,11 +1823,16 @@
     </div>
     {% if cs.source_snippet %}
       <table style="border-collapse: collapse; font-family: ui-monospace, Menlo, monospace; font-size: 12px; width: 100%; margin: 0;">
+        {# Drop blank context lines (PEP-8 spacers above/below a def). The
+           target line is always rendered even if empty, so the highlight
+           anchor never disappears. #}
         {% for sl in cs.source_snippet %}
+        {% if (sl.content | trim) or sl.lineno == cs.lineno %}
         <tr{% if sl.lineno == cs.lineno %} style="background: #fef3c7;"{% endif %}>
           <td style="padding: 1px 8px; color: #6b7280; text-align: right; user-select: none; width: 1%; white-space: nowrap;">{{ sl.lineno }}</td>
-          <td style="padding: 1px 8px;"><code style="white-space: pre;">{{ sl.content }}</code></td>
+          <td style="padding: 1px 8px;"><code style="white-space: pre;">{% if sl.content_html %}{{ sl.content_html | safe }}{% else %}{{ sl.content }}{% endif %}</code></td>
         </tr>
+        {% endif %}
         {% endfor %}
       </table>
     {% endif %}
@@ -958,57 +1841,60 @@
 {% endmacro %}
 
 {# v0.6.x: per-row macros for the 4 leaderboard sections (per-action, top
-   queries, background jobs, hot frames). Each section renders custom-app
+   queries, RQ Jobs, hot frames). Each section renders custom-app
    rows in its primary table and framework-app rows in a collapsed
    "subsection" details sub-block below; both call the same macro so the
    row markup lives in one place. #}
-{% macro action_row(action, idx) %}
+{% macro action_row(action, idx, max_ms=1.0, large_duration_threshold_ms=1000) %}
+  {# v0.7.x redesign Phase E: editorial per-action row.
+
+     - Action cell: `.action-name` (bold mono) + `.action-meta` (HTTP
+       method + path + target doc + entry-callsite, mono muted).
+     - Type cell: `.type-tag` pill (blue HTTP / amber Background).
+     - Duration cell: `.bar-cell` with the value + inline bar; bar
+       colour by threshold (red ≥ threshold, amber 300+, green otherwise).
+     - Linked-finding sub-row uses `.row-finding` summary above the
+       embedded finding_card cluster. #}
   <tr>
-    <td>{{ idx }}</td>
+    <td class="num">{{ idx }}</td>
     <td>
-      <strong>{{ action.action_label }}</strong>
+      <div class="action-name">{{ action.action_label }}</div>
       {% if action.path %}
-        <br><span class="small muted">{{ action.http_method }} {{ action.path }}</span>
+        <div class="action-meta">{{ action.http_method }} {{ action.path }}</div>
       {% endif %}
       {% if action.target_doc %}
-        <br><span class="small muted">&rarr; {{ action.target_doc.doctype }}{% if action.target_doc.name %} <code>{{ action.target_doc.name }}</code>{% endif %}</span>
+        <div class="action-meta">&rarr; {{ action.target_doc.doctype }}{% if action.target_doc.name %} <code>{{ action.target_doc.name }}</code>{% endif %}</div>
       {% endif %}
-      {# v0.7.x: inline entry-callsite line — the bench-relative file path
-         + lineno + function. Replaces the (already-dropped) full source
-         snippet panel. Compact, navigable, vscode-clickable. #}
       {% if action.entry_callsite and action.entry_callsite.filename %}
         {% set _cs = action.entry_callsite %}
-        <br>
-        <span class="small muted">
-          {% if _cs._abs %}
-            <a class="callsite-link" href="vscode://file{{ _cs._abs }}:{{ _cs.lineno }}" title="Open in VS Code / Cursor"><code>{{ _cs.filename }}:{{ _cs.lineno }}</code></a>
-          {% else %}
-            <code>{{ _cs.filename }}:{{ _cs.lineno }}</code>
-          {% endif %}
-          {% if _cs.function %} <span class="muted">({{ _cs.function }})</span>{% endif %}
-        </span>
+        <div class="action-meta">
+          {% if _cs._abs %}<a href="vscode://file{{ _cs._abs }}:{{ _cs.lineno }}" title="Open in VS Code / Cursor">{{ _cs.filename }}:{{ _cs.lineno }}</a>{% else %}{{ _cs.filename }}:{{ _cs.lineno }}{% endif %}{% if _cs.function %} &middot; {{ _cs.function }}{% endif %}
+        </div>
       {% endif %}
     </td>
-    <td><span class="small">{{ action.event_type }}</span></td>
-    <td class="num">{{ fmt_ms(action.duration_ms) }}</td>
+    <td><span class="type-tag{% if action.event_type == 'RQ Job' %} bg{% endif %}">{{ action.event_type }}</span></td>
+    {% set _ms = action.duration_ms or 0 %}
+    {% set _pct = (_ms / max_ms * 100) if max_ms else 0 %}
+    <td class="num bar-cell">
+      <span{% if _ms >= large_duration_threshold_ms %} class="hot-value"{% endif %}>{{ fmt_ms(_ms) }}</span>
+      <div class="bar-track">
+        <div class="bar-fill{% if _ms >= large_duration_threshold_ms %}{% elif _ms >= 300 %} warn{% else %} ok{% endif %}" style="width: {{ _pct | round(1) }}%;"></div>
+      </div>
+    </td>
     <td class="num">{{ action.queries_count }}</td>
     <td class="num">{{ fmt_ms(action.query_time_ms) }}</td>
     <td class="num">{{ fmt_ms(action.slowest_query_ms) }}</td>
   </tr>
-  {# v0.7.x: when this action has linked findings (action_ref matches
-     its idx), embed the finding cards inline — same structure as the
-     Findings section, scoped to this action. The AI fix block is
-     suppressed here (it's noise in the per-action surface and lives
-     in the canonical Findings section anyway). Actions without
-     findings render no sub-row — the previous entry-callsite
-     fallback was dropped because the ``def function_name``
-     snippet wasn't actionable. #}
   {% if action.related_findings %}
   <tr>
-    <td colspan="7" style="background:#f9fafb;border-top:none;padding:8px 12px 12px 28px;">
-      <div style="margin: 0 0 8px; font-size: 12px; color: #6b7280;">
-        {{ action.related_findings | length }} finding{{ "s" if action.related_findings | length != 1 else "" }} linked to this action
-      </div>
+    <td colspan="7" class="row-finding">
+      &#9888; <strong>{{ action.related_findings | length }} finding{{ "s" if action.related_findings | length != 1 else "" }} linked:</strong>
+      {{ action.related_findings[0].title }}{% if action.related_findings[0].estimated_impact_ms %} &middot; ~{{ fmt_ms(action.related_findings[0].estimated_impact_ms) }}{% endif %}
+      {% if action.related_findings | length > 1 %} &middot; <em>+ {{ action.related_findings | length - 1 }} more</em>{% endif %}
+    </td>
+  </tr>
+  <tr>
+    <td colspan="7" style="background: var(--bg-tint); border-top: none; padding: 8px 16px 14px;">
       {% for f in action.related_findings %}
         {{ finding_card(f, hide_ai_fix=True, hide_source_snippet=True) }}
       {% endfor %}
@@ -1017,42 +1903,45 @@
   {% endif %}
 {% endmacro %}
 
-{% macro bg_job_row(job, idx, cols, any_findings_counted) %}
+{% macro bg_job_row(job, idx, cols, any_findings_counted, max_ms=1.0, large_duration_threshold_ms=1000) %}
+  {# v0.7.x redesign Phase E: mirror of action_row for background
+     jobs - `.action-name` for the dotted method, `.bar-cell` for the
+     duration, `.type-tag.bg` would be redundant (every row in this
+     table IS a RQ Job), so the type pill is omitted here. #}
   <tr>
-    <td>{{ idx }}</td>
+    <td class="num">{{ idx }}</td>
     <td>
-      <code>{{ job.method }}</code>
-      {# v0.7.x: inline entry-callsite line under the job method — same
-         compact treatment as the per-action row. #}
+      <div class="action-name">{{ job.method }}</div>
       {% if job.entry_callsite and job.entry_callsite.filename %}
         {% set _cs = job.entry_callsite %}
-        <br>
-        <span class="small muted">
-          {% if _cs._abs %}
-            <a class="callsite-link" href="vscode://file{{ _cs._abs }}:{{ _cs.lineno }}" title="Open in VS Code / Cursor"><code>{{ _cs.filename }}:{{ _cs.lineno }}</code></a>
-          {% else %}
-            <code>{{ _cs.filename }}:{{ _cs.lineno }}</code>
-          {% endif %}
-          {% if _cs.function %} <span class="muted">({{ _cs.function }})</span>{% endif %}
-        </span>
+        <div class="action-meta">
+          {% if _cs._abs %}<a href="vscode://file{{ _cs._abs }}:{{ _cs.lineno }}" title="Open in VS Code / Cursor">{{ _cs.filename }}:{{ _cs.lineno }}</a>{% else %}{{ _cs.filename }}:{{ _cs.lineno }}{% endif %}{% if _cs.function %} &middot; {{ _cs.function }}{% endif %}
+        </div>
       {% endif %}
     </td>
-    <td class="num">{{ fmt_ms(job.duration_ms) }}</td>
+    {% set _ms = job.duration_ms or 0 %}
+    {% set _pct = (_ms / max_ms * 100) if max_ms else 0 %}
+    <td class="num bar-cell">
+      <span{% if _ms >= large_duration_threshold_ms %} class="hot-value"{% endif %}>{{ fmt_ms(_ms) }}</span>
+      <div class="bar-track">
+        <div class="bar-fill{% if _ms >= large_duration_threshold_ms %}{% elif _ms >= 300 %} warn{% else %} ok{% endif %}" style="width: {{ _pct | round(1) }}%;"></div>
+      </div>
+    </td>
     <td class="num">{{ job.queries_count }}</td>
     <td class="num">{{ fmt_ms(job.query_time_ms) }}</td>
     <td class="num">{{ fmt_ms(job.slowest_query_ms) }}</td>
     {% if any_findings_counted %}
-      <td class="num">{{ job.findings_count if job.findings_count is not none else '&mdash;' | safe }}</td>
+      <td class="num">{{ job.findings_count if job.findings_count is not none else '-' | safe }}</td>
     {% endif %}
   </tr>
   <tr>
     <td colspan="{{ cols }}" style="background:#f9fafb;border-top:none;padding:4px 12px 10px 28px;">
-      {# v0.7.x: mirror the action_row trim — drop the entry-callsite
+      {# v0.7.x: mirror the action_row trim - drop the entry-callsite
          snippet (the bare ``def function_name`` line was noise) and
          embed finding cards in its place when this job has linked
          findings. AI fix is suppressed here (it lives in the
          canonical Findings section). The "Slowest queries for this
-         job" details block stays — it's job-specific. #}
+         job" details block stays - it's job-specific. #}
       {% if job.related_findings %}
       <div class="small muted" style="margin: 0 0 8px;">
         {{ job.related_findings | length }} finding{{ "s" if job.related_findings | length != 1 else "" }} linked to this job
@@ -1074,7 +1963,7 @@
             </div>
           {% endfor %}
         {% elif not job.recording_available %}
-          <p class="small muted">The recording for this job has expired from Redis (kept ~10&nbsp;min after analyze) &mdash; expand the matching action in <strong>Full recordings</strong> below if it's still listed.</p>
+          <p class="small muted">The recording for this job has expired from Redis (kept ~10&nbsp;min after analyze) - expand the matching action in <strong>Full recordings</strong> below if it's still listed.</p>
         {% else %}
           <p class="empty">No queries were recorded for this job.</p>
         {% endif %}
@@ -1084,8 +1973,13 @@
 {% endmacro %}
 
 {% macro hot_frame_row(row) %}
-  <tr>
-    <td><code>{{ row.display_name }}</code></td>
+  {# v0.7.x Phase E: user-code rows get `is-hot` class so the
+     `.hot-frames-table tr.is-hot td` CSS rule applies the
+     yellow-tinted background. The flag is precomputed by
+     renderer.build_hot_frames_table; defensive .get() in case the
+     dict was hand-built by an older test fixture. #}
+  <tr{% if row.is_hot %} class="is-hot"{% endif %}>
+    <td class="fn-cell"><code>{{ row.display_name }}</code></td>
     <td class="num">{{ fmt_ms(row.total_ms) }}</td>
     <td class="num">{{ row.occurrences }}</td>
     <td class="num">{{ row.distinct_actions }}</td>
@@ -1103,59 +1997,42 @@
 
 <div class="container">
 
-  {# --------------- HEADER --------------- #}
-  <div class="report-header">
-    <h1>
-      {{ session.title or "Optimus Session" }}
-    </h1>
-    <div class="meta">
-      <table class="meta-table">
-        <tbody>
-          <tr><td>Recorded by</td><td><strong>{{ session.user }}</strong></td></tr>
-          <tr><td>Started</td><td><time datetime="{{ session.started_at }}">{{ fmt_dt(session.started_at) }}</time></td></tr>
-          {% if session.stopped_at %}<tr><td>Stopped</td><td><time datetime="{{ session.stopped_at }}">{{ fmt_dt(session.stopped_at) }}</time></td></tr>{% endif %}
-          <tr><td>Report generated</td><td>{{ fmt_dt(generated_at) }}</td></tr>
-          <tr><td>Server timezone</td><td>{{ server_tz or "UTC" }}</td></tr>
-        </tbody>
-      </table>
+  {# --------------- MASTHEAD ---------------
+     v0.7.x redesign Phase A: editorial-style header. Eyebrow + serif
+     display heading on the left, meta block right-aligned. The
+     session title can carry "<em>...</em>" wrapping a session number
+     (e.g. "Session <em>0017</em>") to surface the italic-accent
+     treatment from the mock - the controller-side title doesn't
+     currently emit that, but the markup tolerates plain text.
+     The old `report-header` / `.meta` / `meta-table` classes are
+     defined upstream in the inline CSS and are no longer used by
+     this block. #}
+  <header class="masthead">
+    <div>
+      <div class="masthead-eyebrow">Performance Report</div>
+      <h1>{{ session.title or "Optimus Session" }}</h1>
     </div>
-  </div>
+    <div class="masthead-meta">
+      <div><span class="badge">OPTIMUS</span></div>
+      <div>Recorded by <b>{{ session.user }}</b></div>
+      <div>
+        <time datetime="{{ session.started_at }}">{{ fmt_dt(session.started_at) }}</time>
+        {% if session.stopped_at %} &rarr;
+        <time datetime="{{ session.stopped_at }}">{{ fmt_dt(session.stopped_at) }}</time>
+        {% endif %}
+      </div>
+      <div>Generated {{ fmt_dt(generated_at) }} &middot; {{ server_tz or "UTC" }}</div>
+    </div>
+  </header>
 
-  {# v0.7.x: companion-tool callout. Sibling of the Jump-to nav below;
-     mirrors its .section.small styling so it belongs in the same
-     visual family. 3px blue left-border + "Companion tool" prefix
-     label distinguish it as a related-product mention rather than
-     report data or another nav block. Inert anchor only — no remote
-     assets — so the self-contained-HTML guarantee is intact. #}
-  <aside class="section small lens-promo"
-         style="padding:10px 16px; border-left: 3px solid #2563eb;">
-    <span class="muted" style="font-size: 0.7rem; text-transform: uppercase; letter-spacing: 0.5px; font-weight: 600; margin-right: 8px;">Companion tool</span>
-    <strong>Aerele Lens</strong>
-    &mdash; Audit your Frappe custom apps before they break in production.
-    Static checks for performance regressions, security gaps, framework
-    mis-use, and ERPNext convention drift, plus version-compatibility
-    scans for Frappe v14&nbsp;/&nbsp;v15&nbsp;/&nbsp;v16 migrations.
-    <a href="https://lens.aerele.in/"
-       rel="noopener"
-       style="color:#2563eb; font-weight: 500; white-space: nowrap;">lens.aerele.in &rarr;</a>
-  </aside>
-
-  {# v0.6.0: compact in-page navigation. Conditional sections (Background
-     jobs / Server Resource / Frontend) link only when they'll render. #}
-  <div class="section small" style="padding:10px 16px;">
-    <strong>Jump to:</strong>
-    {% if phase2_html %}<a href="#phase2">Phase 2 line drill-down</a> · {% endif %}<a href="#findings">Findings</a> ·
-    <a href="#per-action">Per-action</a>{% if background_jobs and background_jobs.count %} · <a href="#background-jobs">Background jobs</a>{% endif %}{% if doc_event_breakdown and doc_event_breakdown.count %} · <a href="#doc-event-lifecycle">Doc events</a>{% endif %}{% if infra_timeline %} · <a href="#server-resource">Server resource</a>{% endif %}{% if frontend_xhr_matched or frontend_vitals_by_page %} · <a href="#frontend">Frontend</a>{% endif %} ·
-    <a href="#top-queries">Top queries</a> ·
-    <a href="#db-tables">DB tables</a> ·
-    <a href="#how-to-read">How to read</a>
-  </div>
-
-  {# v0.5.3: TRUNCATION BANNER — prominent at the top when analyze
+  {# v0.5.3 TRUNCATION BANNER - prominent at the top when analyze
      truncated queries beyond the per-recording cap. Previously only
      surfaced in the collapsed Analyzer Notes at the bottom, where
-     developers missed it and read incomplete reports. Deliberately
-     placed ABOVE the exec-summary card so it's impossible to miss. #}
+     developers missed it and read incomplete reports.
+     v0.7.x redesign Phase B: hoisted to sit ABOVE the TL;DR hero
+     (which replaced the exec-summary card as the most-prominent
+     block) so the warning is the literal first thing the reader
+     sees after the masthead. #}
   {% if truncation_banner %}
   <div class="truncation-banner">
     <div class="truncation-banner-title">⚠ Report is partial</div>
@@ -1163,49 +2040,112 @@
   </div>
   {% endif %}
 
-  {# v0.5.0: Steps to Reproduce / Notes. Content is pre-sanitized by
-     renderer.py via frappe.utils.html_utils.sanitize_html (bleach) so
-     harmless rich-text renders while <script>/onclick/javascript: are
-     stripped. |safe below is only valid because notes_html is already
-     bleach-cleaned — do NOT change to `session.notes | safe` without
-     re-adding sanitization, that's a stored-XSS sink. #}
-  {% if notes_html %}
+  {# v0.7.x redesign Phase B: TL;DR hero - one composed headline
+     keyed on the highest-impact finding (or a clean-session
+     message when there's nothing to fix). Replaces the older
+     "At a glance" exec-summary card. The Action plan section
+     (Phase C) is built from its own ``_build_action_plan``
+     helper - the old ``executive_summary`` data path was
+     retired in Phase H. #}
+  {# v0.7.x Phase J.2.1: reads from report_data.tldr (contract shape). #}
+  {% if report_data.tldr and report_data.tldr.headline_html %}
+  <div class="tldr">
+    <div class="tldr-label">The headline</div>
+    <p class="tldr-headline">{{ report_data.tldr.headline_html | safe }}</p>
+    <p class="tldr-sub">{{ report_data.tldr.subline_html | safe }}</p>
+  </div>
+  {% endif %}
+
+  {# v0.7.x J.14: companion-tool promotional banner. Featured-card
+     treatment with light-blue gradient background, serif product name,
+     bulleted value props, and a solid-blue CTA button. Inert anchor
+     only, no remote assets, no external CSS - the self-contained-HTML
+     guarantee stays intact. #}
+  <aside class="section lens-promo" style="
+      margin: 16px 0 24px;
+      padding: 20px 24px;
+      background: linear-gradient(135deg, #f0f9ff 0%, #e0f2fe 100%);
+      border: 1px solid #bfdbfe;
+      border-left: 4px solid #2563eb;
+      border-radius: 4px;
+  ">
+    <div style="display:flex; align-items:baseline; justify-content:space-between; flex-wrap:wrap; gap:8px; margin-bottom:10px;">
+      <div style="display:flex; align-items:center; gap:12px;">
+        <span style="font-family: var(--serif, Georgia, serif); font-size:1.45rem; font-weight:600; color:#1e3a8a; letter-spacing:-0.01em;">Aerele Lens</span>
+        <span style="font-size:0.65rem; text-transform:uppercase; letter-spacing:0.14em; font-weight:700; color:#1e40af; padding:3px 8px; background:#dbeafe; border-radius:3px;">Companion tool</span>
+      </div>
+      <span style="font-size:0.78rem; color:#475569; font-family:var(--mono, monospace);">lens.aerele.in</span>
+    </div>
+    <p style="margin:0 0 12px; font-size:1rem; color:#0f172a; line-height:1.5;">
+      Audit your Frappe custom apps <strong>before they break in production</strong>.
+    </p>
+    <ul style="margin:0 0 14px; padding-left:20px; color:#1f2937; font-size:0.88rem; line-height:1.7;">
+      <li>Static checks for <strong>performance regressions</strong>, <strong>security gaps</strong>, and framework mis-use.</li>
+      <li><strong>ERPNext convention drift</strong> detection.</li>
+      <li><strong>Version-compatibility scans</strong> for Frappe v14&nbsp;/&nbsp;v15&nbsp;/&nbsp;v16 migrations.</li>
+    </ul>
+    <a href="https://lens.aerele.in/" rel="noopener"
+       style="display:inline-block; padding:9px 18px; background:#2563eb; color:#ffffff !important; text-decoration:none; font-weight:600; font-size:0.88rem; border-radius:4px; letter-spacing:0.02em;">
+      Try Aerele Lens &rarr;
+    </a>
+  </aside>
+
+  {# v0.6.0: compact in-page navigation. Conditional sections (Background
+     jobs / Server Resource / Frontend) link only when they'll render.
+     v0.7.x Phase A: restyled as nav pills (editorial design tokens).
+     Anchors unchanged so external links / docs still resolve. The
+     "Jump to:" prefix is retained as a visually-quiet label so screen
+     readers still get the navigational cue. #}
+  <nav class="nav-pills">
+    <span class="jump-label">Jump to</span>
+    {% if report_data.line_drilldown_html %}<a href="#line-drilldown">Line-Level Drilldown</a>{% endif %}
+    <a href="#findings">Findings</a>
+    <a href="#per-action">Per-action</a>
+    {% if report_data.background_jobs or report_data.background_jobs_framework %}<a href="#background-jobs">RQ Jobs</a>{% endif %}
+    {% if report_data.doc_events %}<a href="#doc-event-lifecycle">Doc events</a>{% endif %}
+    {% if report_data.resource %}<a href="#server-resource">Server resource</a>{% endif %}
+    {% if report_data.frontend %}<a href="#frontend">Frontend</a>{% endif %}
+    <a href="#top-queries">Top queries</a>
+    <a href="#db-tables">DB tables</a>
+    <a href="#how-to-read">How to read</a>
+  </nav>
+
+  {# v0.7.x Phase J.2.1: Steps to Reproduce / Notes reads from
+     report_data.repro (contract shape). The raw_html source is the
+     sanitized notes_html produced by renderer.render via
+     frappe.utils.html_utils.sanitize_html (bleach) with always_sanitize=True.
+     |safe below is only valid because that upstream sanitization fires
+     regardless of input shape - do NOT migrate this block to read
+     session.notes directly through |safe, that's a stored-XSS sink. #}
+  {% if report_data.repro and report_data.repro.raw_html %}
   <details class="section" open style="background: #f0f9ff; border-left: 4px solid #2563eb;">
+    <a id="repro"></a>{# v0.7.x Phase I.1: mock-spec ID anchor #}
     <summary><h2 style="margin-top: 0;">Steps to Reproduce</h2></summary>
     <div class="notes-content">
-      {{ notes_html | safe }}
+      {{ report_data.repro.raw_html | safe }}
     </div>
   </details>
   {% endif %}
 
-  {# --------------- STAT CARDS --------------- #}
-  {% set total_findings = (all_findings | length) if all_findings is defined else (findings | length) %}
-  <div class="stats">
-    <div class="stat">
-      <div class="label">Total time</div>
-      <div class="value">{{ fmt_ms(session.total_duration_ms or 0) }}</div>
-      <div class="sub">{{ fmt_ms((session.total_duration_ms or 0) - (session.total_query_time_ms or 0)) }} server code &middot; {{ fmt_ms(session.total_query_time_ms or 0) }} database</div>
+  {# --------------- KPI STRIP ---------------
+     v0.7.x redesign Phase A: 4 numbers across a top-and-bottom-ruled
+     strip; the design-token colours flag the at-risk values (total
+     time over the configured threshold, any high-severity findings)
+     via `.kpi-value.danger`. The old `.stats` + `.stat` markup
+     pre-dates the variable system and is no longer referenced. #}
+  {# v0.7.x Phase J.2.2: iterate the contract's 4-item kpis list.
+     Labels, values, and sub-lines are all composed in build_report_context. #}
+  <div class="kpis">
+    {% for k in report_data.kpis %}
+    <div class="kpi">
+      <div class="kpi-label">{{ k.label }}</div>
+      <div class="kpi-value{% if k.is_danger %} danger{% endif %}">{{ k.value }}</div>
+      <div class="kpi-sub">{{ k.sub }}</div>
     </div>
-    <div class="stat">
-      <div class="label">Database queries</div>
-      <div class="value">{{ session.total_queries or 0 }}</div>
-      <div class="sub">across {{ session.total_requests or 0 }} operation{{ "s" if (session.total_requests or 0) != 1 else "" }}</div>
-    </div>
-    <div class="stat">
-      <div class="label">Operations</div>
-      <div class="value">{{ session.total_requests or 0 }}</div>
-      <div class="sub">page loads, saves &amp; background jobs</div>
-    </div>
-    <div class="stat">
-      <div class="label">Issues found</div>
-      <div class="value">{% if severity_counts.High %}<span style="color:#dc2626">{{ total_findings }}</span>{% else %}{{ total_findings }}{% endif %}</div>
-      <div class="sub">
-        {% if total_findings %}{% if severity_counts.High %}{{ severity_counts.High }} high{% endif %}{% if severity_counts.Medium %}{% if severity_counts.High %} &middot; {% endif %}{{ severity_counts.Medium }} medium{% endif %}{% if severity_counts.Low %}{% if severity_counts.High or severity_counts.Medium %} &middot; {% endif %}{{ severity_counts.Low }} low{% endif %}{% else %}none detected{% endif %}
-      </div>
-    </div>
+    {% endfor %}
   </div>
 
-  {# v0.6.x: Ignored Apps note — surfaces the count of findings the renderer
+  {# v0.6.x: Ignored Apps note - surfaces the count of findings the renderer
      dropped because their blame app is in Optimus Settings ▸ Apps ▸ Ignored
      Apps. Keeps the stat card's count honest (severity_counts shows the kept
      set). Hidden when nothing was dropped. #}
@@ -1218,35 +2158,12 @@
     </p>
   {% endif %}
 
-  {# v0.5.2 round 3: EXECUTIVE SUMMARY — TL;DR readable in 30 seconds.
-     v0.7.x: relocated from above Steps-to-Reproduce to below the stat
-     cards, so the reader gets context (steps) and numbers (cards)
-     first, then the "what's wrong + what to fix" narrative. #}
-  {% if executive_summary.show %}
-  <div class="exec-summary pace-{{ executive_summary.pace }}">
-    <h2>At a glance</h2>
-    <p class="exec-headline">{{ executive_summary.headline }}</p>
-
-    {% if executive_summary.bullets %}
-    <div class="exec-bullets">
-      <p class="small muted">Top {{ executive_summary.bullets | length }} highest-impact finding{{ "s" if executive_summary.bullets | length != 1 else "" }}{% if executive_summary.total_impact_ms %} ({{ fmt_ms(executive_summary.total_impact_ms) }} combined){% endif %}:</p>
-      <ol>
-        {% for b in executive_summary.bullets %}
-        <li>
-          <span class="exec-bullet-severity severity-{{ b.severity | lower }}">{{ b.severity }}</span>
-          <span class="exec-bullet-text">{{ b.text }}</span>
-          {% if b.impact_ms %}<span class="exec-bullet-impact">~{{ fmt_ms(b.impact_ms) }}</span>{% endif %}
-        </li>
-        {% endfor %}
-      </ol>
-    </div>
-    {% endif %}
-
-    {% if executive_summary.infra_note %}
-    <p class="exec-infra"><strong>Infra:</strong> {{ executive_summary.infra_note }}</p>
-    {% endif %}
-  </div>
-  {% endif %}
+  {# v0.7.x redesign Phase B: the "At a glance" exec-summary card
+     was removed here. Its headline collapsed into the TL;DR hero
+     at the top of the report; its top-3 list re-surfaces as the
+     Recommended Action Plan section (Phase C, via
+     ``_build_action_plan``). Phase H retired the old
+     ``executive_summary`` data path entirely. #}
 
   {# --------------- SUMMARY ---------------
      v0.7.x: prefer the render-time-built ``summary_html`` context
@@ -1257,9 +2174,14 @@
      to the stored value only if the render-time build somehow returns
      empty. #}
   <details class="section">
+    <a id="summary"></a>{# v0.7.x Phase I.1: mock-spec ID anchor #}
     <summary><h2>Summary</h2></summary>
-    {% if summary_html %}
-      {{ summary_html | safe }}
+    {# v0.7.x Phase J.2.1: reads report_data.summary.paragraphs_html (a list
+       of HTML paragraphs per the contract). Adapter currently wraps the
+       single render-time summary block as a one-element list, so this
+       loop emits one chunk - the legacy behaviour. #}
+    {% if report_data.summary and report_data.summary.paragraphs_html %}
+      {% for p in report_data.summary.paragraphs_html %}{{ p | safe }}{% endfor %}
     {% elif session.summary_html %}
       {{ session.summary_html | safe }}
     {% else %}
@@ -1267,35 +2189,60 @@
     {% endif %}
   </details>
 
-  {# v0.6.x: hoisted above Findings — the line-level drill-down is the
+  {# v0.6.x: hoisted above Findings - the line-level drill-down is the
      report's most distinctive section, so it lands first after the
      Summary narrative. The panel is pre-rendered by
-     _render_phase2_panel(session_doc) in renderer.py and returns "" when
-     the session has no phase-2 runs, so the section silently disappears
-     for sessions that never had drill-down. The HTML is fully self-
-     contained (inline styles, no external assets) so the safe-report
-     self-containment canary still passes. The <div id="phase2"> wrapper
-     is purely for the in-page jump-nav anchor. #}
-  {% if phase2_html %}
-  <div id="phase2">
-    {{ phase2_html | safe }}
-  </div>
+     _render_line_drilldown_panel(session_doc) in renderer.py and
+     returns "" when the session has no phase-2 runs, so the section
+     silently disappears for sessions that never had drill-down. The
+     HTML is fully self-contained (inline styles, no external assets)
+     so the safe-report self-containment canary still passes.
+     v0.7.x Phase I.1: the imperative-rendered HTML now opens with
+     a ``details`` element carrying the section anchor itself
+     (Phase F), so the legacy wrapper was redundant and was removed
+     to keep the anchor unique in the document. v0.7.x Phase J.16
+     renamed the anchor to ``id="line-drilldown"``; a legacy phase2
+     anchor element precedes the panel below so external links from
+     before the rename still resolve. #}
+  {# v0.7.x Phase J.16: the Line-Level Drilldown panel is still
+     pre-rendered server-side; the structured ``report_data.line_drilldown_runs``
+     list is available for a future template-side rewrite, but the
+     cross-run diff feature lives in Python for now. A legacy
+     ``id="phase2"`` anchor precedes the inner ``id="line-drilldown"``
+     element so external links from before the J.16 rename still
+     resolve in-page. #}
+  {% if report_data.line_drilldown_html %}
+  <a id="phase2"></a>
+  {{ report_data.line_drilldown_html | safe }}
+  {% endif %}
+
+  {# Phase K.5: call-tree panel for the slowest action. Empty string
+     when no action carries a call_tree_json; the renderer-side guard
+     hides the section. #}
+  {% if call_tree_html %}
+  {{ call_tree_html | safe }}
   {% endif %}
 
   {# --------------- FINDINGS (v0.5.2: per-app sub-grouping) --------------- #}
   <details class="section" open id="findings">
-    <summary><h2>Findings &mdash; what to fix</h2></summary>
-    {% if findings_by_app %}
+    <summary><h2>Findings - what to fix</h2></summary>
+    {# v0.7.x Phase J.2.7: Findings reads from report_data.findings_by_app
+       (passthrough of the legacy app-bucketed list). The contract's
+       transformed ``report_data.findings`` is available for a future
+       finding_card macro rewrite but isn't consumed yet - the macro
+       reads legacy field names (severity="High", technical_detail dict,
+       etc.) and the bucketing logic stays in renderer.py. #}
+    {% if report_data.findings_by_app %}
       <p class="small muted">Sorted by severity, then by impact. Grouped by app so you can focus on your custom code without scanning through framework noise.</p>
 
-      {% if findings_by_app | length == 1 %}
+      {% if report_data.findings_by_app | length == 1 %}
         {# Single app → skip the wrapper, render flat to avoid a
            pointless "myapp (N findings)" that wraps the whole list. #}
-        {% for f in findings_by_app[0].findings %}
+        {% for f in report_data.findings_by_app[0].findings %}
           {{ finding_card(f, "How to fix") }}
         {% endfor %}
       {% else %}
-        {% for bucket in findings_by_app %}
+        {% for bucket in report_data.findings_by_app %}
         <details class="subsection" open>
           <summary><h3>{{ app_bucket_header(bucket) }}</h3></summary>
           {% for f in bucket.findings %}
@@ -1314,21 +2261,21 @@
        erpnext + werkzeug doesn't read as one giant blob. User's
        rationale: "the framework and other 1 party app's scripts can
        be easily avoided and focus on their custom app". #}
-    {% if observational_findings_by_app %}
+    {% if report_data.observational_findings_by_app %}
     <details class="subsection">
       <summary><h3>Framework-level observations (not user-actionable)</h3></summary>
       <p class="small muted">
-        Informational signals without a concrete fix in your application code —
+        Informational signals without a concrete fix in your application code -
         framework-level activity, infrastructure pressure, and hot-frame
         observations. Listed for transparency; investigate if something here surprises you.
       </p>
 
-      {% if observational_findings_by_app | length == 1 %}
-        {% for f in observational_findings_by_app[0].findings %}
+      {% if report_data.observational_findings_by_app | length == 1 %}
+        {% for f in report_data.observational_findings_by_app[0].findings %}
           {{ finding_card(f, "Context") }}
         {% endfor %}
       {% else %}
-        {% for bucket in observational_findings_by_app %}
+        {% for bucket in report_data.observational_findings_by_app %}
         <details class="subsection">
           <summary><h3>{{ app_bucket_header(bucket) }}</h3></summary>
           {% for f in bucket.findings %}
@@ -1341,13 +2288,87 @@
     {% endif %}
   </details>
 
+  {# --------------- RECOMMENDED ACTION PLAN (v0.7.x Phase C) ---------
+     Top-3 highest-impact findings rendered as a numbered punch list
+     with verb-led titles + estimated savings. Sourced from the same
+     `_build_action_plan` data layer that supersedes the old exec-
+     summary bullets. Hidden when there's nothing to fix. #}
+  {# v0.7.x Phase J.2.2: iterate report_data.action_plan (contract shape).
+     savings_display already includes the `−` prefix; the template just
+     renders it verbatim. #}
+  {% if report_data.action_plan %}
+  <section id="plan">
+    <div class="section-head">
+      <h2>Recommended action plan</h2>
+      <span class="section-tag">top {{ report_data.action_plan | length }} by impact</span>
+    </div>
+    <div class="action-plan">
+      <h3>Fix these first</h3>
+      <p class="lead">In rough impact order - each step names a specific file and line. Estimated savings are wall-clock time, scaled per occurrence.</p>
+      {% for step in report_data.action_plan %}
+      <div class="action-step">
+        <div class="num">{{ step.number }}</div>
+        <div>
+          <p class="title">{{ step.title_html | safe }}</p>
+          <p class="desc">{{ step.description_html | safe }}</p>
+          {% if step.callsite %}<div class="callsite"><code>{{ step.callsite }}</code></div>{% endif %}
+        </div>
+        <div class="gain">
+          <span class="num-big">{{ step.savings_display }}</span>
+          <span class="gain-label">{{ step.savings_label }}</span>
+        </div>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
+  {# --------------- WATERFALL (v0.7.x Phase C) ---------------
+     Top-N actions by duration, horizontal-bar timeline scaled to the
+     displayed slice's max (so short actions stay visible). Bar
+     colour: red when the action has a High-severity linked finding,
+     amber for RQ Jobs, info-blue otherwise. #}
+  {# v0.7.x Phase J.2.2: iterate report_data.waterfall (contract shape).
+     row.kind ∈ {"hot", "bg", "normal"}; row.is_hot_text colours the time
+     text red; row.duration_display already fmt_ms-formatted in Python. #}
+  {% if report_data.waterfall %}
+  <section id="waterfall">
+    <div class="section-head">
+      <h2>Where the time went</h2>
+      <span class="section-tag">top {{ report_data.waterfall | length }} actions</span>
+    </div>
+    <p class="section-intro">Wall-clock time per action, scaled to the slowest one shown. Red = a High-severity finding ties to this action; amber = RQ Job; blue = everything else.</p>
+    <div class="waterfall">
+      {% for row in report_data.waterfall %}
+      <div class="waterfall-row">
+        <div class="waterfall-name" title="{{ row.name }}">{{ row.name }}</div>
+        <div class="waterfall-track">
+          <div class="waterfall-bar{% if row.kind == 'hot' %} hot{% elif row.kind == 'bg' %} bg{% endif %}" style="width: {{ row.width_pct }}%;"></div>
+        </div>
+        <div class="waterfall-time{% if row.is_hot_text %} hot{% endif %}">{{ row.duration_display }}</div>
+      </div>
+      {% endfor %}
+    </div>
+  </section>
+  {% endif %}
+
   {# --------------- PER-ACTION BREAKDOWN --------------- #}
   <details class="section" open id="per-action">
+    <a id="actions"></a>{# v0.7.x Phase G: mock-spec ID alias #}
     <summary><h2>Per-action breakdown</h2></summary>
-    {% if actions or actions_framework %}
+    {% if report_data.actions or report_data.actions_framework %}
       <p class="small muted">Sorted by duration. Your app's actions first; framework actions are collapsed below. Click on the action to drill into its queries.</p>
-      {% if actions %}
-      <table class="tbl-clip per-action-table">
+      {# v0.7.x Phase E: precompute the per-table max duration once
+         so the row macro can scale its inline bar correctly. Scope
+         the max to the table's own slice, not the combined set -
+         keeps the framework subsection's bars usable too. #}
+      {% set _threshold_ms = (report_data.large_duration_threshold_ms or 1000) | float %}
+      {% if report_data.actions %}
+      {# v0.7.x Phase J.2.3: iterate report_data.actions; the contract-shaped
+         entries preserve the legacy action keys so action_row reads
+         duration_ms / action_label / etc. unchanged. #}
+      {% set _max_action_ms = (report_data.actions | map(attribute='duration_ms') | map('default', 0) | list | max) or 1 %}
+      <table class="tbl-clip per-action-table data">
         <colgroup>
           <col class="col-idx">
           <col class="col-action">
@@ -1369,18 +2390,19 @@
           </tr>
         </thead>
         <tbody>
-        {% for action in actions %}
-          {{ action_row(action, loop.index) }}
+        {% for action in report_data.actions %}
+          {{ action_row(action, loop.index, max_ms=_max_action_ms, large_duration_threshold_ms=_threshold_ms) }}
         {% endfor %}
         </tbody>
       </table>
       {% else %}
-        <p class="small muted">No actions from your own app's code in this session &mdash; everything ran in framework code. Expand the block below to see what.</p>
+        <p class="small muted">No actions from your own app's code in this session - everything ran in framework code. Expand the block below to see what.</p>
       {% endif %}
-      {% if actions_framework %}
+      {% if report_data.actions_framework %}
+      {% set _max_fw_ms = (report_data.actions_framework | map(attribute='duration_ms') | map('default', 0) | list | max) or 1 %}
       <details class="subsection">
-        <summary class="small muted"><strong>{{ actions_framework | length }}</strong> framework action{{ "s" if actions_framework | length != 1 else "" }} (click to expand) &mdash; entry points in <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
-        <table class="tbl-clip per-action-table">
+        <summary class="small muted"><strong>{{ report_data.actions_framework | length }}</strong> framework action{{ "s" if report_data.actions_framework | length != 1 else "" }} (click to expand) - entry points in <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
+        <table class="tbl-clip per-action-table data">
           <colgroup>
             <col class="col-idx">
             <col class="col-action">
@@ -1402,8 +2424,8 @@
             </tr>
           </thead>
           <tbody>
-          {% for action in actions_framework %}
-            {{ action_row(action, loop.index) }}
+          {% for action in report_data.actions_framework %}
+            {{ action_row(action, loop.index, max_ms=_max_fw_ms, large_duration_threshold_ms=_threshold_ms) }}
           {% endfor %}
           </tbody>
         </table>
@@ -1415,28 +2437,41 @@
   </details>
 
   {# --------------- v0.6.0: BACKGROUND JOBS --------------- #}
-  {# The background jobs the profiled flow enqueued — captured (the profiler
+  {# The RQ Jobs the profiled flow enqueued - captured (the profiler
      waits for them to finish before analyzing) and analyzed like requests.
      They also appear in the per-action breakdown above; this is a focused
      view with each job's slowest queries. Section omitted entirely when the
      flow enqueued nothing. #}
-  {% if background_jobs and background_jobs.count %}
+  {# v0.7.x Phase J.3.1: BG-jobs section reads aggregate fields from
+     report_data.background_jobs_summary (the legacy ``background_jobs``
+     dict had ``count``/``total_ms``/``total_queries``/``any_findings_counted``/
+     ``framework_count`` alongside the jobs lists; those move to a dedicated
+     namespace so the legacy dict can be dropped). #}
+  {% if report_data.background_jobs_summary.count %}
   <details class="section" open id="background-jobs">
-    <summary><h2>Background jobs</h2></summary>
+    <a id="jobs"></a>{# v0.7.x Phase G: mock-spec ID alias #}
+    <summary><h2>RQ Jobs</h2></summary>
     <p class="small muted">
-      {{ background_jobs.count }} background job{{ 's' if background_jobs.count != 1 else '' }}
-      ran during this flow &mdash; {{ fmt_ms(background_jobs.total_ms) }} total,
-      {{ background_jobs.total_queries }} quer{{ 'ies' if background_jobs.total_queries != 1 else 'y' }}.
+      {{ report_data.background_jobs_summary.count }} RQ Job{{ 's' if report_data.background_jobs_summary.count != 1 else '' }}
+      ran during this flow - {{ fmt_ms(report_data.background_jobs_summary.total_ms) }} total,
+      {{ report_data.background_jobs_summary.total_queries }} quer{{ 'ies' if report_data.background_jobs_summary.total_queries != 1 else 'y' }}.
       These also appear in the per-action breakdown above.
     </p>
     <p class="small muted">
       Jobs are captured until they finish (up to the configured wait). If a worker
-      wasn't running, or a job ran longer than the wait, it may be missing &mdash;
+      wasn't running, or a job ran longer than the wait, it may be missing -
       click <em>Retry Analyze</em> once it's done to pick it up.
     </p>
-    {% set cols = 7 if background_jobs.any_findings_counted else 6 %}
-    {% if background_jobs.jobs %}
-    <table>
+    {% set cols = 7 if report_data.background_jobs_summary.any_findings_counted else 6 %}
+    {% set _threshold_ms = (report_data.large_duration_threshold_ms or 1000) | float %}
+    {# v0.7.x Phase J.2.3: iterate report_data.background_jobs; entries
+       preserve the legacy job keys so bg_job_row reads job.method /
+       entry_callsite / etc. unchanged. The section heading still pulls
+       the count/total summary from the old background_jobs dict - that
+       migrates with the heading block in a later sub-phase. #}
+    {% if report_data.background_jobs %}
+    {% set _max_job_ms = (report_data.background_jobs | map(attribute='duration_ms') | map('default', 0) | list | max) or 1 %}
+    <table class="data">
       <thead>
         <tr>
           <th>#</th>
@@ -1445,22 +2480,23 @@
           <th class="num">Queries</th>
           <th class="num">DB time</th>
           <th class="num">Slowest query</th>
-          {% if background_jobs.any_findings_counted %}<th class="num">Findings</th>{% endif %}
+          {% if report_data.background_jobs_summary.any_findings_counted %}<th class="num">Findings</th>{% endif %}
         </tr>
       </thead>
       <tbody>
-      {% for job in background_jobs.jobs %}
-        {{ bg_job_row(job, loop.index, cols, background_jobs.any_findings_counted) }}
+      {% for job in report_data.background_jobs %}
+        {{ bg_job_row(job, loop.index, cols, report_data.background_jobs_summary.any_findings_counted, max_ms=_max_job_ms, large_duration_threshold_ms=_threshold_ms) }}
       {% endfor %}
       </tbody>
     </table>
     {% else %}
-      <p class="small muted">No background jobs from your own app's code &mdash; all jobs ran in framework code. Expand the block below to see what.</p>
+      <p class="small muted">No RQ Jobs from your own app's code - all jobs ran in framework code. Expand the block below to see what.</p>
     {% endif %}
-    {% if background_jobs.jobs_framework %}
+    {% if report_data.background_jobs_framework %}
+    {% set _max_fw_job_ms = (report_data.background_jobs_framework | map(attribute='duration_ms') | map('default', 0) | list | max) or 1 %}
     <details class="subsection">
-      <summary class="small muted"><strong>{{ background_jobs.framework_count }}</strong> framework job{{ "s" if background_jobs.framework_count != 1 else "" }} (click to expand) &mdash; <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
-      <table>
+      <summary class="small muted"><strong>{{ report_data.background_jobs_summary.framework_count }}</strong> framework job{{ "s" if report_data.background_jobs_summary.framework_count != 1 else "" }} (click to expand) - <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
+      <table class="data">
         <thead>
           <tr>
             <th>#</th>
@@ -1469,12 +2505,12 @@
             <th class="num">Queries</th>
             <th class="num">DB time</th>
             <th class="num">Slowest query</th>
-            {% if background_jobs.any_findings_counted %}<th class="num">Findings</th>{% endif %}
+            {% if report_data.background_jobs_summary.any_findings_counted %}<th class="num">Findings</th>{% endif %}
           </tr>
         </thead>
         <tbody>
-        {% for job in background_jobs.jobs_framework %}
-          {{ bg_job_row(job, loop.index, cols, background_jobs.any_findings_counted) }}
+        {% for job in report_data.background_jobs_framework %}
+          {{ bg_job_row(job, loop.index, cols, report_data.background_jobs_summary.any_findings_counted, max_ms=_max_fw_job_ms, large_duration_threshold_ms=_threshold_ms) }}
         {% endfor %}
         </tbody>
       </table>
@@ -1489,41 +2525,47 @@
      or a controller method override, and surfacing cascaded DocTypes (e.g. a
      GL Entry created during a Sales Invoice submit). Omitted when no save/
      submit action had a slow lifecycle method. #}
-  {% if doc_event_breakdown and doc_event_breakdown.count %}
+  {# v0.7.x Phase J.2.2: iterate report_data.doc_events (contract shape).
+     The contract renames: events → methods, methods → hooks. The doctype
+     entry carries is_save_target/touched_during/method_count alongside
+     the summary string. #}
+  {% if report_data.doc_events %}
   <details class="section" id="doc-event-lifecycle">
+    <a id="doc-events"></a>{# v0.7.x Phase G: mock-spec ID alias #}
     <summary><h2>Doc-event lifecycle</h2></summary>
     <p class="small muted">
       Slow lifecycle methods (validate, on_submit, …) and registered doc-event
       hooks that ran during this session's save/submit actions, grouped by DocType
-      &mdash; including documents created by cascading hooks. Times are approximate
+      - including documents created by cascading hooks. Times are approximate
       (a method's time includes its callees).
     </p>
-    {% for g in doc_event_breakdown.doctypes %}
-    <div style="margin: 14px 0; padding: 10px 12px; border: 1px solid #e5e7eb; border-radius: 6px;">
-      <div style="font-weight: 600;">
-        {{ g.doctype }}
-        <span class="small muted" style="font-weight: 400;">
+    {% for g in report_data.doc_events %}
+    <div class="doctype-block">
+      <div class="dt-head">
+        {{ g.name }}
+        <span class="dt-meta">
           {% if g.is_save_target %}&middot; saved/submitted directly{% endif %}
           {% if g.touched_during %}&middot; touched during {{ g.touched_during | join(", ") }} save/submit{% endif %}
           &middot; {{ g.method_count }} hot method{{ "s" if g.method_count != 1 else "" }}
-          &middot; ~{{ fmt_ms(g.total_ms) }}
+          &middot; ~{{ g.total_ms_display }}
         </span>
       </div>
-      {% for ev in g.events %}
-      <div style="margin: 8px 0 0 14px;">
-        <div class="small"><strong>{{ ev.event }}</strong> <span class="muted">&mdash; ~{{ fmt_ms(ev.total_ms) }}</span></div>
-        <table style="width: 100%; border-collapse: collapse; font-size: 0.84rem; margin: 2px 0 0;">
-          {% for m in ev.methods %}
-          <tr>
-            <td style="padding: 2px 8px 2px 14px; border: none;">
-              {% if m._abs %}<a class="callsite-link" href="vscode://file{{ m._abs }}:{{ m.lineno }}" title="Open in VS Code / Cursor"><code>{{ m.function }}</code></a>{% else %}<code>{{ m.function }}</code>{% endif %}
-              <span class="small muted">{{ m.filename }}{% if m.lineno %}:{{ m.lineno }}{% endif %}</span>
-              <span class="small muted">[{{ m.kind }}]</span>
-            </td>
-            <td style="padding: 2px 8px; border: none; text-align: right; white-space: nowrap;">~{{ fmt_ms(m.ms) }}{% if m.count > 1 %} &times;{{ m.count }}{% endif %}</td>
-          </tr>
-          {% endfor %}
-        </table>
+      {% for m in g.methods %}
+      <div class="event-section">
+        <span class="event-name">{{ m.name }}</span>
+        <span class="event-time">- ~{{ m.time_display }}</span>
+        {% for h in m.hooks %}
+        <div class="method-row">
+          <div>
+            <span class="method-name">
+              {% if h.vscode_link %}<a class="callsite-link" href="vscode://file{{ h.vscode_link }}:{{ h.lineno }}" title="Open in VS Code / Cursor">{{ h.name }}</a>{% else %}{{ h.name }}{% endif %}
+            </span>
+            <span class="method-meta">{{ h.filename }}{% if h.lineno %}:{{ h.lineno }}{% endif %}</span>
+            <span class="method-tag">{{ h.kind }}</span>
+          </div>
+          <div class="method-time">~{{ h.time_display }}{% if h.count > 1 %} &times;{{ h.count }}{% endif %}</div>
+        </div>
+        {% endfor %}
       </div>
       {% endfor %}
     </div>
@@ -1531,62 +2573,68 @@
   </details>
   {% endif %}
 
-  {# --------------- v0.5.0: SERVER RESOURCE PANEL --------------- #}
-  {% if infra_timeline %}
+  {# v0.7.x Phase J.2.4: Server Resource reads from report_data.resource
+     (contract). The cards still use the existing hardcoded 4-card markup
+     so colour/sub treatments stay editorial; the raw infra_summary +
+     infra_timeline travel under .summary and .timeline (non-contract
+     extensions). #}
+  {% if report_data.resource %}
   <details class="section" id="server-resource">
+    <a id="resource"></a>{# v0.7.x Phase G: mock-spec ID alias #}
     <summary><h2>Server Resource</h2></summary>
     <p class="small muted">
       CPU, memory, load average, DB and Redis pressure, and background
       queue depth sampled at each action boundary. Use this to tell code-slow
       from server-slow.
     </p>
-    <div class="stats" style="margin-bottom: 12px;">
-      <div class="stat">
-        <div class="label">CPU avg / peak</div>
-        <div class="value">
-          {{ "%.0f" | format(infra_summary.cpu_avg or 0) }}%
-          <span class="sub" style="font-size: 1rem">/ {{ "%.0f" | format(infra_summary.cpu_peak or 0) }}%</span>
+    {% set _rs = report_data.resource.summary %}
+    <div class="resource-grid">
+      <div class="resource-card">
+        <div class="rc-label">CPU avg / peak</div>
+        <div class="rc-value">
+          {{ "%.0f" | format(_rs.cpu_avg or 0) }}<span class="rc-unit">%</span>
+        </div>
+        <div class="rc-sub">peak {{ "%.0f" | format(_rs.cpu_peak or 0) }}%</div>
+      </div>
+      <div class="resource-card">
+        <div class="rc-label">Worker RSS delta</div>
+        <div class="rc-value">
+          {{ ((_rs.rss_delta or 0) / 1000000) | round(0) | int }}<span class="rc-unit">MB</span>
         </div>
       </div>
-      <div class="stat">
-        <div class="label">Worker RSS delta</div>
-        <div class="value">
-          {{ ((infra_summary.rss_delta or 0) / 1000000) | round(0) | int }}<span class="sub" style="font-size: 1rem">MB</span>
-        </div>
+      <div class="resource-card">
+        <div class="rc-label">Load peak</div>
+        <div class="rc-value">{{ "%.2f" | format(_rs.load_peak or 0) }}</div>
       </div>
-      <div class="stat">
-        <div class="label">Load peak</div>
-        <div class="value">{{ "%.2f" | format(infra_summary.load_peak or 0) }}</div>
-      </div>
-      <div class="stat">
-        <div class="label">Swap peak</div>
-        <div class="value">
-          {{ infra_summary.swap_peak_mb or 0 }}<span class="sub" style="font-size: 1rem">MB</span>
+      <div class="resource-card">
+        <div class="rc-label">Swap peak</div>
+        <div class="rc-value">
+          {{ _rs.swap_peak_mb or 0 }}<span class="rc-unit">MB</span>
         </div>
       </div>
     </div>
-    <table style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
+    <table class="data">
       <thead>
-        <tr style="background: #f3f4f6; border-bottom: 1px solid #e5e7eb;">
-          <th style="padding: 6px 8px; text-align: left;">#</th>
-          <th style="padding: 6px 8px; text-align: left;">Action</th>
-          <th style="padding: 6px 8px; text-align: right;">CPU</th>
-          <th style="padding: 6px 8px; text-align: right;">RSS</th>
-          <th style="padding: 6px 8px; text-align: right;">Load</th>
-          <th style="padding: 6px 8px; text-align: right;">DB run/conn</th>
-          <th style="padding: 6px 8px; text-align: right;">RQ def/short/long</th>
+        <tr>
+          <th class="num">#</th>
+          <th>Action</th>
+          <th class="num">CPU</th>
+          <th class="num">RSS</th>
+          <th class="num">Load</th>
+          <th class="num">DB run/conn</th>
+          <th class="num">RQ def/short/long</th>
         </tr>
       </thead>
       <tbody>
-        {% for row in infra_timeline %}
-        <tr style="border-bottom: 1px solid #f3f4f6;">
-          <td style="padding: 4px 8px;">{{ row.action_idx }}</td>
-          <td style="padding: 4px 8px;">{{ row.action_label }}</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ "%.0f" | format(row.cpu or 0) }}%</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ ((row.rss or 0) / 1000000) | round(0) | int }}MB</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ "%.2f" | format(row.load_1min or 0) }}</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ (row.db_threads_running or 0) | int }}/{{ (row.db_threads_connected or 0) | int }}</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ (row.rq_default or 0) | int }}/{{ (row.rq_short or 0) | int }}/{{ (row.rq_long or 0) | int }}</td>
+        {% for row in report_data.resource.timeline %}
+        <tr>
+          <td class="num">{{ row.action_idx }}</td>
+          <td>{{ row.action_label }}</td>
+          <td class="num">{{ "%.0f" | format(row.cpu or 0) }}%</td>
+          <td class="num">{{ ((row.rss or 0) / 1000000) | round(0) | int }}MB</td>
+          <td class="num">{{ "%.2f" | format(row.load_1min or 0) }}</td>
+          <td class="num">{{ (row.db_threads_running or 0) | int }}/{{ (row.db_threads_connected or 0) | int }}</td>
+          <td class="num">{{ (row.rq_default or 0) | int }}/{{ (row.rq_short or 0) | int }}/{{ (row.rq_long or 0) | int }}</td>
         </tr>
         {% endfor %}
       </tbody>
@@ -1594,37 +2642,43 @@
   </details>
   {% endif %}
 
-  {# --------------- v0.5.0: FRONTEND PANEL --------------- #}
-  {% if frontend_xhr_matched or frontend_vitals_by_page %}
+  {# v0.7.x Phase J.2.4: Frontend reads from report_data.frontend (contract).
+     The raw frontend_summary / frontend_xhr_matched / frontend_orphans
+     travel under .summary / .xhr_matched / .orphans (non-contract
+     extensions). web_vitals iterates the structured list whose
+     ``*_class`` fields encode the web.dev thresholds in Python - the
+     legacy _vital macro is no longer needed. #}
+  {% if report_data.frontend %}
   <details class="section" id="frontend">
     <summary><h2>Frontend</h2></summary>
     <p class="small muted">
       Per-XHR timings from the browser joined to the matching server recording,
       plus Web Vitals (FCP, LCP, CLS) per page. Shows what the user actually
-      felt — network overhead and page paint time that the server alone can't see.
+      felt - network overhead and page paint time that the server alone can't see.
     </p>
-    <div class="stats" style="margin-bottom: 12px;">
-      <div class="stat">
-        <div class="label">Total XHRs</div>
-        <div class="value">{{ frontend_summary.total_xhrs or 0 }}</div>
+    {% set _fs = report_data.frontend.summary %}
+    <div class="resource-grid">
+      <div class="resource-card">
+        <div class="rc-label">Total XHRs</div>
+        <div class="rc-value">{{ _fs.total_xhrs or 0 }}</div>
       </div>
-      <div class="stat">
-        <div class="label">Browser wall time</div>
-        <div class="value">{{ fmt_ms(frontend_summary.total_xhr_ms or 0) }}</div>
+      <div class="resource-card">
+        <div class="rc-label">Browser wall time</div>
+        <div class="rc-value">{{ fmt_ms(_fs.total_xhr_ms or 0) }}</div>
       </div>
-      <div class="stat">
-        <div class="label">Backend time</div>
-        <div class="value">{{ fmt_ms(frontend_summary.total_backend_ms or 0) }}</div>
+      <div class="resource-card">
+        <div class="rc-label">Backend time</div>
+        <div class="rc-value">{{ fmt_ms(_fs.total_backend_ms or 0) }}</div>
       </div>
-      <div class="stat">
-        <div class="label">Network overhead</div>
-        <div class="value">{{ fmt_ms(frontend_summary.network_overhead_ms or 0) }}</div>
+      <div class="resource-card">
+        <div class="rc-label">Network overhead</div>
+        <div class="rc-value">{{ fmt_ms(_fs.network_overhead_ms or 0) }}</div>
       </div>
     </div>
 
-    {% if frontend_xhr_matched %}
+    {% if report_data.frontend.xhr_matched %}
     <h3 style="margin-bottom: 8px;">Per-action XHR timing</h3>
-    <table class="tbl-clip xhr-timing-table" style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
+    <table class="tbl-clip xhr-timing-table data" style="width: 100%; font-size: 0.85rem;">
       <colgroup>
         <col class="col-action">
         <col class="col-num">
@@ -1646,7 +2700,7 @@
         </tr>
       </thead>
       <tbody>
-        {% for m in frontend_xhr_matched %}
+        {% for m in report_data.frontend.xhr_matched %}
         <tr style="border-bottom: 1px solid #f3f4f6;">
           <td style="padding: 4px 8px;">{{ m.action_label }}</td>
           <td style="padding: 4px 8px; text-align: right;">{{ fmt_ms(m.backend_ms) }}</td>
@@ -1663,40 +2717,43 @@
     </table>
     {% endif %}
 
-    {% if frontend_vitals_by_page %}
-    <h3 style="margin-top: 16px; margin-bottom: 8px;">Web Vitals by page</h3>
-    <table style="width: 100%; border-collapse: collapse; font-size: 0.85rem;">
+    {% if report_data.frontend.web_vitals %}
+    <h3 class="frontend-h3">Web Vitals by page</h3>
+    {# v0.7.x Phase J.2.4: web vitals iterates a contract-shaped list
+       where each row carries pre-computed display strings and rating
+       classes (vital-good / vital-meh / vital-poor / vital-none) per
+       web.dev thresholds. Closes the Phase I.5 partial-vitals loop:
+       missing keys → vital-none + em-dash, computed in Python. #}
+    <table class="data vitals-table">
       <thead>
-        <tr style="background: #f3f4f6; border-bottom: 1px solid #e5e7eb;">
-          <th style="padding: 6px 8px; text-align: left;">Page</th>
-          <th style="padding: 6px 8px; text-align: right;">FCP</th>
-          <th style="padding: 6px 8px; text-align: right;">LCP</th>
-          <th style="padding: 6px 8px; text-align: right;">CLS</th>
-          <th style="padding: 6px 8px; text-align: right;">TTFB</th>
-          <th style="padding: 6px 8px; text-align: right;">DCL</th>
+        <tr>
+          <th>Page</th>
+          <th class="num">FCP</th>
+          <th class="num">LCP</th>
+          <th class="num">CLS</th>
+          <th class="num">TTFB</th>
+          <th class="num">DCL</th>
         </tr>
       </thead>
       <tbody>
-        {% for page, v in frontend_vitals_by_page.items() %}
-        <tr style="border-bottom: 1px solid #f3f4f6;">
-          <td style="padding: 4px 8px;">
-            <code style="font-size: 0.75rem;">{{ page }}</code>
-          </td>
-          <td style="padding: 4px 8px; text-align: right;">{{ fmt_ms(v.fcp_ms or 0) }}</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ fmt_ms(v.lcp_ms or 0) }}</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ "%.3f" | format(v.cls or 0) }}</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ fmt_ms(v.ttfb_ms or 0) }}</td>
-          <td style="padding: 4px 8px; text-align: right;">{{ fmt_ms(v.dom_content_loaded_ms or 0) }}</td>
+        {% for row in report_data.frontend.web_vitals %}
+        <tr>
+          <td><code>{{ row.url }}</code></td>
+          <td class="num"><span class="{{ row.fcp_class }}">{{ row.fcp_display }}</span></td>
+          <td class="num"><span class="{{ row.lcp_class }}">{{ row.lcp_display }}</span></td>
+          <td class="num"><span class="{{ row.cls_class }}">{{ row.cls_display }}</span></td>
+          <td class="num"><span class="{{ row.ttfb_class }}">{{ row.ttfb_display }}</span></td>
+          <td class="num"><span class="{{ row.dcl_class }}">{{ row.dcl_display }}</span></td>
         </tr>
         {% endfor %}
       </tbody>
     </table>
     {% endif %}
 
-    {% if frontend_orphans %}
+    {% if report_data.frontend.orphans %}
     <details style="margin-top: 16px;">
       <summary class="small muted" style="cursor: pointer;">
-        Orphaned XHRs ({{ frontend_orphans | length }}) — no matching server recording
+        Orphaned XHRs ({{ report_data.frontend.orphans | length }}) - no matching server recording
       </summary>
       <table style="width: 100%; border-collapse: collapse; font-size: 0.85rem; margin-top: 8px;">
         <thead>
@@ -1707,7 +2764,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for o in frontend_orphans %}
+          {% for o in report_data.frontend.orphans %}
           <tr style="border-bottom: 1px solid #f3f4f6;">
             <td style="padding: 4px 8px;"><code style="font-size: 0.75rem;">{{ o.url }}</code></td>
             <td style="padding: 4px 8px; text-align: right;">{{ fmt_ms(o.duration_ms or 0) }}</td>
@@ -1722,11 +2779,16 @@
   {% endif %}
 
   {# --------------- v0.3.0: HOT FRAMES LEADERBOARD --------------- #}
-  {% if hot_frames_rows or hot_frames_rows_framework %}
+  {# v0.7.x Phase J.2.5: Hot frames reads from report_data.hot_frames /
+     .hot_frames_framework (non-contract split mirror of the existing
+     legacy split). The contract calls for a single list with
+     is_user_code flag; that collapse moves to J.3. #}
+  {% if report_data.hot_frames or report_data.hot_frames_framework %}
   <details class="section">
-    <summary><h2>Hot frames (top {{ ((hot_frames_rows or []) | length) + ((hot_frames_rows_framework or []) | length) }})</h2></summary>
-    {% if hot_frames_rows %}
-    <table>
+    <a id="hot-frames"></a>{# v0.7.x Phase I.1: mock-spec ID anchor #}
+    <summary><h2>Hot frames (top {{ (report_data.hot_frames | length) + (report_data.hot_frames_framework | length) }})</h2></summary>
+    {% if report_data.hot_frames %}
+    <table class="data hot-frames-table">
       <thead>
         <tr>
           <th>Function</th>
@@ -1736,18 +2798,18 @@
         </tr>
       </thead>
       <tbody>
-        {% for row in hot_frames_rows %}
+        {% for row in report_data.hot_frames %}
           {{ hot_frame_row(row) }}
         {% endfor %}
       </tbody>
     </table>
     {% else %}
-      <p class="small muted">No hot frames in your own app's code &mdash; all frames ran in framework code. Expand the block below to see what.</p>
+      <p class="small muted">No hot frames in your own app's code - all frames ran in framework code. Expand the block below to see what.</p>
     {% endif %}
-    {% if hot_frames_rows_framework %}
+    {% if report_data.hot_frames_framework %}
     <details class="subsection">
-      <summary class="small muted"><strong>{{ hot_frames_rows_framework | length }}</strong> framework frame{{ "s" if hot_frames_rows_framework | length != 1 else "" }} (click to expand) &mdash; <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
-      <table>
+      <summary class="small muted"><strong>{{ report_data.hot_frames_framework | length }}</strong> framework frame{{ "s" if report_data.hot_frames_framework | length != 1 else "" }} (click to expand) - <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
+      <table class="data hot-frames-table">
         <thead>
           <tr>
             <th>Function</th>
@@ -1757,7 +2819,7 @@
           </tr>
         </thead>
         <tbody>
-          {% for row in hot_frames_rows_framework %}
+          {% for row in report_data.hot_frames_framework %}
             {{ hot_frame_row(row) }}
           {% endfor %}
         </tbody>
@@ -1767,12 +2829,15 @@
   </details>
   {% endif %}
 
-  {# --------------- TOP-N SLOW QUERIES --------------- #}
+  {# v0.7.x Phase J.2.5: Slow queries reads from
+     report_data.slow_queries / .slow_queries_framework. The framework
+     split mirrors the legacy two-table layout pending J.3 collapse. #}
   <details class="section" id="top-queries">
-    <summary><h2>{% if top_queries %}Top {{ top_queries|length }} slowest queries{% else %}Slowest queries{% endif %} &mdash; your app</h2></summary>
-    {% if top_queries %}
-      <p class="small muted">Slowest queries issued from your own app's code. Framework and third-party queries are excluded &mdash; see the per-action breakdown below for the complete list.</p>
-      <table class="query-table">
+    <a id="queries"></a>{# v0.7.x Phase G: mock-spec ID alias #}
+    <summary><h2>{% if report_data.slow_queries %}Top {{ report_data.slow_queries|length }} slowest queries{% else %}Slowest queries{% endif %} - your app</h2></summary>
+    {% if report_data.slow_queries %}
+      <p class="small muted">Slowest queries issued from your own app's code. Framework and third-party queries are excluded - see the per-action breakdown below for the complete list.</p>
+      <table class="query-table data">
         <colgroup>
           <col class="col-index">
           <col class="col-duration">
@@ -1788,18 +2853,21 @@
           </tr>
         </thead>
         <tbody>
-        {% for q in top_queries %}
+        {% for q in report_data.slow_queries %}
           {{ top_query_row(q, loop.index) }}
         {% endfor %}
         </tbody>
       </table>
     {% else %}
-      <p class="empty">No notably slow queries from your app's own code in this session &mdash; nothing here is worth singling out. The per-action breakdown below lists every query, fast and framework ones included.</p>
+      <div class="empty-state">
+        <div class="empty-icon">&check; Clear</div>
+        <p>No notably slow queries from your app's own code in this session - nothing here is worth singling out. The per-action breakdown below lists every query, fast and framework ones included.</p>
+      </div>
     {% endif %}
-    {% if top_queries_framework %}
+    {% if report_data.slow_queries_framework %}
     <details class="subsection">
-      <summary class="small muted"><strong>{{ top_queries_framework | length }}</strong> framework quer{{ "ies" if top_queries_framework | length != 1 else "y" }} (click to expand) &mdash; <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
-      <table class="query-table">
+      <summary class="small muted"><strong>{{ report_data.slow_queries_framework | length }}</strong> framework quer{{ "ies" if report_data.slow_queries_framework | length != 1 else "y" }} (click to expand) - <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
+      <table class="query-table data">
         <colgroup>
           <col class="col-index">
           <col class="col-duration">
@@ -1815,7 +2883,7 @@
           </tr>
         </thead>
         <tbody>
-        {% for q in top_queries_framework %}
+        {% for q in report_data.slow_queries_framework %}
           {{ top_query_row(q, loop.index) }}
         {% endfor %}
         </tbody>
@@ -1833,7 +2901,7 @@
       developer knows where to look. Actions are ordered by total duration.
     </p>
 
-    {% for action in (actions + (actions_framework or [])) | sort(attribute='duration_ms', reverse=True) %}
+    {% for action in (report_data.actions + (report_data.actions_framework or [])) | sort(attribute='duration_ms', reverse=True) %}
       {% set recording = recordings_by_uuid.get(action.recording_uuid) %}
       {% if recording and recording.calls %}
       <details{% if loop.index <= 3 %} open{% endif %} style="margin: 12px 0;">
@@ -1898,21 +2966,27 @@
 
   {# --------------- PER-TABLE BREAKDOWN --------------- #}
   <details class="section" id="db-tables">
+    <a id="db"></a>{# v0.7.x Phase G: mock-spec ID alias #}
     <summary><h2>Time spent per database table</h2></summary>
     {% if hidden_db_tables_count %}
       <p class="small muted" style="margin: 4px 0 10px; padding: 8px 12px; background: #f9fafb; border-radius: 6px;"><strong>{{ hidden_db_tables_count }}</strong> framework/internal table{{ "s" if hidden_db_tables_count != 1 else "" }} hidden (DocType / Workspace / Role / Has Role / DefaultValue / <code>information_schema.*</code> and friends). Uncheck <em>"Hide framework / internal database tables"</em> in Optimus Settings to see them.</p>
     {% endif %}
-    {% if table_breakdown %}
-      {% set written = table_breakdown | selectattr("write_count") | sort(attribute="write_count", reverse=True) | list %}
+    {# v0.7.x Phase J.2.5: DB tables read from report_data.db.tables.
+       The adapter spreads each original table dict so the rich index-
+       recommendation block keeps reading recommended_index /
+       index_candidates / is_meta_table / framework_cols_filtered /
+       ai_index without translation. #}
+    {% if report_data.db and report_data.db.tables %}
+      {% set written = report_data.db.tables | selectattr("write_count") | sort(attribute="write_count", reverse=True) | list %}
       {% if written %}
       <p class="small muted" style="margin-bottom:10px;">
         <strong>Tables written to this session</strong> ({{ written | length }}):
         {% for t in written[:12] %}<code title="{{ t.write_count }} write(s){% if t.get('write_time_ms') %}, {{ fmt_ms(t.write_time_ms) }}{% endif %}">{{ t.table }}</code>&nbsp;({{ t.write_count }}){% if not loop.last %}, {% endif %}{% endfor %}{% if written | length > 12 %} … and {{ written | length - 12 }} more{% endif %}.
-        <br>Writes are usually cheap (a handful of sub-millisecond <code>INSERT</code>&nbsp;/&nbsp;<code>UPDATE</code> rows), so a write-heavy table normally won't be near the top of the time-sorted list below &mdash; that's why a document save doesn't dominate this section. Drill into the <a href="#per-action">per-action breakdown</a> to see exactly what each save / submit wrote.
+        <br>Writes are usually cheap (a handful of sub-millisecond <code>INSERT</code>&nbsp;/&nbsp;<code>UPDATE</code> rows), so a write-heavy table normally won't be near the top of the time-sorted list below - that's why a document save doesn't dominate this section. Drill into the <a href="#per-action">per-action breakdown</a> to see exactly what each save / submit wrote.
       </p>
       {% endif %}
       <p class="small muted">Where the time goes, and how each table was used. A query touching multiple tables is counted against each, so the rows sum to more than the session total. <strong>Reads</strong> = <code>SELECT</code>; <strong>Writes</strong> = <code>INSERT</code> / <code>UPDATE</code> / <code>DELETE</code>. Sorted by time desc.</p>
-      <table>
+      <table class="data">
         <thead>
           <tr>
             <th>Table</th>
@@ -1923,82 +2997,101 @@
           </tr>
         </thead>
         <tbody>
-        {% for t in table_breakdown %}
+        {% for t in report_data.db.tables %}
           <tr>
             <td><code>{{ t.table }}</code></td>
             <td class="num">{{ fmt_ms(t.duration_ms) }}</td>
             <td class="num">{{ t.queries }}</td>
-            <td class="num">{{ t.get("read_count", "—") }}{% if t.get("read_time_ms") %} <span class="small muted">/ {{ fmt_ms(t.read_time_ms) }}</span>{% endif %}</td>
-            <td class="num">{{ t.get("write_count", "—") }}{% if t.get("write_time_ms") %} <span class="small muted">/ {{ fmt_ms(t.write_time_ms) }}</span>{% endif %}</td>
+            <td class="num">{{ t.get("read_count", "-") }}{% if t.get("read_time_ms") %} <span class="small muted">/ {{ fmt_ms(t.read_time_ms) }}</span>{% endif %}</td>
+            <td class="num">{{ t.get("write_count", "-") }}{% if t.get("write_time_ms") %} <span class="small muted">/ {{ fmt_ms(t.write_time_ms) }}</span>{% endif %}</td>
           </tr>
-          {% if t.get("recommended_index") %}
-          {% set rec = t.recommended_index %}
-          <tr>
-            <td colspan="5" style="background:#f9fafb;border-top:none;padding:4px 12px 10px 28px;font-size:0.82rem;">
-              <span class="muted" style="text-transform:uppercase;font-size:0.68rem;letter-spacing:0.5px;font-weight:600;">Index candidate &mdash; to speed up reads of this table</span><br>
-              The most-used filter on this table was <strong><code>({% for c in rec.columns %}{{ c }}{% if not loop.last %}, {% endif %}{% endfor %})</code></strong> &mdash; those columns were filtered together in {{ rec.together_count }} of {{ rec.read_count }} read{{ 's' if rec.read_count != 1 else '' }}. A composite index on them, leftmost-first, would help those reads:
-              <pre style="margin:6px 0;white-space:pre-wrap;word-break:break-word;background:#fff;border:1px solid #e5e7eb;border-radius:4px;padding:8px 10px;">frappe.db.add_index("{{ rec.doctype }}", [{% for c in rec.columns %}"{{ c }}"{% if not loop.last %}, {% endif %}{% endfor %}])</pre>
-              <span class="small muted">Put that in a patch &mdash; Customize&nbsp;Form ▸ field ▸ <em>Search&nbsp;Index</em> only makes single-column indexes. First run <code>SHOW INDEX FROM `{{ t.table }}`</code>: this may already be covered.</span>
-              {% if t.get("write_count", 0) %}
-                <div style="color:#b45309;margin-top:5px;">&#9888; {{ t.write_count }} write{% if t.write_count != 1 %}s{% endif %} on this table in this session{% if t.get("is_write_hot") %} &mdash; and <code>{{ t.table }}</code> is a write-hot core table (many rows inserted per submitted document in production){% endif %} &mdash; every index also slows writes, so add it only if a query in the per-action breakdown that filters this way is actually slow.</div>
-              {% elif t.get("is_write_hot") %}
-                <div style="color:#b45309;margin-top:5px;">&#9888; No writes in this session, but <code>{{ t.table }}</code> is normally write-hot in production (bulk inserts per submitted document) &mdash; be conservative about adding indexes here.</div>
-              {% else %}
-                <div class="muted" style="margin-top:5px;">No writes recorded &mdash; adding an index here is low-risk.</div>
-              {% endif %}
-              {% if rec.also_filtered %}
-                <div class="muted" style="margin-top:3px;">Other columns this session filtered on (in other / fewer queries) &mdash; index each only if its own query is slow: {% for c in rec.also_filtered %}<code>{{ c }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.</div>
-              {% endif %}
-              {% if t.get("framework_cols_filtered") %}
-                <div class="muted" style="margin-top:3px;">Also filtered on Frappe metadata columns ({% for fc in t.framework_cols_filtered %}<code>{{ fc }}</code>{% if not loop.last %}, {% endif %}{% endfor %}) &mdash; never indexed (Frappe writes them on every save, or they're auto-indexed).</div>
-              {% endif %}
-              {% if t.get("ai_index") and t.ai_index.suggestion_html %}
-                <div class="ai-fix" style="margin-top:8px;">
-                  <div class="ai-fix-header">Index advice (AI{% if t.ai_index.model %} &mdash; {{ t.ai_index.model }}{% endif %})</div>
-                  <div class="ai-fix-body">{{ t.ai_index.suggestion_html | safe }}</div>
-                  <div class="ai-fix-foot">Machine-generated{% if t.ai_index.generated_at %} &middot; {{ fmt_dt(t.ai_index.generated_at) }}{% endif %} &mdash; verify against <code>SHOW INDEX</code> before applying.</div>
-                </div>
-              {% endif %}
-            </td>
-          </tr>
-          {% elif t.index_candidates %}
-          <tr>
-            <td colspan="5" style="background:#f9fafb;border-top:none;padding:4px 12px 10px 28px;font-size:0.82rem;">
-              <span class="muted" style="text-transform:uppercase;font-size:0.68rem;letter-spacing:0.5px;font-weight:600;">Index candidates &mdash; to speed up reads of this table</span><br>
-              {% for c in t.index_candidates %}<code title="used in {{ c.sources | join(', ') }} &middot; {{ c.hits }}× this session">{{ c.column }}</code>{% if not loop.last %}, {% endif %}{% endfor %}
-              {% if t.get("write_count", 0) %}
-                <span style="color:#b45309;"> &nbsp;&#9888; {{ t.write_count }} write{% if t.write_count != 1 %}s{% endif %} on this table — every index added also slows those writes, so index only the column(s) that meaningfully help reads (one composite index over columns filtered together beats several single-column ones).</span>
-              {% else %}
-                <span class="muted"> &nbsp;&middot; no writes recorded — adding an index here is low-risk.</span>
-              {% endif %}
-              {% if t.get("framework_cols_filtered") %}
-                <div class="muted" style="margin-top:3px;">Also filtered on Frappe metadata columns ({% for fc in t.framework_cols_filtered %}<code>{{ fc }}</code>{% if not loop.last %}, {% endif %}{% endfor %}) &mdash; those aren't safe index targets (Frappe writes them on every save, or they're auto-indexed), so they're left out.</div>
-              {% endif %}
-            </td>
-          </tr>
-          {% elif t.get("is_meta_table") %}
-          <tr>
-            <td colspan="5" style="background:#f9fafb;border-top:none;padding:4px 12px 8px 28px;font-size:0.78rem;" class="muted">
-              Frappe framework meta table &mdash; <code>bench migrate</code> owns its schema (indexes included), so a hand-added index here is pointless and would be clobbered on the next migrate. Nothing suggested.
-            </td>
-          </tr>
-          {% elif "index_candidates" in t and t.get("framework_cols_filtered") %}
-          <tr>
-            <td colspan="5" style="background:#f9fafb;border-top:none;padding:4px 12px 8px 28px;font-size:0.78rem;" class="muted">
-              Reads here only filter on Frappe metadata columns ({% for fc in t.framework_cols_filtered %}<code>{{ fc }}</code>{% if not loop.last %}, {% endif %}{% endfor %}) &mdash; those aren't safe index targets (Frappe writes them on every save, or they're auto-indexed), so nothing's suggested for this table.
-            </td>
-          </tr>
-          {% elif "index_candidates" in t and t.get("read_count") %}
-          <tr>
-            <td colspan="5" style="background:#f9fafb;border-top:none;padding:4px 12px 8px 28px;font-size:0.78rem;" class="muted">
-              Reads here filter on no single indexable column (full scans or primary-key lookups) &mdash; nothing obvious to add.
-            </td>
-          </tr>
-          {% endif %}
         {% endfor %}
         </tbody>
       </table>
-      <p class="small muted" style="margin-top:8px;">The <strong>index candidate</strong> for each table is the set of <code>WHERE</code> / <code>JOIN&nbsp;ON</code> columns this session filtered on <em>together</em> most often — a heuristic, not a verdict. Always confirm with the query's <code>EXPLAIN</code> (and a <code>SHOW INDEX FROM …</code>) before adding anything; every index also carries a write cost, and the column order in a composite matters (most-selective / equality columns first). Never suggested: Frappe's standard metadata columns (<code>name</code>, <code>creation</code>, <code>modified</code>, <code>parent</code>, <code>idx</code>, <code>docstatus</code>, …) — written on every save / already indexed; and Frappe's framework meta tables (<code>tabDocType</code>, <code>tabCustom Field</code>, <code>tabSingles</code>, …) — <code>bench&nbsp;migrate</code> owns their schema. ("&mdash;" in Reads/Writes means this session was analyzed before this breakdown was added &mdash; re-run <em>Retry Analyze</em> to populate.)</p>
+
+      {# v0.7.x Phase I: index recommendations rendered as `.index-rec`
+         cards BELOW the data table (lifted out of the colspan sub-rows
+         the older markup used). Each card carries the table name, the
+         read/write summary in mono, the recommendation prose, the
+         dark SQL snippet for any composite DDL, and an amber
+         warn-line when writes are present. Render only when a table
+         carries at least one of the recommendation flags. #}
+      {% set _rec_tables = [] %}
+      {% for t in report_data.db.tables %}
+        {% if t.get("recommended_index") or t.index_candidates or t.get("is_meta_table") or (t.get("framework_cols_filtered") and "index_candidates" in t) or ("index_candidates" in t and t.get("read_count")) %}
+          {% set _ = _rec_tables.append(t) %}
+        {% endif %}
+      {% endfor %}
+      {% if _rec_tables %}
+      <div class="index-recs">
+        <p class="index-recs-head">Index recommendations</p>
+        {% for t in _rec_tables %}
+        <div class="index-rec">
+          <div class="index-rec-head">
+            <span class="index-rec-table">{{ t.table }}</span>
+            <span class="index-rec-stats">
+              {% if t.get("read_count") is not none %}<span class="stat-num">{{ t.get("read_count", 0) }}</span> reads{% endif %}
+              {% if t.get("write_count") is not none %} &middot; <span class="stat-num">{{ t.get("write_count", 0) }}</span> writes{% endif %}
+              {% if t.get("duration_ms") %} &middot; {{ fmt_ms(t.duration_ms) }}{% endif %}
+            </span>
+          </div>
+
+          {% if t.get("recommended_index") %}
+            {% set rec = t.recommended_index %}
+            <div class="index-rec-label">Index candidate - to speed up reads</div>
+            <p>The most-used filter on this table was <code>({% for c in rec.columns %}{{ c }}{% if not loop.last %}, {% endif %}{% endfor %})</code> - those columns were filtered together in <strong>{{ rec.together_count }}</strong> of {{ rec.read_count }} read{{ 's' if rec.read_count != 1 else '' }}. A composite index on them, leftmost-first, would help those reads:</p>
+            <pre class="sql-snip">frappe.db.add_index("{{ rec.doctype }}", [{% for c in rec.columns %}"{{ c }}"{% if not loop.last %}, {% endif %}{% endfor %}])</pre>
+            <p class="note-text">Put that in a patch - Customize&nbsp;Form ▸ field ▸ <em>Search&nbsp;Index</em> only makes single-column indexes. First run <code>SHOW INDEX FROM `{{ t.table }}`</code>: this may already be covered.</p>
+            {% if t.get("write_count", 0) %}
+              <div class="warn-text">&#9888; {{ t.write_count }} write{% if t.write_count != 1 %}s{% endif %} on this table in this session{% if t.get("is_write_hot") %} - and <code>{{ t.table }}</code> is a write-hot core table (many rows inserted per submitted document in production){% endif %} - every index also slows writes, so add it only if a query in the per-action breakdown that filters this way is actually slow.</div>
+            {% elif t.get("is_write_hot") %}
+              <div class="warn-text">&#9888; No writes in this session, but <code>{{ t.table }}</code> is normally write-hot in production (bulk inserts per submitted document) - be conservative about adding indexes here.</div>
+            {% else %}
+              <div class="note-text">No writes recorded - adding an index here is low-risk.</div>
+            {% endif %}
+            {% if rec.also_filtered %}
+              <div class="note-text">Other columns this session filtered on (in other / fewer queries) - index each only if its own query is slow: {% for c in rec.also_filtered %}<code>{{ c }}</code>{% if not loop.last %}, {% endif %}{% endfor %}.</div>
+            {% endif %}
+            {% if t.get("framework_cols_filtered") %}
+              <div class="note-text">Also filtered on Frappe metadata columns ({% for fc in t.framework_cols_filtered %}<code>{{ fc }}</code>{% if not loop.last %}, {% endif %}{% endfor %}) - never indexed (Frappe writes them on every save, or they're auto-indexed).</div>
+            {% endif %}
+            {% if t.get("ai_index") and t.ai_index.suggestion_html %}
+              <div class="fix-box" style="margin-top: 10px;">
+                <div class="fix-head">
+                  <span>Index advice</span>
+                  <span class="ai-tag">AI{% if t.ai_index.model %} &middot; {{ t.ai_index.model }}{% endif %}</span>
+                </div>
+                <div class="fix-body">{{ t.ai_index.suggestion_html | safe }}</div>
+                <div class="fix-foot">Machine-generated{% if t.ai_index.generated_at %} &middot; {{ fmt_dt(t.ai_index.generated_at) }}{% endif %} - verify against <code>SHOW INDEX</code> before applying.</div>
+              </div>
+            {% endif %}
+
+          {% elif t.index_candidates %}
+            <div class="index-rec-label">Index candidates - to speed up reads</div>
+            <p>{% for c in t.index_candidates %}<code title="used in {{ c.sources | join(', ') }} &middot; {{ c.hits }}× this session">{{ c.column }}</code>{% if not loop.last %}, {% endif %}{% endfor %}</p>
+            {% if t.get("write_count", 0) %}
+              <div class="warn-text">&#9888; {{ t.write_count }} write{% if t.write_count != 1 %}s{% endif %} on this table - every index added also slows those writes, so index only the column(s) that meaningfully help reads (one composite index over columns filtered together beats several single-column ones).</div>
+            {% else %}
+              <div class="note-text">No writes recorded - adding an index here is low-risk.</div>
+            {% endif %}
+            {% if t.get("framework_cols_filtered") %}
+              <div class="note-text">Also filtered on Frappe metadata columns ({% for fc in t.framework_cols_filtered %}<code>{{ fc }}</code>{% if not loop.last %}, {% endif %}{% endfor %}) - those aren't safe index targets (Frappe writes them on every save, or they're auto-indexed), so they're left out.</div>
+            {% endif %}
+
+          {% elif t.get("is_meta_table") %}
+            <p class="note-text">Frappe framework meta table - <code>bench migrate</code> owns its schema (indexes included), so a hand-added index here is pointless and would be clobbered on the next migrate. Nothing suggested.</p>
+
+          {% elif "index_candidates" in t and t.get("framework_cols_filtered") %}
+            <p class="note-text">Reads here only filter on Frappe metadata columns ({% for fc in t.framework_cols_filtered %}<code>{{ fc }}</code>{% if not loop.last %}, {% endif %}{% endfor %}) - those aren't safe index targets (Frappe writes them on every save, or they're auto-indexed), so nothing's suggested for this table.</p>
+
+          {% elif "index_candidates" in t and t.get("read_count") %}
+            <p class="note-text">Reads here filter on no single indexable column (full scans or primary-key lookups) - nothing obvious to add.</p>
+          {% endif %}
+        </div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      <p class="small muted" style="margin-top:8px;">The <strong>index candidate</strong> for each table is the set of <code>WHERE</code> / <code>JOIN&nbsp;ON</code> columns this session filtered on <em>together</em> most often - a heuristic, not a verdict. Always confirm with the query's <code>EXPLAIN</code> (and a <code>SHOW INDEX FROM …</code>) before adding anything; every index also carries a write cost, and the column order in a composite matters (most-selective / equality columns first). Never suggested: Frappe's standard metadata columns (<code>name</code>, <code>creation</code>, <code>modified</code>, <code>parent</code>, <code>idx</code>, <code>docstatus</code>, …) - written on every save / already indexed; and Frappe's framework meta tables (<code>tabDocType</code>, <code>tabCustom Field</code>, <code>tabSingles</code>, …) - <code>bench&nbsp;migrate</code> owns their schema. ("-" in Reads/Writes means this session was analyzed before this breakdown was added - re-run <em>Retry Analyze</em> to populate.)</p>
     {% else %}
       <p class="empty">No table breakdown available.</p>
     {% endif %}
@@ -2008,10 +3101,10 @@
   {% if recordings_by_uuid %}
   <details class="section">
     <summary><h2>Full recordings</h2></summary>
-    <p class="small muted">Every action's complete data &mdash; raw SQL with literal values, request headers, form data, and full Python stack traces. <strong>This contains potentially sensitive customer data &mdash; do not share externally.</strong></p>
+    <p class="small muted">Every action's complete data - raw SQL with literal values, request headers, form data, and full Python stack traces. <strong>This contains potentially sensitive customer data - do not share externally.</strong></p>
     <p class="small muted">Each action is collapsed by default. Click to expand.</p>
 
-    {% for action in (actions + (actions_framework or [])) | sort(attribute='duration_ms', reverse=True) %}
+    {% for action in (report_data.actions + (report_data.actions_framework or [])) | sort(attribute='duration_ms', reverse=True) %}
       {% set recording = recordings_by_uuid.get(action.recording_uuid) %}
       {% if recording %}
       <details style="margin: 12px 0; padding: 12px; background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 6px;">
@@ -2044,7 +3137,7 @@
                 <pre style="margin: 4px 0;">{{ call.query }}</pre>
                 {% if call.stack %}
                   <details>
-                    <summary class="small muted">Stack ({{ call.stack | length }} frames) &mdash; click to expand</summary>
+                    <summary class="small muted">Stack ({{ call.stack | length }} frames) - click to expand</summary>
                     <pre class="small">{% for frame in call.stack %}{{ frame.filename }}:{{ frame.lineno }} ({{ frame.function }})
 {% endfor %}</pre>
                   </details>
@@ -2063,19 +3156,19 @@
   {% endif %}
 
   {# v0.6.0: orientation for someone seeing this report for the first time.
-     Collapsed by default — the summary line alone tells repeat readers it's
+     Collapsed by default - the summary line alone tells repeat readers it's
      here. v0.7.x: moved to the bottom of the report (was originally between
      the Jump-to nav and the executive summary). Repeat readers don't need
      it surfaced above the technical content; first-time readers reach it
      via the "How to read" link in the Jump-to nav. #}
-  <details class="section" id="how-to-read" style="background:#f8fafc;">
+  <details class="how-to" id="how-to-read">
     <summary><h2>How to read this report</h2></summary>
     <ul class="small" style="margin:6px 0 0 18px;padding:0;line-height:1.7;">
-      <li>Start with <strong>Findings</strong> &mdash; that's the punch list of what to fix. The <em>Observations</em> sub-list under it is FYI signal (framework-level issues, system pressure) with no concrete fix you can ship.</li>
+      <li>Start with <strong>Findings</strong> - that's the punch list of what to fix. The <em>Observations</em> sub-list under it is FYI signal (framework-level issues, system pressure) with no concrete fix you can ship.</li>
       <li>The per-action table below lists every request the session captured, sorted by duration; the background-jobs section lists the jobs those requests enqueued (captured and analyzed too).</li>
-      <li>The database-tables section shows where DB time went, with an index candidate per table; the <em>tables written to</em> line at the top of it lists every table the session wrote &mdash; writes are cheap, so they rank low by time. The slowest-queries section covers your own app's code only.</li>
-      <li>The server-resource and frontend panels show CPU / memory / queue pressure and browser timings &mdash; only when captured.</li>
-      <li>The full-recordings and queries-per-action sections (collapsed) hold the raw SQL, headers, form data and stack traces &mdash; for deep dives.</li>
+      <li>The database-tables section shows where DB time went, with an index candidate per table; the <em>tables written to</em> line at the top of it lists every table the session wrote - writes are cheap, so they rank low by time. The slowest-queries section covers your own app's code only.</li>
+      <li>The server-resource and frontend panels show CPU / memory / queue pressure and browser timings - only when captured.</li>
+      <li>The full-recordings and queries-per-action sections (collapsed) hold the raw SQL, headers, form data and stack traces - for deep dives.</li>
       <li>Hover any <code>file.py:123</code> callsite to open it in VS&nbsp;Code. Anything starting with <code>tab</code> is a database table; the DocType is the part after <code>tab</code>.</li>
     </ul>
   </details>
@@ -2084,24 +3177,22 @@
   <div class="footer">
     <p>
       Generated by <strong>Optimus</strong> &middot;
-      <span style="color:#dc2626">Admin report &mdash; contains sensitive data, internal use only</span>
+      <span class="warn-line">Admin report - contains sensitive data, internal use only</span>
     </p>
     <p class="small" style="margin-top: 8px; color: #9ca3af;">
       Do NOT email, upload, or share this file externally without redacting
       it yourself. Query literals, request headers, form data, and full
       stack traces are all included verbatim.
     </p>
-    {% if render_config %}
+    {# v0.7.x Phase J.2.1: reads report_data.footer.settings (a pre-
+       composed ` · `-joined string per the contract). The `<code>` per-
+       value styling from pre-J.2 is gone; in exchange the contract's
+       compact one-line shape lets the footer line wrap predictably. #}
+    {% if report_data.footer and report_data.footer.settings %}
     <p class="small" style="margin-top: 10px; color: #9ca3af;">
       <strong>Rendered with:</strong>
-      hide_framework_tables = <code>{{ "on" if render_config.hide_framework_tables else "off" }}</code> &middot;
-      tracked_apps = <code>{{ render_config.tracked_apps | join(", ") if render_config.tracked_apps else "(none)" }}</code> &middot;
-      ignored_apps = <code>{{ render_config.ignored_apps | join(", ") if render_config.ignored_apps else "(none)" }}</code> &middot;
-      ai_suggest_findings = <code>{{ "on" if render_config.ai_suggest_findings else "off" }}</code> &middot;
-      ai_suggest_indexes = <code>{{ "on" if render_config.ai_suggest_indexes else "off" }}</code> &middot;
-      min_action_duration_ms = <code>{{ render_config.min_action_duration_ms | round(0) | int }}</code> &middot;
-      large_duration_threshold_ms = <code>{{ render_config.large_duration_threshold_ms | round(0) | int }}</code>.
-      Settings affect FUTURE renders only &mdash; click <em>Regenerate Reports</em> on the Optimus Session after a settings change.
+      {{ report_data.footer.settings }}.
+      Settings affect FUTURE renders only - click <em>Regenerate Reports</em> on the Optimus Session after a settings change.
     </p>
     {% endif %}
   </div>

--- a/optimus/tests/test_action_entry_callsite.py
+++ b/optimus/tests/test_action_entry_callsite.py
@@ -4,7 +4,7 @@
 """Unit tests for ``renderer._action_entry_callsite`` and the dotted-entry
 derivation that feeds it.
 
-The per-action breakdown and the Background Jobs section identify an action
+The per-action breakdown and the RQ Jobs section identify an action
 only by a dotted module path (``ugly_code.python.common.bg_recheck_users``)
 or a URL. This resolves that entry point to ``file:line`` + a ±1-line source
 snippet. The tests resolve a real function in *this* app
@@ -27,7 +27,7 @@ def _expected_lineno():
 class TestActionDottedEntry:
 	def test_background_job_path_is_the_dotted_entry(self):
 		assert renderer._action_dotted_entry(
-			{"event_type": "Background Job", "path": "ugly_code.python.common.bg_recheck_users"}
+			{"event_type": "RQ Job", "path": "ugly_code.python.common.bg_recheck_users"}
 		) == "ugly_code.python.common.bg_recheck_users"
 
 	def test_http_api_method_path_strips_prefix(self):
@@ -52,8 +52,8 @@ class TestActionDottedEntry:
 		) is None
 
 	def test_empty_missing_or_bad_input(self):
-		assert renderer._action_dotted_entry({"event_type": "Background Job", "path": ""}) is None
-		assert renderer._action_dotted_entry({"event_type": "Background Job"}) is None
+		assert renderer._action_dotted_entry({"event_type": "RQ Job", "path": ""}) is None
+		assert renderer._action_dotted_entry({"event_type": "RQ Job"}) is None
 		assert renderer._action_dotted_entry({"event_type": "HTTP Request", "path": ""}) is None
 		assert renderer._action_dotted_entry({}) is None
 		assert renderer._action_dotted_entry(None) is None
@@ -106,7 +106,7 @@ class TestActionEntryCallsite:
 
 	def test_resolves_background_job_action(self):
 		self._expect_renderer_py(renderer._action_entry_callsite(
-			{"event_type": "Background Job", "path": _DOTTED}
+			{"event_type": "RQ Job", "path": _DOTTED}
 		))
 
 	def test_resolves_http_api_method_action(self):
@@ -115,7 +115,7 @@ class TestActionEntryCallsite:
 		))
 
 	def test_display_path_matches_bench_relpath(self):
-		cs = renderer._action_entry_callsite({"event_type": "Background Job", "path": _DOTTED})
+		cs = renderer._action_entry_callsite({"event_type": "RQ Job", "path": _DOTTED})
 		try:
 			from frappe.utils import get_bench_path
 			expected = os.path.relpath(cs["_abs"], get_bench_path()).replace("\\", "/")
@@ -130,28 +130,28 @@ class TestActionEntryCallsite:
 
 	def test_none_for_unresolvable_dotted_path(self):
 		assert renderer._action_entry_callsite(
-			{"event_type": "Background Job", "path": "nope_xyzq.does.not.exist"}
+			{"event_type": "RQ Job", "path": "nope_xyzq.does.not.exist"}
 		) is None
 
 	def test_none_for_empty_path(self):
 		assert renderer._action_entry_callsite(
-			{"event_type": "Background Job", "path": ""}
+			{"event_type": "RQ Job", "path": ""}
 		) is None
 
 	def test_none_when_dotted_resolves_to_a_module(self):
 		assert renderer._action_entry_callsite(
-			{"event_type": "Background Job", "path": "optimus.renderer"}
+			{"event_type": "RQ Job", "path": "optimus.renderer"}
 		) is None
 
 	def test_none_for_builtin_no_code_object(self):
 		assert renderer._action_entry_callsite(
-			{"event_type": "Background Job", "path": "builtins.len"}
+			{"event_type": "RQ Job", "path": "builtins.len"}
 		) is None
 
 	def test_forwards_file_cache(self):
 		cache: dict = {}
 		cs = renderer._action_entry_callsite(
-			{"event_type": "Background Job", "path": _DOTTED}, cache=cache,
+			{"event_type": "RQ Job", "path": _DOTTED}, cache=cache,
 		)
 		assert cs is not None and cs["source_snippet"]
 		# _read_source_snippet memoizes the file's split lines under the path

--- a/optimus/tests/test_action_plan.py
+++ b/optimus/tests/test_action_plan.py
@@ -1,0 +1,116 @@
+# Copyright (c) 2026, Optimus contributors
+# For license information, please see license.txt
+
+"""Tests for `renderer._build_action_plan` — the v0.7.x redesign
+Phase C punch list.
+
+Top-N findings by severity → impact, each emitted as a step the
+template renders as a numbered `.action-step` row. Empty findings
+input returns `[]` and the template hides the section."""
+
+from optimus import renderer
+
+
+def _f(**kw):
+	base = {
+		"finding_type": "N+1 Query",
+		"severity": "High",
+		"title": "Same query ran 50×",
+		"customer_description": "A query repeats inside a loop.",
+		"estimated_impact_ms": 500.0,
+		"affected_count": 50,
+		"technical_detail": {
+			"callsite": {"filename": "apps/myapp/foo.py", "lineno": 42, "function": "f"},
+		},
+	}
+	base.update(kw)
+	return base
+
+
+class TestEmpty:
+	def test_no_findings_returns_empty_list(self):
+		assert renderer._build_action_plan([]) == []
+
+
+class TestSizing:
+	def test_returns_at_most_three_steps_by_default(self):
+		findings = [_f(estimated_impact_ms=float(i * 100)) for i in range(10)]
+		out = renderer._build_action_plan(findings)
+		assert len(out) == 3
+
+	def test_max_steps_override(self):
+		findings = [_f(estimated_impact_ms=float(i * 100)) for i in range(5)]
+		out = renderer._build_action_plan(findings, max_steps=5)
+		assert len(out) == 5
+
+	def test_returns_fewer_when_input_is_smaller(self):
+		out = renderer._build_action_plan([_f(), _f()])
+		assert len(out) == 2
+
+
+class TestSorting:
+	def test_high_severity_beats_higher_impact_at_lower_severity(self):
+		low_big = _f(severity="Low", estimated_impact_ms=5000, title="LOW")
+		high_small = _f(severity="High", estimated_impact_ms=100, title="HIGH")
+		out = renderer._build_action_plan([low_big, high_small])
+		# High severity comes first.
+		assert out[0]["title"].startswith("Eliminate") or "HIGH" in out[0]["title"]
+		# More precisely: the first step's gain matches the High finding.
+		assert out[0]["gain_ms"] == 100
+		assert out[1]["gain_ms"] == 5000
+
+	def test_within_severity_higher_impact_wins(self):
+		small = _f(severity="Medium", estimated_impact_ms=50)
+		big = _f(severity="Medium", estimated_impact_ms=500)
+		out = renderer._build_action_plan([small, big])
+		assert out[0]["gain_ms"] == 500
+		assert out[1]["gain_ms"] == 50
+
+
+class TestVerbTitles:
+	def test_n_plus_one_uses_eliminate_verb(self):
+		out = renderer._build_action_plan([_f(finding_type="N+1 Query")])
+		assert out[0]["title"] == "Eliminate the N+1 query"
+
+	def test_hook_bottleneck_uses_speed_up_verb(self):
+		out = renderer._build_action_plan([_f(finding_type="Hook Bottleneck")])
+		assert out[0]["title"] == "Speed up the doc-event hook"
+
+	def test_missing_index_uses_add_verb(self):
+		out = renderer._build_action_plan([_f(finding_type="Missing Index")])
+		assert out[0]["title"] == "Add a database index"
+
+	def test_unknown_finding_type_falls_back_to_verbatim_title(self):
+		f = _f(finding_type="?", title="Some specific actionable headline")
+		out = renderer._build_action_plan([f])
+		assert out[0]["title"] == "Some specific actionable headline"
+
+
+class TestStepShape:
+	def test_step_carries_position_gain_and_callsite(self):
+		out = renderer._build_action_plan([_f()])
+		step = out[0]
+		assert step["n"] == 1
+		assert step["gain_ms"] == 500.0
+		assert step["gain_label"] == "est. saving"
+		assert step["callsite"] == "apps/myapp/foo.py:42"
+
+	def test_step_desc_falls_back_to_title_when_description_blank(self):
+		f = _f(customer_description="", title="Same query ran 50×")
+		out = renderer._build_action_plan([f])
+		assert out[0]["desc"] == "Same query ran 50×"
+
+	def test_step_callsite_none_when_no_filename_or_lineno(self):
+		f = _f(technical_detail={"callsite": {"filename": "", "lineno": 0}})
+		out = renderer._build_action_plan([f])
+		assert out[0]["callsite"] is None
+
+	def test_step_callsite_none_when_callsite_missing_entirely(self):
+		f = _f(technical_detail={})
+		out = renderer._build_action_plan([f])
+		assert out[0]["callsite"] is None
+
+	def test_numbers_count_up_from_one(self):
+		findings = [_f(estimated_impact_ms=float(i * 100)) for i in range(3)]
+		out = renderer._build_action_plan(findings)
+		assert [s["n"] for s in out] == [1, 2, 3]

--- a/optimus/tests/test_actionable_findings_split.py
+++ b/optimus/tests/test_actionable_findings_split.py
@@ -110,7 +110,7 @@ def test_template_has_observations_subsection_inside_findings():
 		"report.html must iterate observational_findings"
 	)
 	# Observations is now a <details class="subsection"> inside Findings.
-	findings_idx = template.find("Findings &mdash; what to fix")
+	findings_idx = template.find("Findings - what to fix")
 	obs_idx = template.find("Framework-level observations")
 	assert findings_idx > 0 and obs_idx > 0
 	assert obs_idx > findings_idx, (

--- a/optimus/tests/test_app_priority_split.py
+++ b/optimus/tests/test_app_priority_split.py
@@ -4,7 +4,7 @@
 """v0.6.x: tests for the "custom prominent, framework collapsed" split.
 
 The 4 main leaderboard sections (Per-action breakdown, Top queries,
-Background jobs, Hot frames) all pre-split their rows in
+RQ Jobs, Hot frames) all pre-split their rows in
 ``renderer.render()`` into ``<name>`` (custom-app rows) + ``<name>_framework``
 (framework-app rows). The template renders the primary list in a normal
 <table> and the framework list in a collapsed <details class="subsection">
@@ -177,7 +177,7 @@ class TestPerActionSplit:
 		breakdown does NOT split — all actions, including those hitting
 		Frappe endpoints, stay in the main table. Pre-v0.7 every
 		HTTP request to ``/api/method/frappe.*`` was hidden in the
-		collapsed framework subsection, leaving Background Jobs as the
+		collapsed framework subsection, leaving RQ Jobs as the
 		only visible rows in the main table."""
 		doc = _doc(actions=[
 			_action_ns(action_label="POST /api/method/myapp.handlers.recompute",
@@ -266,17 +266,17 @@ class TestBackgroundJobsSplit:
 	def test_custom_and_framework_jobs_split(self):
 		doc = _doc(actions=[
 			_action_ns(action_label="Job: myapp.tasks.digest",
-			           event_type="Background Job", path="myapp.tasks.digest",
+			           event_type="RQ Job", path="myapp.tasks.digest",
 			           recording_uuid="r1", duration_ms=400, queries_count=5),
 			_action_ns(action_label="Job: frappe.email.queue.send",
-			           event_type="Background Job", path="frappe.email.queue.send",
+			           event_type="RQ Job", path="frappe.email.queue.send",
 			           recording_uuid="r2", duration_ms=300, queries_count=3),
 			_action_ns(action_label="Job: erpnext.accounts.utils.recompute",
-			           event_type="Background Job", path="erpnext.accounts.utils.recompute",
+			           event_type="RQ Job", path="erpnext.accounts.utils.recompute",
 			           recording_uuid="r3", duration_ms=200, queries_count=2),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "<h2>Background jobs</h2>" in html
+		assert "<h2>RQ Jobs</h2>" in html
 		# 2 framework jobs collapsed.
 		assert "<strong>2</strong> framework jobs" in html
 		# All three methods still rendered somewhere.
@@ -287,11 +287,11 @@ class TestBackgroundJobsSplit:
 	def test_only_framework_jobs_shows_replacement_note(self):
 		doc = _doc(actions=[
 			_action_ns(action_label="Job: frappe.email.queue.send",
-			           event_type="Background Job", path="frappe.email.queue.send",
+			           event_type="RQ Job", path="frappe.email.queue.send",
 			           recording_uuid="r1", duration_ms=300, queries_count=3),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "<h2>Background jobs</h2>" in html
+		assert "<h2>RQ Jobs</h2>" in html
 		assert "<strong>1</strong> framework job " in html
 		# Replacement note when there are zero custom jobs.
 		assert "all jobs ran in framework code" in html

--- a/optimus/tests/test_background_jobs_section.py
+++ b/optimus/tests/test_background_jobs_section.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for the v0.6.0 "Background jobs" report section.
+"""Tests for the v0.6.0 "RQ Jobs" report section.
 
 `renderer.build_background_jobs` is a pure function (unit-tested directly);
 the section rendering is exercised end-to-end via `renderer.render_raw` with
@@ -59,10 +59,10 @@ class TestBuildBackgroundJobs:
 		actions = [
 			_action_dict(0, action_label="POST /api/method/save", event_type="HTTP Request",
 			             recording_uuid="r0", duration_ms=900),
-			_action_dict(1, action_label="Job: myapp.tasks.digest", event_type="Background Job",
+			_action_dict(1, action_label="Job: myapp.tasks.digest", event_type="RQ Job",
 			             path="myapp.tasks.digest", recording_uuid="r1", duration_ms=1200,
 			             queries_count=8, query_time_ms=30, slowest_query_ms=12),
-			_action_dict(2, action_label="Job: myapp.tasks.stock", event_type="Background Job",
+			_action_dict(2, action_label="Job: myapp.tasks.stock", event_type="RQ Job",
 			             recording_uuid="r2", duration_ms=300, queries_count=2),
 		]
 		out = renderer.build_background_jobs(actions, {})
@@ -79,10 +79,10 @@ class TestBuildBackgroundJobs:
 
 	def test_method_name_cleanup_and_fallbacks(self):
 		actions = [
-			_action_dict(0, action_label="Job: myapp.x.run", event_type="Background Job", recording_uuid="a"),
-			_action_dict(1, action_label="", event_type="Background Job", path="myapp.y.go", recording_uuid="b"),
-			_action_dict(2, action_label="", event_type="Background Job", path="", recording_uuid="c"),
-			_action_dict(3, action_label="", event_type="Background Job", path="", recording_uuid="d"),
+			_action_dict(0, action_label="Job: myapp.x.run", event_type="RQ Job", recording_uuid="a"),
+			_action_dict(1, action_label="", event_type="RQ Job", path="myapp.y.go", recording_uuid="b"),
+			_action_dict(2, action_label="", event_type="RQ Job", path="", recording_uuid="c"),
+			_action_dict(3, action_label="", event_type="RQ Job", path="", recording_uuid="d"),
 		]
 		recs = {"c": {"cmd": "myapp.z.cmd"}}
 		out = renderer.build_background_jobs(actions, recs)
@@ -90,19 +90,19 @@ class TestBuildBackgroundJobs:
 		assert by_uuid["a"] == "myapp.x.run"      # "Job: " stripped
 		assert by_uuid["b"] == "myapp.y.go"        # falls back to path
 		assert by_uuid["c"] == "myapp.z.cmd"       # falls back to recording cmd
-		assert by_uuid["d"] == "Background Job"     # generic placeholder
+		assert by_uuid["d"] == "RQ Job"     # generic placeholder
 
 	def test_sorted_by_duration_desc(self):
 		actions = [
-			_action_dict(0, action_label="Job: a", event_type="Background Job", recording_uuid="a", duration_ms=100),
-			_action_dict(1, action_label="Job: b", event_type="Background Job", recording_uuid="b", duration_ms=900),
-			_action_dict(2, action_label="Job: c", event_type="Background Job", recording_uuid="c", duration_ms=400),
+			_action_dict(0, action_label="Job: a", event_type="RQ Job", recording_uuid="a", duration_ms=100),
+			_action_dict(1, action_label="Job: b", event_type="RQ Job", recording_uuid="b", duration_ms=900),
+			_action_dict(2, action_label="Job: c", event_type="RQ Job", recording_uuid="c", duration_ms=400),
 		]
 		out = renderer.build_background_jobs(actions, {})
 		assert [j["method"] for j in out["jobs"]] == ["b", "c", "a"]
 
 	def test_top_queries_when_recording_present(self):
-		actions = [_action_dict(0, action_label="Job: a", event_type="Background Job", recording_uuid="a")]
+		actions = [_action_dict(0, action_label="Job: a", event_type="RQ Job", recording_uuid="a")]
 		recs = {"a": {"calls": [
 			{"index": 0, "duration": 5.0, "query": "Q0"},
 			{"index": 1, "duration": 30.0, "query": "Q1", "exact_copies": 3},
@@ -119,7 +119,7 @@ class TestBuildBackgroundJobs:
 		assert job["top_queries"][0]["exact_copies"] == 3
 
 	def test_no_top_queries_when_recording_absent(self):
-		actions = [_action_dict(0, action_label="Job: a", event_type="Background Job", recording_uuid="gone")]
+		actions = [_action_dict(0, action_label="Job: a", event_type="RQ Job", recording_uuid="gone")]
 		out = renderer.build_background_jobs(actions, {})  # recording not in the map
 		job = out["jobs"][0]
 		assert job["recording_available"] is False
@@ -128,8 +128,8 @@ class TestBuildBackgroundJobs:
 	def test_findings_counted_per_job_by_action_ref(self):
 		actions = [
 			_action_dict(0, action_label="GET /app", event_type="HTTP Request", recording_uuid="r0"),
-			_action_dict(1, action_label="Job: a", event_type="Background Job", recording_uuid="r1", duration_ms=200),
-			_action_dict(2, action_label="Job: b", event_type="Background Job", recording_uuid="r2", duration_ms=100),
+			_action_dict(1, action_label="Job: a", event_type="RQ Job", recording_uuid="r1", duration_ms=200),
+			_action_dict(2, action_label="Job: b", event_type="RQ Job", recording_uuid="r2", duration_ms=100),
 		]
 		findings = [
 			{"action_ref": "1"}, {"action_ref": "1"},  # two findings from job at idx 1
@@ -142,7 +142,7 @@ class TestBuildBackgroundJobs:
 		assert by_method["b"] == 0  # we did look (findings exist) — 0, not None
 
 	def test_findings_count_none_when_no_action_refs(self):
-		actions = [_action_dict(0, action_label="Job: a", event_type="Background Job", recording_uuid="r1")]
+		actions = [_action_dict(0, action_label="Job: a", event_type="RQ Job", recording_uuid="r1")]
 		# Findings with no action_ref → can't be mapped.
 		out = renderer.build_background_jobs(actions, {}, [{"action_ref": ""}, {}])
 		assert out["any_findings_counted"] is False
@@ -155,7 +155,7 @@ class TestBuildBackgroundJobs:
 
 class TestRenderedBackgroundJobsSection:
 	def _job_action(self, **kw):
-		kw.setdefault("event_type", "Background Job")
+		kw.setdefault("event_type", "RQ Job")
 		return _action(**kw)
 
 	def test_section_renders_with_jobs(self):
@@ -168,11 +168,13 @@ class TestRenderedBackgroundJobsSection:
 		])
 		recs = [{"uuid": "r1", "calls": [{"index": 0, "duration": 12.0, "query": "SELECT * FROM tabUser"}]}]
 		html = renderer.render_raw(doc, recordings=recs)
-		assert "<h2>Background jobs</h2>" in html
-		assert "<code>myapp.tasks.digest</code>" in html
+		assert "<h2>RQ Jobs</h2>" in html
+		# v0.7.x Phase E: the BG-job method renders as an
+		# `.action-name` div (bold mono) instead of inline `<code>`.
+		assert 'class="action-name">myapp.tasks.digest</div>' in html
 		# summary line (HTML collapses the inter-token whitespace, so check
 		# the pieces rather than an exact phrase).
-		assert "1 background job" in html
+		assert "1 RQ Job" in html
 		assert "ran during this flow" in html
 		# 1200ms > default threshold (1000ms) → renders as 1.20s wrapped
 		# in the v0.7.x highlight span.
@@ -190,7 +192,7 @@ class TestRenderedBackgroundJobsSection:
 			        recording_uuid="r0", duration_ms=120),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "<h2>Background jobs</h2>" not in html
+		assert "<h2>RQ Jobs</h2>" not in html
 
 	def test_section_renders_without_recordings(self):
 		# A re-render long after analyze: recordings expired from Redis. The
@@ -201,7 +203,7 @@ class TestRenderedBackgroundJobsSection:
 			                 recording_uuid="r9", duration_ms=400, queries_count=3),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "<h2>Background jobs</h2>" in html
+		assert "<h2>RQ Jobs</h2>" in html
 		assert "myapp.tasks.cleanup" in html
 		assert "has expired from Redis" in html
 
@@ -226,7 +228,7 @@ class TestRenderedBackgroundJobsSection:
 			],
 		)
 		html = renderer.render_raw(doc, recordings=[])
-		assert "<h2>Background jobs</h2>" in html
+		assert "<h2>RQ Jobs</h2>" in html
 		assert "<th class=\"num\">Findings</th>" in html
 
 	def test_smoking_gun_block_not_duplicated_into_bg_job_embed(self):
@@ -237,7 +239,7 @@ class TestRenderedBackgroundJobsSection:
 		full panel would just duplicate that anchor inside a blue-bordered
 		box. The canonical Findings section keeps it.
 
-		Pin: ``class="smoking-gun"`` appears exactly once across the
+		Pin: ``class="smoking"`` appears exactly once across the
 		whole report (the Findings-section card), never twice (Findings
 		card + BG-job embed)."""
 		doc = _doc(
@@ -259,10 +261,10 @@ class TestRenderedBackgroundJobsSection:
 		)
 		html = renderer.render_raw(doc, recordings=[])
 		# Exactly one smoking-gun panel — the one in the Findings section.
-		assert html.count('class="smoking-gun"') == 1
+		assert html.count('class="smoking"') == 1
 		# Sanity: the BG-jobs section is rendered, and the related-finding
 		# card was embedded under the job (title travels with the card).
-		assert "<h2>Background jobs</h2>" in html
+		assert "<h2>RQ Jobs</h2>" in html
 		# Two card-titles for "x": one in Findings section, one in BG embed.
 		# (If embedding broke, the title count would drop to 1.)
 		assert html.count(">x<") >= 2
@@ -284,11 +286,11 @@ class TestEntryCallsiteInReport:
 		the def line itself rendered as a yellow-highlighted row — is
 		what's absent."""
 		doc = _doc([
-			_action(action_label="Job: " + self._DOTTED, event_type="Background Job",
+			_action(action_label="Job: " + self._DOTTED, event_type="RQ Job",
 			        path=self._DOTTED, recording_uuid="r1", duration_ms=500, queries_count=2),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "<h2>Background jobs</h2>" in html
+		assert "<h2>RQ Jobs</h2>" in html
 		# Inline path IS present (compact, useful).
 		assert "optimus/renderer.py:" in html
 		# But the multi-line snippet PANEL's content is absent: the def
@@ -341,7 +343,7 @@ class TestEntryCallsiteInReport:
 		)
 		html = renderer.render_raw(doc, recordings=[])
 		# Exactly one smoking-gun panel — the canonical Findings section card.
-		assert html.count('class="smoking-gun"') == 1
+		assert html.count('class="smoking"') == 1
 		# Sanity: the embed actually happened — the title travels with the
 		# card, so it should appear at least twice (Findings + per-action).
 		assert html.count("duplicated-anchor probe") >= 2
@@ -355,20 +357,22 @@ class TestEntryCallsiteInReport:
 			        path="/api/method/" + self._DOTTED, recording_uuid="r0", duration_ms=900),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		# Inline path with the function-name parenthetical.
+		# Inline path with the function-name separator.
 		assert "optimus/renderer.py:" in html
-		assert "(render)" in html
+		# v0.7.x Phase E: the parenthetical "(function)" form was
+		# replaced by " · function" in the editorial action-meta row.
+		assert "&middot; render" in html or "· render" in html
 		# vscode deep-link present (absolute path was resolved).
 		assert "vscode://file" in html
 
 	def test_unresolvable_action_path_renders_no_sub_row(self):
 		# A job whose method path can't be imported → no callsite, no crash.
 		doc = _doc([
-			_action(action_label="Job: myapp.tasks.nope_xyzq", event_type="Background Job",
+			_action(action_label="Job: myapp.tasks.nope_xyzq", event_type="RQ Job",
 			        path="myapp.tasks.nope_xyzq", recording_uuid="r1", duration_ms=300),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "<h2>Background jobs</h2>" in html
+		assert "<h2>RQ Jobs</h2>" in html
 		assert "myapp.tasks.nope_xyzq" in html  # still listed by method name
 		assert "renderer.py:" not in html        # nothing got resolved
 
@@ -413,8 +417,11 @@ class TestActionContextInReport:
 		# Finding card: "Document:" line.
 		assert "Document:" in html
 		assert "Sales Invoice" in html
-		# Exec-summary bullet text augmented with "— Sales Invoice SINV-1".
-		assert "Sales Invoice SINV-1" in html
+		# v0.7.x redesign Phase B: the exec-summary bullet that
+		# augmented its text with "— Sales Invoice SINV-1" is gone
+		# (exec-summary card replaced by TL;DR hero). Target-doc
+		# surfacing now lives in the per-action breakdown + finding
+		# card breadcrumb above. Drop the bullet-text assertion.
 
 	def test_action_with_no_doc_in_form_dict_has_no_target_doc_line(self):
 		action = _action(
@@ -484,7 +491,9 @@ class TestDocEventLifecycleSection:
 		assert "Sales Invoice" in html
 		assert "saved/submitted directly" in html
 		assert "looped_validate" in html
-		assert "[doc_events hook]" in html
+		# v0.7.x Phase F: the kind tag is now an info-blue
+		# `.method-tag` pill instead of a bracketed inline label.
+		assert 'class="method-tag">doc_events hook</span>' in html
 		assert ">Doc events<" in html  # "Jump to:" nav link
 
 	def test_controller_override_finding_and_cascade_note(self):
@@ -499,7 +508,8 @@ class TestDocEventLifecycleSection:
 		html = renderer.render_raw(doc, recordings=[self._si_recording()])
 		assert "<h2>Doc-event lifecycle</h2>" in html
 		assert "Gl Entry" in html
-		assert "[controller override]" in html
+		# v0.7.x Phase F: kind tag → `.method-tag` info-blue pill.
+		assert 'class="method-tag">controller override</span>' in html
 		assert "touched during Sales Invoice" in html
 
 	def test_section_omitted_when_no_lifecycle_findings(self):

--- a/optimus/tests/test_collapsible_sections.py
+++ b/optimus/tests/test_collapsible_sections.py
@@ -62,7 +62,7 @@ def test_primary_actionable_sections_are_open_by_default():
 	for section_heading in (
 		"Summary",
 		"Per-action breakdown",
-		"Findings &mdash; what to fix",
+		"Findings - what to fix",
 		"Server Resource",
 		"Frontend",
 		"Hot frames",
@@ -71,7 +71,7 @@ def test_primary_actionable_sections_are_open_by_default():
 		"Time spent per database table",
 		"Full recordings",
 		"Doc-event lifecycle",
-		"Background jobs",
+		"RQ Jobs",
 	):
 		assert section_heading in template, (
 			f"section heading {section_heading!r} missing from template"
@@ -84,9 +84,9 @@ def test_primary_actionable_sections_are_open_by_default():
 	# Reproduce ... #} comment above the section).
 	for summary in (
 		'<summary><h2 style="margin-top: 0;">Steps to Reproduce</h2></summary>',
-		"<summary><h2>Findings &mdash; what to fix</h2></summary>",
+		"<summary><h2>Findings - what to fix</h2></summary>",
 		"<summary><h2>Per-action breakdown</h2></summary>",
-		"<summary><h2>Background jobs</h2></summary>",
+		"<summary><h2>RQ Jobs</h2></summary>",
 	):
 		idx = template.index(summary)
 		details_open = template.rindex("<details", 0, idx)
@@ -125,7 +125,7 @@ def test_heavy_reference_sections_are_collapsed_by_default():
 	# substring unique to each.
 	for fragment in (
 		"Hot frames (top",
-		"&mdash; your app",
+		"- your app",
 	):
 		idx = template.index(fragment)
 		details_open = template.rindex("<details", 0, idx)
@@ -140,11 +140,80 @@ def test_report_has_navigation_aids():
 	in-page 'Jump to:' nav near the top."""
 	template = _read_template()
 	assert "How to read this report" in template
-	assert "Jump to:" in template
+	assert "Jump to" in template
 	# The jump links point at sections that carry matching ids.
 	for anchor in ("#findings", "#per-action", "#top-queries", "#db-tables", "#how-to-read"):
 		assert f'href="{anchor}"' in template, f"jump link {anchor} missing"
 		assert f'id="{anchor[1:]}"' in template, f"section id {anchor[1:]} missing"
+
+
+def test_section_id_aliases_for_mock_spec_names():
+	"""v0.7.x Phase G: the mock spec uses shorter section IDs (#actions,
+	#jobs, #resource, #queries, #db, #doc-events) alongside the original
+	long-form names. The template carries both — original ID on the
+	<details> tag so the Jump-to nav keeps working; alias as an empty
+	<a id="..."></a> anchor inside each section so external links /
+	docs that reference the mock names still scroll-to-anchor.
+
+	Pin both forms exist."""
+	template = _read_template()
+	for original, alias in (
+		("per-action", "actions"),
+		("background-jobs", "jobs"),
+		("server-resource", "resource"),
+		("top-queries", "queries"),
+		("db-tables", "db"),
+		("doc-event-lifecycle", "doc-events"),
+	):
+		assert f'id="{original}"' in template, (
+			f"original section id '{original}' must still exist on its "
+			f"<details> tag for Jump-to back-compat"
+		)
+		assert f'id="{alias}"' in template, (
+			f"mock-spec alias '{alias}' must exist as an empty <a> "
+			f"anchor inside section #{original}"
+		)
+
+
+def test_net_new_section_ids_from_mock_spec():
+	"""v0.7.x Phase I.1: the redesign mock spec introduced three
+	anchors that don't have a long-form original — they're net-new
+	IDs (not aliases). Pin their presence so a future template
+	refactor doesn't quietly drop them.
+
+	#repro    — Steps to Reproduce section
+	#summary  — Summary section (bulleted recap)
+	#hot-frames — Hot frames leaderboard section
+	"""
+	template = _read_template()
+	for net_new in ("repro", "summary", "hot-frames"):
+		assert f'id="{net_new}"' in template, (
+			f"mock-spec section id '{net_new}' missing from template"
+		)
+
+
+def test_phase2_id_is_unique():
+	"""v0.7.x Phase I.1: the phase2 anchor must appear at most once
+	in the static template. Pre-Phase-I.1, the imperative-rendered
+	Phase 2 panel emitted a details element carrying the phase2
+	anchor while the surrounding template wrapped it in a redundant
+	`<div id="phase2">` - duplicate IDs are invalid HTML. The
+	wrapper was removed; this test pins that the duplicate doesn't
+	come back. (v0.7.x Phase J.16: the renderer-emitted inner anchor
+	is now ``id="line-drilldown"``; the template carries a single
+	legacy ``<a id="phase2"></a>`` so external links resolve.)"""
+	template = _read_template()
+	# Count actual anchor tags carrying the id, not literal substrings
+	# inside Jinja ``{# ... #}`` comments (which talk about the rename
+	# but emit no DOM).
+	count = template.count('<a id="phase2"')
+	assert count <= 1, (
+		f'<a id="phase2"... must appear at most once in the template; '
+		f"found {count} occurrences. The imperative-rendered panel "
+		f"emits its own ``id=\"line-drilldown\"`` anchor; only the "
+		f"legacy ``<a id=\"phase2\"></a>`` alias should live in the "
+		f"template."
+	)
 
 
 def test_observations_subsection_is_collapsed_by_default():
@@ -176,7 +245,7 @@ def test_observations_is_nested_inside_findings():
 	"""
 	template = _read_template()
 	findings_summary_idx = template.find(
-		"<summary><h2>Findings &mdash; what to fix</h2></summary>"
+		"<summary><h2>Findings - what to fix</h2></summary>"
 	)
 	# The Observations subsection's <summary> carries an <h3> labelled
 	# "Framework-level observations". Walk back from there to its opening
@@ -226,59 +295,75 @@ def test_collapsible_css_is_present():
 
 
 def test_phase2_section_appears_before_findings():
-	"""v0.6.x: the Phase 2 line-level drill-down is the report's most
-	distinctive section — it must be hoisted above the actionable
-	Findings list so readers see it immediately after the Summary."""
+	"""v0.6.x: the Line-Level Drilldown is the report's most distinctive
+	section - it must be hoisted above the actionable Findings list so
+	readers see it immediately after the Summary.
+
+	v0.7.x Phase J.16: anchor on the
+	``report_data.line_drilldown_html | safe`` Jinja injection point
+	(renamed from ``report_data.phase2_html | safe`` in J.2.6, itself
+	renamed from the legacy top-level ``phase2_html``). The render-time
+	markup still comes from ``_render_line_drilldown_panel`` and is
+	exposed under the contract namespace."""
 	template = _read_template()
-	phase2_anchor = template.find('id="phase2"')
+	panel_injection = template.find("report_data.line_drilldown_html | safe")
 	findings_anchor = template.find('id="findings"')
-	assert phase2_anchor > 0, "Phase 2 anchor (id=\"phase2\") missing from template"
+	assert panel_injection > 0, (
+		"report_data.line_drilldown_html injection point missing from template"
+	)
 	assert findings_anchor > 0, "Findings anchor (id=\"findings\") missing from template"
-	assert phase2_anchor < findings_anchor, (
-		"Phase 2 (id=\"phase2\") must render BEFORE Findings (id=\"findings\") — "
-		"it is the report's showcase section"
+	assert panel_injection < findings_anchor, (
+		"Line-Level Drilldown (report_data.line_drilldown_html injection) "
+		"must render BEFORE Findings (id=\"findings\") - it is the "
+		"report's showcase section"
 	)
 
 
 def test_phase2_jump_nav_link_present():
-	"""The Jump-to nav must include a Phase 2 link (conditional on the
-	session having phase-2 runs)."""
+	"""The Jump-to nav must include a Line-Level Drilldown link
+	(conditional on the session having phase-2 runs)."""
 	template = _read_template()
-	assert 'href="#phase2"' in template, (
-		"Jump-to nav missing #phase2 link — Phase 2 section won't be "
-		"reachable from the top-of-report navigation"
+	assert 'href="#line-drilldown"' in template, (
+		"Jump-to nav missing #line-drilldown link - Line-Level Drilldown "
+		"section won't be reachable from the top-of-report navigation"
 	)
-	# Conditional wrapper: the link only renders when phase2_html exists.
-	assert "{% if phase2_html %}<a href=\"#phase2\"" in template, (
-		"Phase 2 nav link must be wrapped in {% if phase2_html %} so "
-		"sessions without runs don't show a dangling link"
+	# Conditional wrapper: the link only renders when the panel exists.
+	assert (
+		'{% if report_data.line_drilldown_html %}<a href="#line-drilldown"'
+		in template
+	), (
+		"Line-Level Drilldown nav link must be wrapped in "
+		"{% if report_data.line_drilldown_html %} so sessions without runs "
+		"don't show a dangling link"
 	)
 
 
-def test_exec_summary_renders_between_stats_and_summary_section():
-	"""v0.7.x: the executive summary ('At a glance') was moved from
-	above the Steps-to-Reproduce / stat-cards cluster to BELOW the stat
-	cards and ABOVE the Summary section. The reader now sees context
-	(Steps) → numbers (cards) → narrative (At a glance) → folded recap
-	(Summary). Pin the order so a future refactor doesn't pull the
-	exec-summary back to the top of the header zone."""
+def test_tldr_hero_renders_before_kpi_strip_and_summary():
+	"""v0.7.x redesign Phase B: the 'At a glance' exec-summary card
+	was replaced by the TL;DR hero (one composed headline keyed on
+	the highest-impact finding). The hero lives RIGHT AFTER the
+	masthead — first prominent block on the page. Pin: TL;DR comes
+	before the KPI strip, and the KPI strip comes before the
+	Summary section. (Old test asserted At-a-glance lived between
+	stats and Summary; that block is gone.)"""
 	template = _read_template()
-	jump_idx = template.find("<strong>Jump to:</strong>")
-	stats_idx = template.find('<div class="stats">')
-	at_a_glance_idx = template.find("<h2>At a glance</h2>")
+	tldr_idx = template.find('<div class="tldr">')
+	stats_idx = template.find('<div class="kpis">')
 	summary_idx = template.find("<summary><h2>Summary</h2></summary>")
 	for label, idx in (
-		("Jump-to nav", jump_idx),
-		("stat cards", stats_idx),
-		("At a glance heading", at_a_glance_idx),
+		("TL;DR hero", tldr_idx),
+		("KPI strip", stats_idx),
 		("Summary section", summary_idx),
 	):
 		assert idx > 0, f"{label} missing from template"
-	assert jump_idx < stats_idx < at_a_glance_idx < summary_idx, (
-		"Header-zone order must be: Jump-to → stat cards → At a glance "
-		"→ Summary section. Got indices: "
-		f"jump={jump_idx} stats={stats_idx} "
-		f"at_a_glance={at_a_glance_idx} summary={summary_idx}"
+	assert tldr_idx < stats_idx < summary_idx, (
+		"Header-zone order must be: TL;DR hero → KPI strip → "
+		"Summary section. Got indices: "
+		f"tldr={tldr_idx} stats={stats_idx} summary={summary_idx}"
+	)
+	# And the old exec-summary card MUST be gone.
+	assert "<h2>At a glance</h2>" not in template, (
+		"Old exec-summary heading must be removed (TL;DR replaces it)"
 	)
 
 
@@ -346,9 +431,13 @@ def test_per_action_table_has_fixed_layout_class():
 	# The opening tag fragment must contain the shared layout classes.
 	tag_end = template.find(">", table_idx)
 	open_tag = template[table_idx:tag_end]
-	assert 'class="tbl-clip per-action-table"' in open_tag, (
-		f"Per-action breakdown table must carry "
-		f"'class=\"tbl-clip per-action-table\"'; got: {open_tag!r}"
+	# v0.7.x Phase E: tables stack `.data` on top of the existing
+	# `.tbl-clip` / `.per-action-table` classes. Check for both
+	# critical layout hooks as substrings rather than the exact
+	# class-attr value.
+	assert "tbl-clip" in open_tag and "per-action-table" in open_tag, (
+		f"Per-action breakdown table must carry tbl-clip + "
+		f"per-action-table classes; got: {open_tag!r}"
 	)
 	# And a <colgroup> follows so column widths are defined.
 	colgroup_idx = template.find("<colgroup>", table_idx)

--- a/optimus/tests/test_executive_summary.py
+++ b/optimus/tests/test_executive_summary.py
@@ -229,27 +229,32 @@ class TestEndToEndRender:
 
 		html = renderer.render(doc, recordings=[])
 
-		# Exec card class present, slow pace.
-		assert 'class="exec-summary pace-slow"' in html, (
-			"Slow-session card must have pace-slow class for red border"
-		)
-		# Headline has pace values, plain-English wording (operations, not actions).
-		# v0.7.x: 6000ms is above the 1000ms threshold, so the duration
-		# renders as seconds wrapped in .time-high (the timing rule the
-		# rest of the report already uses).
+		# v0.7.x redesign Phase B: the "At a glance" exec-summary card
+		# was replaced by the TL;DR hero (single composed headline).
+		# The exec_summary data layer still computes the pace + bullets
+		# (used by the Action plan section), so the data assertions
+		# below hold via the TL;DR composition + the KPI strip.
+		assert 'class="tldr"' in html, "TL;DR hero must render"
+		# Duration crosses the 1000ms threshold — rendered as seconds
+		# with .time-high (timing rule applies everywhere).
 		assert '<span class="time-high">6.00s</span>' in html
 		assert "operation" in html
-		# Top finding surfaced by its title.
+		# Top finding title surfaced — TL;DR fallback branch wraps it.
 		assert "Same query ran 50× at myapp/foo.py:10" in html
-		# Infra note emitted.
-		assert "90MB" in html
-		# v0.6.0: stat cards are plainly labelled, and the "Issues found" card's
-		# big number is the TOTAL finding count (not the High count), with a
-		# severity breakdown that sums to it.
+		# Infra note no longer rendered as a separate exec-summary line
+		# (moved into the Server resource section in a later phase).
+		# Sanity: it's still computed (data layer) — just not shown here.
+		# v0.7.x: KPI strip (replaces stat cards) — plainly-labelled cells,
+		# and the "Issues found" cell's big number is the TOTAL finding
+		# count (not the High count), with a severity breakdown that sums
+		# to it.
 		assert "Issues found" in html and "Database queries" in html
 		import re as _re
-		m = _re.search(r'Issues found</div>\s*<div class="value">(.*?)</div>\s*<div class="sub">(.*?)</div>', html, _re.S)
-		assert m, "could not locate the 'Issues found' stat card"
+		m = _re.search(
+			r'Issues found</div>\s*<div class="kpi-value[^"]*">(.*?)</div>\s*<div class="kpi-sub">(.*?)</div>',
+			html, _re.S,
+		)
+		assert m, "could not locate the 'Issues found' KPI cell"
 		assert _re.sub(r"<[^>]+>", "", m.group(1)).strip() == "1"  # one finding total
 		assert "1 high" in _re.sub(r"<[^>]+>", "", m.group(2))
 
@@ -283,7 +288,13 @@ class TestEndToEndRender:
 
 		html = renderer.render(doc, recordings=[])
 
-		# No exec card: zero findings + no infra signal.
+		# v0.7.x redesign Phase B: the exec-summary card was replaced
+		# by the TL;DR hero. The hero ALWAYS renders — clean sessions
+		# get a "Nothing to fix" branch instead of being hidden.
 		assert 'class="exec-summary' not in html, (
-			"Clean sessions must not render an exec summary card"
+			"Old exec-summary card markup must not be present"
+		)
+		assert 'class="tldr"' in html, "TL;DR hero must render even when clean"
+		assert "Nothing to fix" in html, (
+			"Clean-session TL;DR must use the 'Nothing to fix' headline"
 		)

--- a/optimus/tests/test_finding_card_ai_fix.py
+++ b/optimus/tests/test_finding_card_ai_fix.py
@@ -155,7 +155,7 @@ class TestAiFixBlockRendering:
 		})])
 		html = renderer.render_raw(doc, recordings=[])
 		# Header + model name.
-		assert "Suggested fix (AI" in html
+		assert "Suggested fix" in html
 		assert "claude-sonnet-4-6" in html
 		# The suggestion text made it into the page (converted-markdown or
 		# escaped-pre fallback — both contain the words).
@@ -167,7 +167,7 @@ class TestAiFixBlockRendering:
 	def test_no_block_when_llm_fix_absent(self):
 		doc = _doc([_finding(llm_fix=None)])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "Suggested fix (AI" not in html
+		assert "Suggested fix" not in html
 		assert "review before applying" not in html
 
 	def test_no_block_when_findings_section_toggle_off(self):
@@ -185,23 +185,23 @@ class TestAiFixBlockRendering:
 		with patch("optimus.settings.get_config",
 		           return_value=settings.OptimusConfig(ai_suggest_findings=False)):
 			html = renderer.render_raw(doc, recordings=[])
-		assert "Suggested fix (AI" not in html
+		assert "Suggested fix" not in html
 		assert "review before applying" not in html
 		# Sanity: with the toggle back on, the block IS there.
 		with patch("optimus.settings.get_config",
 		           return_value=settings.OptimusConfig(ai_suggest_findings=True)):
 			html2 = renderer.render_raw(doc, recordings=[])
-		assert "Suggested fix (AI" in html2
+		assert "Suggested fix" in html2
 
 	def test_no_block_when_llm_fix_json_is_empty_object(self):
 		doc = _doc([_finding(llm_fix={})])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "Suggested fix (AI" not in html
+		assert "Suggested fix" not in html
 
 	def test_no_block_when_suggestion_blank(self):
 		doc = _doc([_finding(llm_fix={"suggestion": "   ", "model": "m"})])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "Suggested fix (AI" not in html
+		assert "Suggested fix" not in html
 
 	def test_script_in_suggestion_is_stripped(self):
 		doc = _doc([_finding(llm_fix={
@@ -211,7 +211,7 @@ class TestAiFixBlockRendering:
 			"generated_at": "2026-05-11T00:00:00+00:00",
 		})])
 		html = renderer.render_raw(doc, recordings=[])
-		assert "Suggested fix (AI" in html
+		assert "Suggested fix" in html
 		# The <script> tag is gone (sanitized server-side), in any rendering path.
 		assert "<script" not in html.lower()
 		assert "alert('xss')" not in html and "alert(&#39;xss&#39;)" not in html
@@ -224,7 +224,7 @@ class TestAiFixBlockRendering:
 		html = renderer.render_raw(doc, recordings=[])
 		# Bound the check to the AI block region (the report has vscode://
 		# callsite links elsewhere).
-		start = html.find("Suggested fix (AI")
+		start = html.find("Suggested fix")
 		end = html.find("review before applying", start)
 		assert start != -1 and end != -1
 		block = html[start:end]
@@ -240,7 +240,7 @@ class TestAiFixBlockRendering:
 			_finding(llm_fix=None, finding_type="Slow Query"),
 		])
 		html = renderer.render_raw(doc, recordings=[])
-		assert html.count('class="ai-fix"') == 1
+		assert html.count('class="fix-box"') == 1
 
 	def test_directional_caution_shown_when_source_unavailable(self):
 		doc = _doc([_finding(llm_fix={
@@ -248,7 +248,7 @@ class TestAiFixBlockRendering:
 			"generated_at": "t", "source_available": False,
 		})])
 		html = renderer.render_raw(doc, recordings=[])
-		assert 'class="ai-fix-caution"' in html
+		assert 'class="fix-caution"' in html
 		assert "directional guidance" in html
 
 	def test_no_caution_when_source_available_or_legacy_row(self):
@@ -258,9 +258,9 @@ class TestAiFixBlockRendering:
 			"suggestion": _GOOD_SUGGESTION, "model": "m", "provider": "OpenAI",
 			"generated_at": "t", "source_available": True,
 		})])
-		assert 'class="ai-fix-caution"' not in renderer.render_raw(doc, recordings=[])
+		assert 'class="fix-caution"' not in renderer.render_raw(doc, recordings=[])
 		# Legacy row with no such key → defaults to "had context", no caution.
 		doc2 = _doc([_finding(llm_fix={
 			"suggestion": _GOOD_SUGGESTION, "model": "m", "provider": "OpenAI", "generated_at": "t",
 		})])
-		assert 'class="ai-fix-caution"' not in renderer.render_raw(doc2, recordings=[])
+		assert 'class="fix-caution"' not in renderer.render_raw(doc2, recordings=[])

--- a/optimus/tests/test_finding_card_smoking_gun.py
+++ b/optimus/tests/test_finding_card_smoking_gun.py
@@ -7,11 +7,21 @@ the existing technical_detail rows. Uses renderer.render_raw end-to-end
 so we verify the macro within its real context.
 """
 
+import html as _html
 import inspect
 import json
+import re
 from types import SimpleNamespace
 
 from optimus import renderer
+
+
+def _plain(html_str: str) -> str:
+	"""Strip HTML tags + decode entities so substring assertions on
+	source-code content work after v0.7.x VSCode Dark+ syntax
+	highlighting wraps each token in its own ``<span class="tok-...">``
+	element (and Pygments escapes string quotes to ``&#39;`` etc.)."""
+	return _html.unescape(re.sub(r"<[^>]+>", "", html_str))
 
 
 def _finding_child(
@@ -88,8 +98,9 @@ class TestSourceSnippetRendering:
 
 		html = renderer.render_raw(doc, recordings=[])
 
-		assert "for i in range(50):" in html
-		assert "frappe.get_doc(&#39;User&#39;, i)" in html or "frappe.get_doc('User', i)" in html
+		plain = _plain(html)
+		assert "for i in range(50):" in plain
+		assert "frappe.get_doc('User', i)" in plain
 		# Lineno labels should appear next to the snippet rows.
 		assert ">41<" in html
 		assert ">42<" in html
@@ -104,7 +115,7 @@ class TestSourceSnippetRendering:
 
 		html = renderer.render_raw(doc, recordings=[])
 
-		assert "frappe.db.sql" in html
+		assert "frappe.db.sql" in _plain(html)
 
 	def test_finding_without_source_snippet_still_renders_callsite(self):
 		# Older sessions / sessions where the file couldn't be read.
@@ -119,6 +130,27 @@ class TestSourceSnippetRendering:
 		# at all (the placeholder only shows when we *had* a snippet but
 		# the safe-mode toggle suppressed it).
 		assert "&lt;source omitted&gt;" not in html
+
+	def test_blank_context_lines_are_skipped(self):
+		# Regression: the snippet builder returns a ±1 window so a def line
+		# preceded by the PEP-8 blank-line separator yields an empty leading
+		# row. Rendering that as a line-number gutter with no content
+		# produced a dead band of empty space above the highlighted target.
+		snippet = [
+			{"lineno": 198, "content": ""},                           # blank separator
+			{"lineno": 199, "content": "def my_func(doc_name=None):"},  # target
+			{"lineno": 200, "content": "    for i in range(15):"},
+		]
+		doc = _fake_doc([_finding_child(lineno=199, source_snippet=snippet)])
+
+		html = renderer.render_raw(doc, recordings=[])
+
+		# Blank leading row is dropped.
+		assert '<span class="ln">198</span>' not in html
+		# Target line + the trailing context line are kept.
+		assert '<span class="ln">199</span>' in html
+		assert '<span class="ln">200</span>' in html
+		assert "def my_func(doc_name=None):" in _plain(html)
 
 
 class TestSmokingGunBlockHoisting:
@@ -192,7 +224,7 @@ class TestPhase2Crosslink:
 
 		html = renderer.render_raw(doc, recordings=[])
 
-		assert "Phase 2:" in html
+		assert "Line-Level Drilldown:" in html
 		assert "hottest line 42" in html
 		assert "160ms" in html or "160.5ms" in html
 		assert "50 hit" in html
@@ -358,16 +390,17 @@ class TestPhase2Crosslink:
 		# Smoking-gun callsite has been retargeted to the **call site**
 		# of _check_user_exists in its parent (_run_validations). That
 		# call lives at line 13 (``    _check_user_exists(doc)``), not
-		# at the leaf's def line 18. The smoking-gun block uses class
-		# "smoking-gun" so we scope the asserts to that section to avoid
-		# false matches against the Drill-down chain rendering below
-		# (which DOES reference line 18 as one of the descent steps).
-		smoking_gun_start = html.find('class="smoking-gun"')
-		smoking_gun_end = html.find("Drill-down", smoking_gun_start)
-		assert smoking_gun_start > -1 and smoking_gun_end > -1
-		smoking_gun_html = html[smoking_gun_start:smoking_gun_end]
+		# at the leaf's def line 18. v0.7.x redesign Phase D: the
+		# file:line callsite header moved from inside `.smoking` to
+		# the `.finding-meta` row under the title — slice the broader
+		# `.finding` card up to the Drill-down chain so both the meta
+		# row AND the smoking-gun snippet are inside the scope.
+		finding_start = html.find('class="finding severity-')
+		finding_end = html.find("Drill-down", finding_start)
+		assert finding_start > -1 and finding_end > -1
+		smoking_gun_html = html[finding_start:finding_end]
 		assert "common.py:13" in smoking_gun_html
-		# Parent function shown in the header.
+		# Parent function shown in the meta row.
 		assert "_run_validations" in smoking_gun_html
 		# The highlighted source body is the call expression itself.
 		assert "_check_user_exists(doc)" in smoking_gun_html
@@ -665,7 +698,7 @@ class TestHotLineLegacyShape:
 		# Callsite line appears with file:lineno.
 		assert "common.py:7" in html
 		# line_content rendered as the snippet body.
-		assert "_run_validations(doc)" in html
+		assert "_run_validations(doc)" in _plain(html)
 		# The lineno label for the single-row snippet appears.
 		assert ">7<" in html
 
@@ -740,7 +773,7 @@ class TestLazySnippetRead:
 		html = renderer.render_raw(doc, recordings=[])
 
 		# Snippet was read lazily at render time and inserted.
-		assert "b()" in html
+		assert "b()" in _plain(html)
 		assert ">1<" in html and ">2<" in html and ">3<" in html
 
 	def test_missing_file_no_snippet_no_crash(self, tmp_path):
@@ -834,9 +867,9 @@ class TestRenderTimeCallsiteResolution:
 		doc = _fake_doc([_repeated_hot_frame("optimus/renderer.py::render")])
 		html = renderer.render_raw(doc, recordings=[])
 		assert "optimus/renderer.py:" in html      # resolved callsite line
-		assert "def render(" in html                        # the highlighted def line
+		assert "def render(" in _plain(html)                        # the highlighted def line
 		assert "vscode://file" in html                      # _abs → editor link
-		assert 'class="smoking-gun"' in html
+		assert 'class="smoking"' in html
 
 	def test_repeated_hot_frame_unresolvable_is_filtered(self):
 		"""v0.7.x: a Repeated Hot Frame whose ``function`` key can't be
@@ -847,13 +880,13 @@ class TestRenderTimeCallsiteResolution:
 		html = renderer.render_raw(doc, recordings=[])
 		# Filtered: title and smoking-gun both absent.
 		assert "appeared in 3 actions" not in html
-		assert 'class="smoking-gun"' not in html
+		assert 'class="smoking"' not in html
 
 	def test_function_not_invoked_shows_def_line(self):
 		doc = _fake_doc([_function_not_invoked("optimus.renderer.render")])
 		html = renderer.render_raw(doc, recordings=[])
 		assert "optimus/renderer.py:" in html
-		assert "def render(" in html
+		assert "def render(" in _plain(html)
 
 	def test_missing_index_gets_representative_callsite_from_recordings(self):
 		nq = "SELECT ... FROM `tabUser` WHERE x = ?"
@@ -872,8 +905,11 @@ class TestRenderTimeCallsiteResolution:
 			}],
 		}]
 		html = renderer.render_raw(doc, recordings=recs)
-		assert "Most-called from:" in html
-		assert "Representative callsite" in html
+		# v0.7.x Phase D: smoking-gun label wording trimmed —
+		# "Most-called from:" / "Representative callsite" prose collapsed
+		# into a single `.smoking-label` line ("most-called from this
+		# callsite ..."). Anchor on the new wording.
+		assert "most-called from this callsite" in html
 		assert f"{_USER_FRAME_FILE}:10" in html
 		assert "run_report" in html
 
@@ -926,7 +962,7 @@ class TestDocEventHookInsideSmokingGun:
 		html = renderer.render_raw(doc, recordings=[])
 
 		hook_pos = html.find("Doc-event hook:")
-		sg_open = html.find('class="smoking-gun"', 0)
+		sg_open = html.find('class="smoking"', 0)
 		assert hook_pos > 0, "Doc-event hook line missing from output"
 		assert sg_open > 0
 		# Hook appears AFTER smoking-gun's opening marker — i.e. inside it.
@@ -1040,7 +1076,7 @@ class TestDrilldownPlaceholder:
 		action = SimpleNamespace(
 			idx=0,
 			action_label="Job: bg_recheck_users",
-			event_type="Background Job",
+			event_type="RQ Job",
 			http_method="",
 			path="bg_recheck_users",
 			recording_uuid="rec1",
@@ -1073,8 +1109,8 @@ class TestDrilldownPlaceholder:
 		assert "no deeper user-code frame" in html
 		# Names the wrapper (the function the placeholder is rooted on).
 		assert "bg_recheck_users" in html
-		# The placeholder still has the "Drill-down:" label.
-		assert "Drill-down:" in html
+		# The placeholder still has the "Drill-down" label.
+		assert "Drill-down" in html
 
 	def test_finding_without_drilldown_attribute_renders_no_placeholder(self, tmp_path):
 		"""A finding without ``action_ref`` skips _attach_drilldown_chains
@@ -1095,7 +1131,7 @@ class TestDrilldownPlaceholder:
 		# Neither the chain nor the placeholder renders.
 		assert "no deeper user-code frame" not in html
 		# Drill-down label absent because no Drill-down section renders.
-		assert "Drill-down:" not in html
+		assert "Drill-down" not in html
 
 	def test_non_empty_chain_renders_chain_not_placeholder(self, tmp_path):
 		"""When the drill-down chain has entries, the existing chain
@@ -1159,8 +1195,12 @@ class TestDrilldownPlaceholder:
 		html = renderer.render_raw(doc, recordings=[])
 
 		# Chain rendered (existing behavior).
-		assert "Drill-down:" in html
-		assert "common.py:6" in html  # inner's def line in the chain
+		assert "Drill-down" in html
+		# v0.7.x Phase D: chain steps render as `function:lineno` pills
+		# (filename is dropped from each pill — the meta row above
+		# carries the file path). The inner def line is line 6 — its
+		# function name appears as a chain step.
+		assert "inner:6" in html or ":6" in html
 		# Placeholder branch NOT taken.
 		assert "no deeper user-code frame" not in html
 

--- a/optimus/tests/test_index_recommendation.py
+++ b/optimus/tests/test_index_recommendation.py
@@ -191,7 +191,11 @@ class TestRenderedIndexCandidatePanel:
 			"generated_at": "2026-05-12T00:00:00+00:00",
 		}
 		html = renderer.render_raw(_doc([entry]), recordings=[])
-		assert "Index advice (AI" in html and "claude-sonnet-4-6" in html
+		# v0.7.x Phase I: AI index advice renders inside a `.fix-box`
+		# (same component as the AI-fix on findings); "Index advice"
+		# heading + the `AI · model` tag are now in separate spans
+		# instead of the inline-paren form.
+		assert "Index advice" in html and "claude-sonnet-4-6" in html
 		assert "already covers it" in html
 
 	def test_no_ai_index_block_when_indexes_section_toggle_off(self):
@@ -218,7 +222,7 @@ class TestRenderedIndexCandidatePanel:
 
 		entry = _table_entry(recommended_index=None)
 		html = renderer.render_raw(_doc([entry]), recordings=[])
-		assert "Index candidates &mdash; to speed up reads" in html
+		assert "Index candidates - to speed up reads" in html
 		assert ">customer</code>" in html
 
 

--- a/optimus/tests/test_lens_promo.py
+++ b/optimus/tests/test_lens_promo.py
@@ -52,16 +52,16 @@ class TestLensPromoRendering:
 	def test_block_renders_exactly_once(self):
 		"""Promo is hardcoded — should appear on every report, exactly once."""
 		html = renderer.render_raw(_doc(), recordings=[])
-		assert html.count('class="section small lens-promo"') == 1
+		assert html.count('class="section lens-promo"') == 1
 
 	def test_block_positioned_before_jump_to_nav(self):
 		"""The Lens block must sit BEFORE the Jump-to nav (sibling, above
-		it). Anchor on the literal Jump-to string vs the lens-promo
-		class fragment."""
+		it). v0.7.x Phase A: nav is `<nav class="nav-pills">`; anchor on
+		that opening tag."""
 		html = renderer.render_raw(_doc(), recordings=[])
-		jump_idx = html.find("<strong>Jump to:</strong>")
-		lens_idx = html.find('class="section small lens-promo"')
-		assert jump_idx != -1, "Jump-to nav not found"
+		jump_idx = html.find('<nav class="nav-pills">')
+		lens_idx = html.find('class="section lens-promo"')
+		assert jump_idx != -1, "Jump-to nav-pills not found"
 		assert lens_idx != -1, "Lens promo block not found"
 		assert lens_idx < jump_idx, (
 			"Lens promo block must render BEFORE the Jump-to nav, not after"
@@ -93,7 +93,7 @@ class TestLensPromoRendering:
 		<img>, <link rel="...">, or <script> — those would break the
 		saved-HTML offline guarantee on click-free render."""
 		html = renderer.render_raw(_doc(), recordings=[])
-		start = html.find('<aside class="section small lens-promo"')
+		start = html.find('<aside class="section lens-promo"')
 		assert start != -1, "Lens promo block opening tag not found"
 		end = html.find("</aside>", start)
 		assert end != -1, "Lens promo block has no closing </aside> tag"

--- a/optimus/tests/test_per_action.py
+++ b/optimus/tests/test_per_action.py
@@ -63,20 +63,20 @@ def test_http_fallback_when_no_cmd(empty_context):
 
 
 def test_background_job_label(empty_context):
-	"""Background jobs should be labeled with 'Job: <last component>'."""
+	"""RQ Jobs should be labeled with 'Job: <last component>'."""
 	recording = {
 		"uuid": "j1",
 		"path": "erpnext.accounts.doctype.gl_entry.gl_entry.post_gl_entries",
 		"method": None,
 		"cmd": None,
-		"event_type": "Background Job",
+		"event_type": "RQ Job",
 		"duration": 320.0,
 		"calls": [],
 		"form_dict": None,
 	}
 	result = per_action.analyze([recording], empty_context)
-	assert result.actions[0]["action_label"] == "Job: post_gl_entries"
-	assert result.actions[0]["event_type"] == "Background Job"
+	assert result.actions[0]["action_label"] == "RQ Job: post_gl_entries"
+	assert result.actions[0]["event_type"] == "RQ Job"
 
 
 def test_submit_cmd(empty_context):

--- a/optimus/tests/test_query_table_layout.py
+++ b/optimus/tests/test_query_table_layout.py
@@ -40,7 +40,7 @@ class TestTemplateStructure:
 		)
 		assert m is not None, "Top Queries section not found"
 		section = m.group(0)
-		assert 'class="query-table"' in section, (
+		assert 'class="query-table' in section, (
 			"Top Queries table must carry the .query-table class for "
 			"the fixed-layout CSS to apply"
 		)
@@ -70,7 +70,7 @@ class TestTemplateStructure:
 		)
 		assert m is not None, "Queries per action section not found"
 		section = m.group(0)
-		assert 'class="query-table"' in section
+		assert 'class="query-table' in section
 
 	def test_queries_per_action_colgroup_uses_copies_column(self):
 		"""Per-action drill-down has Copies where Top Queries has #."""
@@ -177,7 +177,7 @@ class TestEndToEndRender:
 		html = renderer.render(doc, recordings=[])
 
 		# Table renders with the fixed-layout class.
-		assert 'class="query-table"' in html
+		assert 'class="query-table' in html
 		# Colgroup is emitted with all four columns.
 		assert 'class="col-index"' in html
 		assert 'class="col-duration"' in html

--- a/optimus/tests/test_render_drilldown.py
+++ b/optimus/tests/test_render_drilldown.py
@@ -121,7 +121,7 @@ class TestDrilldownRender:
 		html = renderer.render_raw(doc, recordings=[])
 
 		# The drill-down label appears on the card.
-		assert '<strong style="color: #1d4ed8;">Drill-down:</strong>' in html
+		assert '<div class="chain-label">Drill-down</div>' in html
 		# Both user-code frames below looped_validate are surfaced.
 		assert "_run_validations" in html
 		assert "_check_user_exists" in html
@@ -131,14 +131,17 @@ class TestDrilldownRender:
 		# stops before it.)
 		# The drill-down block lives inside the smoking-gun container, so
 		# locate it and assert the framework path isn't inside that span.
-		dd_idx = html.find("Drill-down:")
+		dd_idx = html.find("Drill-down")
 		assert dd_idx > 0
 		dd_segment = html[dd_idx:dd_idx + 4000]
 		assert "frappe/frappe/model/document.py" not in dd_segment, (
 			"framework frame leaked into the drill-down block"
 		)
-		# Percentages render as "% of parent".
-		assert "% of parent" in html
+		# v0.7.x Phase D: drill-down chain renders as pill steps; the
+		# per-step `% of parent` value isn't shown in the new layout
+		# (the mock dropped it for visual cleanliness — data still
+		# available via the underlying drilldown_chain dict for API
+		# consumers).
 
 	def test_finding_without_matching_tree_node_renders_placeholder(self):
 		"""v0.7.x: a finding whose callsite doesn't match any node in
@@ -170,7 +173,7 @@ class TestDrilldownRender:
 		html = renderer.render_raw(doc, recordings=[])
 
 		# Drill-down label IS present (the placeholder uses it).
-		assert "Drill-down:" in html
+		assert "Drill-down" in html
 		# Placeholder text rendered.
 		assert "no deeper user-code frame" in html
 		# No actual chain entries rendered — the bg of `_run_validations`
@@ -197,7 +200,7 @@ class TestDrilldownRender:
 		)
 		html = renderer.render_raw(doc, recordings=[])
 
-		assert "Drill-down:" not in html
+		assert "Drill-down" not in html
 
 	def test_action_without_call_tree_skips_drilldown(self):
 		from optimus import renderer
@@ -219,4 +222,4 @@ class TestDrilldownRender:
 			)],
 		)
 		html = renderer.render_raw(doc, recordings=[])
-		assert "Drill-down:" not in html
+		assert "Drill-down" not in html

--- a/optimus/tests/test_render_duration_threshold.py
+++ b/optimus/tests/test_render_duration_threshold.py
@@ -64,7 +64,7 @@ class TestDefaultThreshold:
 		# Fast action stays in ms.
 		assert ">800ms<" in html
 		# Footer stamps the default threshold (1000).
-		assert "large_duration_threshold_ms = <code>1000</code>" in html
+		assert "large_duration_threshold_ms=1000" in html
 
 
 class TestDisabledThreshold:
@@ -82,7 +82,7 @@ class TestDisabledThreshold:
 
 		assert ">5234ms<" in html
 		assert ">5.23s<" not in html
-		assert "large_duration_threshold_ms = <code>0</code>" in html
+		assert "large_duration_threshold_ms=0" in html
 
 
 class TestHighThreshold:
@@ -100,7 +100,7 @@ class TestHighThreshold:
 
 		assert ">5234ms<" in html
 		assert ">5.23s<" not in html
-		assert "large_duration_threshold_ms = <code>10000</code>" in html
+		assert "large_duration_threshold_ms=10000" in html
 
 
 class TestLowThreshold:

--- a/optimus/tests/test_render_phase2_panel.py
+++ b/optimus/tests/test_render_phase2_panel.py
@@ -67,7 +67,11 @@ class TestRenderPhase2PanelSingleRun:
 		html = renderer._render_phase2_panel(session)
 
 		assert "my_app.x.compute" in html
-		assert "Phase 2: Line-Level Drilldown" in html
+		# v0.7.x Phase I.2: heading dropped the "Phase 2" prefix —
+		# now reads just "Line-Level Drilldown" (the section's own
+		# content makes the line-level drilldown nature self-evident
+		# without the internal-phase jargon).
+		assert "Line-Level Drilldown" in html
 
 	def test_source_always_rendered(self):
 		# v0.6.0 Round 7: safe-mode source toggle removed. Source is
@@ -151,7 +155,10 @@ class TestRenderPhase2PanelAutoExpandChain:
 		root_idx = html.rfind("my_app.x.root_fn")
 		assert root_idx > -1
 		nearby = html[max(0, root_idx - 200):root_idx]
-		assert "margin: 12px 0 12px 24px" not in nearby
+		# v0.7.x Phase F: indent now expressed via `.indent-1` /
+		# `.indent-2` class names on the `.phase2-func` block, not
+		# inline margin. Anchor on the class instead.
+		assert "indent-1" not in nearby
 		assert "↳" not in nearby
 
 	def test_auto_expanded_descendant_renders_indented(self):
@@ -164,8 +171,11 @@ class TestRenderPhase2PanelAutoExpandChain:
 		desc_idx = html.rfind("my_app.x.descendant")
 		assert desc_idx > -1
 		nearby = html[max(0, desc_idx - 300):desc_idx]
-		assert "margin: 12px 0 12px 24px" in nearby
-		assert "↳" in nearby
+		# v0.7.x Phase F: indent now `.indent-1` class on the
+		# `.phase2-func` block + `&#x21B3;` arrow span before the
+		# function name.
+		assert "indent-1" in nearby
+		assert "&#x21B3;" in nearby
 
 	def test_no_picks_json_falls_back_to_curated_no_indent(self):
 		# Older runs may not carry source markers; renderer should treat
@@ -210,9 +220,11 @@ class TestRenderPhase2PanelSelfContainment:
 
 
 class TestRenderPhase2PanelPosition:
-	"""v0.6.x: Phase 2 is hoisted above the Findings section in the report.
-	A render-level check that the rendered HTML places the ``id="phase2"``
-	anchor before the ``<h2>Findings &mdash; what to fix</h2>`` heading.
+	"""v0.6.x: Line-Level Drilldown is hoisted above the Findings section
+	in the report. A render-level check that the rendered HTML places
+	the section anchor (``id="phase2"`` legacy alias or
+	``id="line-drilldown"`` canonical) before the
+	``<h2>Findings - what to fix</h2>`` heading.
 	"""
 
 	def _session_doc(self, *, with_phase2=True):
@@ -238,7 +250,7 @@ class TestRenderPhase2PanelPosition:
 	def test_phase2_anchor_renders_before_findings_h2(self):
 		html = renderer.render_raw(self._session_doc(with_phase2=True), recordings=[])
 		phase2_idx = html.find('id="phase2"')
-		findings_h2 = html.find("<h2>Findings &mdash; what to fix</h2>")
+		findings_h2 = html.find("<h2>Findings - what to fix</h2>")
 		assert phase2_idx > 0, "id=\"phase2\" wrapper missing from rendered HTML"
 		assert findings_h2 > 0, "Findings <h2> missing from rendered HTML"
 		assert phase2_idx < findings_h2, (
@@ -249,13 +261,17 @@ class TestRenderPhase2PanelPosition:
 	def test_phase2_jump_nav_link_appears_when_runs_present(self):
 		html = renderer.render_raw(self._session_doc(with_phase2=True), recordings=[])
 		# The jump-nav link is the visible affordance for the hoisted section.
-		assert 'href="#phase2"' in html
-		assert "Phase 2 line drill-down" in html
+		# v0.7.x Phase J.16: nav anchor renamed from "#phase2" to
+		# "#line-drilldown"; the legacy "#phase2" anchor element still
+		# precedes the panel so external links resolve.
+		assert 'href="#line-drilldown"' in html
+		assert ">Line-Level Drilldown</a>" in html
 
 	def test_phase2_omitted_when_no_runs(self):
 		html = renderer.render_raw(self._session_doc(with_phase2=False), recordings=[])
 		# Conditional both ways: no panel + no jump link when the session
 		# had no phase-2 runs.
 		assert 'id="phase2"' not in html
-		assert 'href="#phase2"' not in html
-		assert "Phase 2 line drill-down" not in html
+		assert 'id="line-drilldown"' not in html
+		assert 'href="#line-drilldown"' not in html
+		assert ">Line-Level Drilldown</a>" not in html

--- a/optimus/tests/test_renderer_v3.py
+++ b/optimus/tests/test_renderer_v3.py
@@ -64,10 +64,11 @@ def test_render_raw_with_donut_and_hot_frames():
 		total_query_time_ms=200,
 	)
 	html = renderer.render_raw(doc, recordings=[])
-	# v0.6.0: Time breakdown donut was folded into the Total time stat card,
-	# now labelled in plain English: `<server-code>ms server code · <db>ms database`.
-	assert "ms server code" in html
-	assert "ms database" in html
+	# v0.6.0: time breakdown was folded into the Total-time stat card.
+	# v0.7.x Phase A: stat card → KPI strip, sub-label now reads
+	# `<server>ms server · <db>ms DB` (tighter editorial copy).
+	assert "ms server" in html
+	assert "ms DB" in html
 	# Hot frames section rendered with full app names (v0.6.0 Round 7
 	# removed safe-mode app collapse).
 	assert "Hot frames" in html

--- a/optimus/tests/test_report_context.py
+++ b/optimus/tests/test_report_context.py
@@ -1,0 +1,600 @@
+# Copyright (c) 2026, Optimus contributors
+# For license information, please see license.txt
+
+"""Tests for ``optimus.report_context.build_report_context`` — the Phase J.1
+adapter that turns our flat 45-key render-context into the 19-key contract
+shape per ``template_variable_contract.md`` (reference design package).
+
+Phase J.1 verification: presence of all 19 top-level keys + minimal per-key
+shape conformance. Deep correctness (display strings, edge cases) is verified
+in Phase J.2 when the template starts consuming the new shape.
+"""
+
+import json
+from types import SimpleNamespace
+
+from optimus import report_context
+from optimus.report_context import (
+	_bar_kind_for,
+	_is_user_code,
+	_web_vital_class,
+	build_report_context,
+)
+
+# Top-level keys the contract specifies, in document order.
+CONTRACT_KEYS = (
+	"session", "tldr", "kpis", "repro", "summary", "findings",
+	"line_drilldown_runs", "action_plan", "waterfall", "actions",
+	"background_jobs", "doc_events", "resource", "frontend",
+	"hot_frames", "slow_queries", "db", "how_to_read_items", "footer",
+)
+
+
+def _doc(**overrides):
+	defaults = dict(
+		name="PS-test",
+		session_uuid="uuid-0017",
+		user="navin@aerele.in",
+		started_at="2026-05-14T18:12:59",
+		stopped_at="2026-05-14T18:13:15",
+		total_duration_ms=4780,
+		total_queries=1868,
+		total_query_time_ms=778,
+		phase_2_runs=[],
+	)
+	defaults.update(overrides)
+	return SimpleNamespace(**defaults)
+
+
+def _ctx(**overrides):
+	defaults = dict(
+		fmt_dt=lambda v: str(v) if v else "",
+		fmt_ms=lambda v, **kw: f"{v:.0f} ms",
+		server_tz="IST",
+		generated_at="2026-05-15 13:12",
+		actions=[],
+		findings=[],
+		tldr=None,
+		notes_html=None,
+		summary_html=None,
+		action_plan=[],
+		waterfall_rows=[],
+		background_jobs={"jobs": []},
+		doc_event_breakdown={},
+		infra_summary={},
+		infra_timeline=[],
+		frontend_vitals_by_page={},
+		frontend_xhr_matched=[],
+		frontend_summary={},
+		frontend_orphans=[],
+		hot_frames_rows=[],
+		ignored_apps=("frappe", "erpnext"),
+		top_queries=[],
+		table_breakdown=[],
+		render_config={},
+	)
+	defaults.update(overrides)
+	return defaults
+
+
+# ----- helpers ------------------------------------------------------------
+
+
+class TestWebVitalClass:
+	def test_none_or_zero_returns_vital_none(self):
+		assert _web_vital_class(None, 1800, 3000) == "vital-none"
+		assert _web_vital_class(0, 1800, 3000) == "vital-none"
+
+	def test_below_good_threshold_returns_vital_good(self):
+		assert _web_vital_class(420, 1800, 3000) == "vital-good"
+
+	def test_between_thresholds_returns_vital_meh(self):
+		assert _web_vital_class(2000, 1800, 3000) == "vital-meh"
+
+	def test_above_poor_threshold_returns_vital_poor(self):
+		assert _web_vital_class(3500, 1800, 3000) == "vital-poor"
+
+	def test_cls_thresholds(self):
+		# CLS uses fractional thresholds.
+		assert _web_vital_class(0.05, 0.1, 0.25) == "vital-good"
+		assert _web_vital_class(0.15, 0.1, 0.25) == "vital-meh"
+		assert _web_vital_class(0.3, 0.1, 0.25) == "vital-poor"
+
+
+class TestBarKindFor:
+	def test_above_one_second_returns_none_default_red(self):
+		assert _bar_kind_for(1500) is None
+		assert _bar_kind_for(1000) is None
+
+	def test_between_300_and_1000_returns_warn(self):
+		assert _bar_kind_for(300) == "warn"
+		assert _bar_kind_for(800) == "warn"
+
+	def test_below_300_returns_ok(self):
+		assert _bar_kind_for(0) == "ok"
+		assert _bar_kind_for(299) == "ok"
+
+	def test_none_returns_ok(self):
+		assert _bar_kind_for(None) == "ok"
+
+
+class TestIsUserCode:
+	def test_user_code_returns_true(self):
+		assert _is_user_code("ugly_code/python/common.py", ("frappe", "erpnext"))
+		assert _is_user_code("ugly_code.python.common.bg_recheck_users", ("frappe", "erpnext"))
+
+	def test_framework_code_returns_false(self):
+		assert not _is_user_code("frappe/desk/form/save.py", ("frappe", "erpnext"))
+		assert not _is_user_code("erpnext.accounts.doctype.x", ("frappe", "erpnext"))
+
+	def test_empty_input_returns_false(self):
+		assert not _is_user_code("", ("frappe",))
+		assert not _is_user_code(None, ("frappe",))
+
+
+# ----- top-level shape ----------------------------------------------------
+
+
+class TestTopLevelKeys:
+	def test_all_19_contract_keys_present(self):
+		# Subset rather than equality — pragmatic non-contract extensions
+		# like ``actions_framework`` / ``background_jobs_framework`` from
+		# J.2.3 are permitted; the contract just specifies a minimum.
+		out = build_report_context(_doc(), _ctx())
+		missing = set(CONTRACT_KEYS) - set(out.keys())
+		assert not missing, f"Missing contract keys: {missing}"
+
+	def test_empty_session_renders_without_error(self):
+		# All keys produced, optional ones may be None.
+		out = build_report_context(_doc(), _ctx())
+		assert out["session"]["id"] == "uuid-0017"
+		assert out["kpis"] is not None and len(out["kpis"]) == 4
+		assert out["footer"]["framework"] == "Frappe v16"
+
+
+# ----- per-key shape conformance ------------------------------------------
+
+
+class TestSessionShape:
+	def test_session_has_contract_fields(self):
+		out = build_report_context(
+			_doc(session_uuid="uuid-X", user="alice@example.com"), _ctx(server_tz="UTC")
+		)
+		s = out["session"]
+		assert s["id"] == "uuid-X"
+		assert s["recorded_by"] == "alice@example.com"
+		assert s["timezone"] == "UTC"
+		assert "started_at" in s
+		assert "ended_at" in s
+		assert "generated_at" in s
+
+
+class TestTldrShape:
+	def test_renames_markup_keys_to_html(self):
+		tldr_in = {
+			"label": "headline",
+			"headline_markup": "<span class='hot'>449 ms</span> hot",
+			"sub_markup": "Session total 4.78s",
+		}
+		out = build_report_context(_doc(), _ctx(tldr=tldr_in))
+		assert "<span class='hot'>" in out["tldr"]["headline_html"]
+		assert "Session total" in out["tldr"]["subline_html"]
+
+	def test_missing_tldr_returns_empty_strings(self):
+		out = build_report_context(_doc(), _ctx(tldr=None))
+		assert out["tldr"]["headline_html"] == ""
+		assert out["tldr"]["subline_html"] == ""
+
+
+class TestKpisShape:
+	def test_kpis_are_exactly_4(self):
+		out = build_report_context(_doc(), _ctx())
+		assert len(out["kpis"]) == 4
+
+	def test_kpi_items_have_required_fields(self):
+		out = build_report_context(_doc(), _ctx())
+		for kpi in out["kpis"]:
+			assert "label" in kpi
+			assert "value" in kpi
+			assert "sub" in kpi
+			assert "is_danger" in kpi
+
+	def test_kpi_labels_match_template_convention(self):
+		# Labels mirror the pre-J.2 template strings so the tested-text
+		# surface doesn't move under us.
+		out = build_report_context(_doc(), _ctx())
+		labels = [k["label"] for k in out["kpis"]]
+		assert labels == ["Total time", "Database queries", "Operations", "Issues found"]
+
+	def test_total_time_kpi_uses_fmt_ms(self):
+		# fmt_ms comes from the ctx so the contract honours the renderer's
+		# threshold-aware ms/s formatting.
+		out = build_report_context(_doc(total_duration_ms=4780), _ctx(
+			fmt_ms=lambda v, **kw: "4.78s" if v == 4780 else f"{v:.0f}ms",
+		))
+		first = out["kpis"][0]
+		assert first["value"] == "4.78s"
+		assert "server" in first["sub"] and "DB" in first["sub"]
+
+	def test_issues_found_sub_renders_severity_breakdown(self):
+		findings = [
+			{"severity": "High", "title": "x"},
+			{"severity": "High", "title": "y"},
+			{"severity": "Low", "title": "z"},
+		]
+		out = build_report_context(_doc(), _ctx(
+			findings=findings,
+			all_findings=findings,
+			severity_counts={"High": 2, "Medium": 0, "Low": 1},
+		))
+		assert "2 high" in out["kpis"][3]["sub"]
+		assert "1 low" in out["kpis"][3]["sub"]
+		assert out["kpis"][3]["is_danger"]
+
+	def test_issues_found_sub_falls_back_to_none_detected(self):
+		out = build_report_context(_doc(), _ctx(
+			findings=[], all_findings=[], severity_counts={"High": 0, "Medium": 0, "Low": 0},
+		))
+		assert out["kpis"][3]["sub"] == "none detected"
+		assert not out["kpis"][3]["is_danger"]
+
+
+class TestReproShape:
+	def test_none_when_no_notes(self):
+		assert build_report_context(_doc(), _ctx(notes_html=None))["repro"] is None
+
+	def test_exposes_raw_html_when_present(self):
+		out = build_report_context(_doc(), _ctx(notes_html="<ol><li>step1</li></ol>"))
+		assert out["repro"]["raw_html"] == "<ol><li>step1</li></ol>"
+
+
+class TestSummaryShape:
+	def test_none_when_no_summary_html(self):
+		assert build_report_context(_doc(), _ctx(summary_html=None))["summary"] is None
+
+	def test_wraps_summary_html_as_paragraph(self):
+		out = build_report_context(_doc(), _ctx(summary_html="<ul><li>foo</li></ul>"))
+		assert out["summary"]["paragraphs_html"] == ["<ul><li>foo</li></ul>"]
+
+
+class TestFindingsShape:
+	def _f(self, **kw):
+		base = {
+			"finding_type": "Slow Hot Path",
+			"severity": "High",
+			"title": "x is slow",
+			"customer_description": "...",
+			"estimated_impact_ms": 449,
+			"affected_count": 100,
+			"action_ref": "1",
+			"technical_detail": {
+				"callsite": {
+					"filename": "ugly_code/python/common.py",
+					"lineno": 20,
+					"function": "_check_user_exists",
+					"source_snippet": [
+						{"lineno": 19, "content": "    for i in range(50):"},
+						{"lineno": 20, "content": "        user = frappe.get_doc('User', user)"},
+					],
+				},
+			},
+			"llm_fix": None,
+		}
+		base.update(kw)
+		return base
+
+	def test_severity_normalized_to_lowercase_short_codes(self):
+		findings = [self._f(severity="High"), self._f(severity="Medium"), self._f(severity="Low")]
+		out = build_report_context(_doc(), _ctx(findings=findings))
+		assert out["findings"][0]["severity"] == "high"
+		assert out["findings"][1]["severity"] == "med"
+		assert out["findings"][2]["severity"] == "low"
+
+	def test_finding_has_contract_fields(self):
+		out = build_report_context(_doc(), _ctx(findings=[self._f()]))
+		f = out["findings"][0]
+		expected_keys = {
+			"severity", "title_html", "file_line", "impact_display",
+			"impact_sub", "smoking_label", "smoking_code_html",
+			"smoking_footnote_html", "chain", "ai_fix",
+		}
+		assert expected_keys.issubset(set(f.keys()))
+
+	def test_smoking_code_html_wraps_target_line_in_hot_line_span(self):
+		out = build_report_context(_doc(), _ctx(findings=[self._f()]))
+		smoking = out["findings"][0]["smoking_code_html"]
+		assert '<span class="hot-line">' in smoking
+		assert '<span class="ln">20</span>' in smoking
+
+	def test_smoking_code_html_drops_blank_context_lines(self):
+		# Regression: Phase I.5 blank-line skip should be preserved.
+		finding = self._f()
+		finding["technical_detail"]["callsite"]["source_snippet"] = [
+			{"lineno": 18, "content": ""},
+			{"lineno": 19, "content": "    for i in range(50):"},
+			{"lineno": 20, "content": "        user = frappe.get_doc(...)"},
+		]
+		out = build_report_context(_doc(), _ctx(findings=[finding]))
+		smoking = out["findings"][0]["smoking_code_html"]
+		assert '<span class="ln">18</span>' not in smoking
+		assert '<span class="ln">19</span>' in smoking
+
+
+class TestPhase2RunsShape:
+	def _phase2_run(self, *, status="Ready", picks=None, results=None):
+		return SimpleNamespace(
+			run_uuid="r1",
+			status=status,
+			started_at="2026-05-14T18:15:21",
+			total_ms=1585.22,
+			picks_json=json.dumps(picks or []),
+			results_json=json.dumps(results or []),
+		)
+
+	def test_empty_when_no_runs(self):
+		out = build_report_context(_doc(phase_2_runs=[]), _ctx())
+		assert out["line_drilldown_runs"] == []
+
+	def test_skips_non_ready_runs(self):
+		out = build_report_context(
+			_doc(phase_2_runs=[self._phase2_run(status="Failed")]), _ctx()
+		)
+		assert out["line_drilldown_runs"] == []
+
+	def test_ready_run_has_contract_fields(self):
+		picks = [{"dotted_path": "x.y.fn", "source": "curated"}]
+		results = [{
+			"dotted_path": "x.y.fn",
+			"qualname": "fn",
+			"file": "/abs/x.py",
+			"lines": [
+				{"lineno": 1, "content": "def fn():", "hits": 1, "total_ms": 10.0, "per_hit_us": 10000},
+			],
+		}]
+		out = build_report_context(
+			_doc(phase_2_runs=[self._phase2_run(picks=picks, results=results)]), _ctx()
+		)
+		run = out["line_drilldown_runs"][0]
+		assert run["number"] == 1
+		assert run["status"] == "Ready"
+		assert run["picks"] == ["x.y.fn"]
+		assert len(run["functions"]) == 1
+		fn = run["functions"][0]
+		assert fn["qualified_name"] == "x.y.fn"
+		assert fn["indent"] == 0
+		assert len(fn["lines"]) == 1
+
+
+class TestActionPlanShape:
+	def test_step_has_contract_fields(self):
+		ap_in = [{
+			"n": 1, "title": "Optimise X", "desc": "Loop fix",
+			"gain_ms": 1414.18, "gain_label": "est. saving",
+			"callsite": "x.py:13", "finding_type": "Slow Hot Path",
+		}]
+		out = build_report_context(_doc(), _ctx(action_plan=ap_in))
+		step = out["action_plan"][0]
+		assert step["number"] == 1
+		assert step["title_html"] == "Optimise X"
+		assert step["description_html"] == "Loop fix"
+		assert step["savings_display"] == "−1414 ms"
+		assert step["savings_label"] == "est. saving"
+
+
+class TestWaterfallShape:
+	def test_row_has_contract_fields(self):
+		# Real fmt_ms switches to seconds at threshold; fixture uses one
+		# that mirrors that behaviour so the display test is meaningful.
+		rows = [{"name": "savedocs", "duration_ms": 1430, "pct": 100.0, "hot": True, "bg": False}]
+		out = build_report_context(_doc(), _ctx(
+			waterfall_rows=rows,
+			fmt_ms=lambda v, **kw: f"{v / 1000:.2f}s" if v >= 1000 else f"{v:.0f}ms",
+		))
+		row = out["waterfall"][0]
+		assert row["name"] == "savedocs"
+		assert row["width_pct"] == 100.0
+		assert row["kind"] == "hot"
+		assert row["is_hot_text"] is True
+		assert row["duration_display"] == "1.43s"
+
+	def test_bg_kind_when_bg_flag_set(self):
+		rows = [{"name": "job", "duration_ms": 500, "pct": 50, "hot": False, "bg": True}]
+		out = build_report_context(_doc(), _ctx(waterfall_rows=rows))
+		assert out["waterfall"][0]["kind"] == "bg"
+
+
+class TestActionsShape:
+	def test_action_has_contract_fields(self):
+		actions = [{
+			"action_label": "save", "event_type": "HTTP Request", "http_method": "POST",
+			"path": "/api/method/save", "duration_ms": 1430, "queries_count": 828,
+			"query_time_ms": 322,
+		}]
+		out = build_report_context(_doc(), _ctx(actions=actions))
+		a = out["actions"][0]
+		assert a["number"] == 1
+		assert a["name"] == "save"
+		assert a["kind"] == "http"
+		assert a["bar_kind"] is None  # ≥1000ms → default red
+		assert a["duration_is_hot"]
+
+	def test_bg_kind_for_background_job_event(self):
+		actions = [{"action_label": "j", "event_type": "RQ Job", "duration_ms": 100}]
+		out = build_report_context(_doc(), _ctx(actions=actions))
+		assert out["actions"][0]["kind"] == "bg"
+
+	def test_finding_inline_html_when_action_linked(self):
+		findings = [{"severity": "High", "title": "Slow loop", "action_ref": "1"}]
+		actions = [{"action_label": "save", "duration_ms": 1430}]
+		out = build_report_context(_doc(), _ctx(actions=actions, findings=findings))
+		assert "Slow loop" in (out["actions"][0]["finding_inline_html"] or "")
+
+
+class TestBackgroundJobsShape:
+	def test_job_has_contract_fields(self):
+		jobs = {"jobs": [{
+			"method": "bg_recheck_users",
+			"duration_ms": 799,
+			"queries_count": 111,
+			"query_time_ms": 61,
+			"findings_count": 1,
+			"entry_callsite": {"filename": "x.py", "lineno": 199},
+		}]}
+		out = build_report_context(_doc(), _ctx(background_jobs=jobs))
+		j = out["background_jobs"][0]
+		assert j["number"] == 1
+		assert j["name"] == "bg_recheck_users"
+		assert j["queries"] == 111
+		assert j["finding_count"] == 1
+		assert j["bar_kind"] == "warn"  # 799ms in [300, 1000)
+
+
+class TestDocEventsShape:
+	def test_doctype_has_contract_fields(self):
+		breakdown = {"doctypes": [{
+			"doctype": "Sales Invoice",
+			"method_count": 1,
+			"total_ms": 737,
+			"events": [{
+				"event": "validate",
+				"total_ms": 737,
+				"methods": [{
+					"function": "looped_validate",
+					"filename": "x.py", "lineno": 6,
+					"ms": 737, "kind": "doc_events hook",
+				}],
+			}],
+		}]}
+		out = build_report_context(_doc(), _ctx(doc_event_breakdown=breakdown))
+		de = out["doc_events"][0]
+		assert de["name"] == "Sales Invoice"
+		assert "hot method" in de["summary"]
+		assert de["methods"][0]["name"] == "validate"
+		assert de["methods"][0]["hooks"][0]["name"] == "looped_validate"
+
+
+class TestResourceShape:
+	def test_none_when_no_infra(self):
+		assert build_report_context(_doc(), _ctx())["resource"] is None
+
+	def test_cpu_card_with_peak(self):
+		infra = {"cpu_avg": 15, "cpu_peak": 62.5}
+		out = build_report_context(_doc(), _ctx(infra_summary=infra))
+		card = out["resource"]["cards"][0]
+		assert card["label"] == "CPU avg / peak"
+		assert card["value_kind"] == "warn"  # 62.5 ≥ 50
+
+	def test_swap_card_with_activity(self):
+		infra = {"swap_peak_mb": 1149}
+		out = build_report_context(_doc(), _ctx(infra_summary=infra))
+		# Find the Swap card
+		swap_card = next(c for c in out["resource"]["cards"] if c["label"] == "Swap peak")
+		assert swap_card["value_kind"] == "warn"
+		assert swap_card["sub_is_warn"]
+
+
+class TestFrontendShape:
+	def test_none_when_no_frontend(self):
+		assert build_report_context(_doc(), _ctx())["frontend"] is None
+
+	def test_web_vital_classes_computed(self):
+		vitals = {"/p": {"fcp_ms": 420, "lcp_ms": 5000, "cls": 0.15, "ttfb_ms": 180, "dom_content_loaded_ms": 890}}
+		out = build_report_context(_doc(), _ctx(frontend_vitals_by_page=vitals))
+		row = out["frontend"]["web_vitals"][0]
+		assert row["fcp_class"] == "vital-good"
+		assert row["lcp_class"] == "vital-poor"
+		assert row["cls_class"] == "vital-meh"
+		assert row["ttfb_class"] == "vital-good"
+
+	def test_partial_vitals_gets_none_class(self):
+		# Regression of the Phase I.5 production crash data shape.
+		vitals = {"/p": {"cls": 0.135}}
+		out = build_report_context(_doc(), _ctx(frontend_vitals_by_page=vitals))
+		row = out["frontend"]["web_vitals"][0]
+		assert row["fcp_class"] == "vital-none"
+		assert row["fcp_display"] == "—"
+		assert row["cls_class"] == "vital-meh"
+
+
+class TestHotFramesShape:
+	def test_user_code_flag_set_for_app_code(self):
+		rows = [{"display_name": "ugly_code/python/common.py::looped_validate", "total_ms": 1414, "occurrences": 2, "distinct_actions": 2}]
+		out = build_report_context(_doc(), _ctx(hot_frames_rows=rows, ignored_apps=("frappe", "erpnext")))
+		assert out["hot_frames"][0]["is_user_code"]
+
+	def test_user_code_flag_false_for_framework_code(self):
+		rows = [{"display_name": "frappe/desk/form/save.py::savedocs", "total_ms": 2045, "occurrences": 2, "distinct_actions": 2}]
+		out = build_report_context(_doc(), _ctx(hot_frames_rows=rows, ignored_apps=("frappe", "erpnext")))
+		assert not out["hot_frames"][0]["is_user_code"]
+
+
+class TestSlowQueriesShape:
+	def test_empty_list_when_no_queries(self):
+		assert build_report_context(_doc(), _ctx())["slow_queries"] == []
+
+	def test_query_has_contract_fields(self):
+		queries = [{"normalized_query": "SELECT * FROM tabUser", "total_ms": 65, "count": 163, "callsite": "x.py:20"}]
+		out = build_report_context(_doc(), _ctx(top_queries=queries))
+		q = out["slow_queries"][0]
+		assert q["sql_excerpt"] == "SELECT * FROM tabUser"
+		assert q["call_count"] == 163
+		assert q["callsite"] == "x.py:20"
+
+
+class TestDbShape:
+	def test_none_when_no_tables(self):
+		assert build_report_context(_doc(), _ctx())["db"] is None
+
+	def test_table_has_contract_fields(self):
+		tables = [{
+			"table": "tabUser", "duration_ms": 65, "queries": 163,
+			"read_count": 163, "write_count": 0,
+			"recommended_index": None,
+		}]
+		out = build_report_context(_doc(), _ctx(table_breakdown=tables))
+		t = out["db"]["tables"][0]
+		assert t["name"] == "tabUser"
+		assert t["queries"] == 163
+		assert t["is_hot"]  # 163 ≥ 100
+
+	def test_index_recommendation_built_when_present(self):
+		tables = [{
+			"table": "tabCommunication", "duration_ms": 15,
+			"queries": 2, "read_count": 2, "write_count": 0,
+			"recommended_index": {
+				"columns": ["communication_type", "reference_doctype"],
+				"doctype": "Communication",
+			},
+		}]
+		out = build_report_context(_doc(), _ctx(table_breakdown=tables))
+		recs = out["db"]["index_recommendations"]
+		assert len(recs) == 1
+		assert recs[0]["table_name"] == "tabCommunication"
+		assert "communication_type" in recs[0]["recommendation_html"]
+		assert 'frappe.db.add_index("Communication"' in recs[0]["sql"]
+
+
+class TestFooterShape:
+	def test_footer_settings_compose_from_render_config(self):
+		rc = {
+			"hide_framework_tables": True,
+			"ignored_apps": ("frappe", "erpnext"),
+			"ai_suggest_findings": True,
+			"ai_suggest_indexes": True,
+		}
+		out = build_report_context(_doc(), _ctx(render_config=rc))
+		s = out["footer"]["settings"]
+		assert "hide_framework_tables=on" in s
+		assert "ignored_apps=frappe, erpnext" in s
+		assert "ai_suggest_findings=on" in s
+
+	def test_footer_framework_label(self):
+		out = build_report_context(_doc(), _ctx())
+		assert out["footer"]["framework"] == "Frappe v16"
+
+
+class TestHowToReadItems:
+	def test_omitted_for_now(self):
+		# J.1 leaves how_to_read_items=None; template falls back to default.
+		out = build_report_context(_doc(), _ctx())
+		assert out["how_to_read_items"] is None

--- a/optimus/tests/test_steps_to_reproduce.py
+++ b/optimus/tests/test_steps_to_reproduce.py
@@ -80,26 +80,32 @@ def test_api_start_writes_notes_to_doc():
 
 
 def test_report_template_renders_notes():
-	"""The report template must render the notes section and
-	use the pre-sanitized `notes_html` context var (which is |safe)."""
+	"""The report template must render the notes section using a
+	pre-sanitized variable. Post-J.2.1 the template reads
+	``report_data.repro.raw_html`` (sourced from the same sanitized
+	``notes_html`` that ``renderer.render`` builds via
+	``sanitize_html(always_sanitize=True)``)."""
 	tpath = os.path.join(HERE, "..", "templates", "report.html")
 	with open(tpath) as f:
 		template = f.read()
 
-	# Template must use the sanitized notes_html var, not raw session.notes.
-	# Using session.notes directly with |safe would be a stored-XSS sink.
-	assert "notes_html" in template
-	assert "notes_html | safe" in template or "notes_html|safe" in template
+	# XSS guard: the template must NEVER pipe the raw doc field through
+	# |safe. The sanitized version is mandatory.
+	assert "session.notes | safe" not in template
+	assert "session.notes|safe" not in template
+
+	# The repro section reads from the contract-shaped report_data.repro.
+	assert "report_data.repro" in template
 	# "Steps to Reproduce" heading must appear so users know the purpose.
 	assert "Steps to Reproduce" in template
 
-	# Verify notes appear ABOVE the "Findings — what to fix" section header.
-	notes_idx = template.find("notes_html")
-	findings_heading_idx = template.find("Findings &mdash; what to fix")
-	assert notes_idx > 0
+	# Repro section renders ABOVE the "Findings — what to fix" section.
+	repro_idx = template.find("report_data.repro")
+	findings_heading_idx = template.find("Findings - what to fix")
+	assert repro_idx > 0
 	assert findings_heading_idx > 0
-	assert findings_heading_idx > notes_idx, (
-		"notes section must appear above 'Findings — what to fix'"
+	assert findings_heading_idx > repro_idx, (
+		"repro section must appear above 'Findings — what to fix'"
 	)
 
 

--- a/optimus/tests/test_table_breakdown.py
+++ b/optimus/tests/test_table_breakdown.py
@@ -607,13 +607,13 @@ class TestRenderConfigFooter:
 		html = renderer.render_raw(self._doc(), recordings=[])
 		# Anchor label is unambiguous.
 		assert "<strong>Rendered with:</strong>" in html
-		assert "hide_framework_tables = <code>on</code>" in html
-		assert "tracked_apps = <code>(none)</code>" in html
-		assert "ignored_apps = <code>(none)</code>" in html
-		assert "ai_suggest_findings = <code>on</code>" in html
-		assert "ai_suggest_indexes = <code>on</code>" in html
-		assert "min_action_duration_ms = <code>0</code>" in html
-		assert "large_duration_threshold_ms = <code>1000</code>" in html
+		assert "hide_framework_tables=on" in html
+		assert "tracked_apps=(none)" in html
+		assert "ignored_apps=(none)" in html
+		assert "ai_suggest_findings=on" in html
+		assert "ai_suggest_indexes=on" in html
+		assert "min_action_duration_ms=0" in html
+		assert "large_duration_threshold_ms=1000" in html
 		# The nudge phrase explains why the user might be looking at stale
 		# data — the whole point of the stamp.
 		assert "Regenerate Reports" in html
@@ -636,10 +636,10 @@ class TestRenderConfigFooter:
 		with patch("optimus.settings.get_config", return_value=cfg):
 			html = renderer.render_raw(self._doc(), recordings=[])
 
-		assert "hide_framework_tables = <code>off</code>" in html
-		assert "tracked_apps = <code>myapp, ugly_code</code>" in html
-		assert "ignored_apps = <code>frappe</code>" in html
-		assert "ai_suggest_findings = <code>off</code>" in html
-		assert "ai_suggest_indexes = <code>off</code>" in html
-		assert "min_action_duration_ms = <code>42</code>" in html
-		assert "large_duration_threshold_ms = <code>2500</code>" in html
+		assert "hide_framework_tables=off" in html
+		assert "tracked_apps=myapp, ugly_code" in html
+		assert "ignored_apps=frappe" in html
+		assert "ai_suggest_findings=off" in html
+		assert "ai_suggest_indexes=off" in html
+		assert "min_action_duration_ms=42" in html
+		assert "large_duration_threshold_ms=2500" in html

--- a/optimus/tests/test_tldr_compose.py
+++ b/optimus/tests/test_tldr_compose.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2026, Optimus contributors
+# For license information, please see license.txt
+
+"""Tests for `renderer._compose_tldr` — the v0.7.x redesign Phase B
+TL;DR hero composer.
+
+The hero picks the single highest-impact finding (severity desc, then
+impact desc) and emits a one-sentence headline keyed on the finding's
+category. Key phrases are wrapped in `<span class="hot">` via
+markupsafe.Markup so the inline red-italic survives Jinja autoescape
+when the template renders `{{ tldr.headline_markup }}`.
+"""
+
+from types import SimpleNamespace
+
+from markupsafe import Markup
+
+from optimus import renderer
+
+
+def _doc(**kw):
+	base = {
+		"total_duration_ms": 4783,
+		"total_queries": 1868,
+		"total_requests": 20,
+	}
+	base.update(kw)
+	return SimpleNamespace(**base)
+
+
+def _finding(**kw):
+	base = {
+		"finding_type": "N+1 Query",
+		"severity": "High",
+		"title": "Same query ran 100×",
+		"estimated_impact_ms": 449.0,
+		"affected_count": 100,
+	}
+	base.update(kw)
+	return base
+
+
+class TestCategoryMap:
+	def test_known_finding_types_map_to_categories(self):
+		assert renderer._category_for("N+1 Query") == "n_plus_one"
+		assert renderer._category_for("Framework N+1") == "n_plus_one"
+		assert renderer._category_for("Hook Bottleneck") == "slow_hook"
+		assert renderer._category_for("Hot Line") == "hot_line"
+		assert renderer._category_for("Missing Index") == "missing_index"
+
+	def test_unknown_or_blank_falls_through_to_other(self):
+		assert renderer._category_for(None) == "other"
+		assert renderer._category_for("") == "other"
+		assert renderer._category_for("Brand New Finding") == "other"
+
+
+class TestHeadlineByCategory:
+	def test_n_plus_one_uses_loop_template(self):
+		tldr = renderer._compose_tldr([_finding()], _doc())
+		head = str(tldr["headline_markup"])
+		assert "One line of code is responsible for" in head
+		assert "100× inside a loop" in head
+		# Highlight spans applied to the impact + loop count.
+		assert head.count('<span class="hot">') >= 2
+
+	def test_slow_hook_uses_hook_template(self):
+		f = _finding(
+			finding_type="Hook Bottleneck",
+			title="In Submit, looped_validate hook consumed 705ms",
+			estimated_impact_ms=705.0,
+		)
+		tldr = renderer._compose_tldr([f], _doc())
+		head = str(tldr["headline_markup"])
+		assert "doc-event hook" in head
+		assert "slowest hook" in head
+		assert "looped_validate" in head
+
+	def test_slow_query_branch(self):
+		f = _finding(
+			finding_type="Slow Query",
+			title="SELECT * FROM tabUser took 1234ms",
+			estimated_impact_ms=1234.0,
+		)
+		tldr = renderer._compose_tldr([f], _doc())
+		head = str(tldr["headline_markup"])
+		assert "A single query took" in head
+		assert "tabUser" in head
+
+	def test_redundant_call_with_count(self):
+		f = _finding(
+			finding_type="Redundant Call",
+			title="frappe.session.user fetched 50×",
+			estimated_impact_ms=200.0,
+			affected_count=50,
+		)
+		tldr = renderer._compose_tldr([f], _doc())
+		head = str(tldr["headline_markup"])
+		assert "Same call repeated" in head
+		assert "50×" in head
+
+	def test_fallback_branch_uses_verbatim_title(self):
+		f = _finding(
+			finding_type="Some Brand New Finding",
+			title="Custom title goes here",
+			estimated_impact_ms=300.0,
+		)
+		tldr = renderer._compose_tldr([f], _doc())
+		head = str(tldr["headline_markup"])
+		assert "Custom title goes here" in head
+		# Even fallback emphasises the impact.
+		assert '<span class="hot">' in head
+
+
+class TestSorting:
+	def test_picks_highest_severity_first(self):
+		# Use the fallback finding_type so the headline includes the
+		# title verbatim — sorting test doesn't care about the
+		# category-specific prose, just which finding wins.
+		low = _finding(finding_type="?", severity="Low", estimated_impact_ms=5000, title="LOW_FINDING")
+		high = _finding(finding_type="?", severity="High", estimated_impact_ms=100, title="HIGH_FINDING")
+		# Low has more impact, but High severity wins.
+		tldr = renderer._compose_tldr([low, high], _doc())
+		assert "HIGH_FINDING" in str(tldr["headline_markup"])
+		assert "LOW_FINDING" not in str(tldr["headline_markup"])
+
+	def test_breaks_severity_ties_by_impact(self):
+		small = _finding(finding_type="?", severity="Medium", estimated_impact_ms=50, title="SMALL_FINDING")
+		big = _finding(finding_type="?", severity="Medium", estimated_impact_ms=500, title="BIG_FINDING")
+		tldr = renderer._compose_tldr([small, big], _doc())
+		# big impact wins at same severity.
+		assert "BIG_FINDING" in str(tldr["headline_markup"])
+		assert "SMALL_FINDING" not in str(tldr["headline_markup"])
+
+
+class TestEmptyState:
+	def test_no_findings_yields_clean_session_branch(self):
+		tldr = renderer._compose_tldr([], _doc())
+		head = str(tldr["headline_markup"])
+		assert tldr["label"] == "Clean session"
+		assert "Nothing to fix" in head
+		# No signal red in the clean branch.
+		assert '<span class="hot">' not in head
+
+	def test_empty_sub_line_drops_severity_phrase(self):
+		tldr = renderer._compose_tldr([], _doc())
+		sub = str(tldr["sub_markup"])
+		assert "severity finding" not in sub
+		# But session totals stay.
+		assert "Session total" in sub
+		assert "20 operations" in sub
+		assert "1868 DB queries" in sub
+
+
+class TestSubLine:
+	def test_sub_line_counts_same_severity_findings(self):
+		findings = [
+			_finding(severity="High"),
+			_finding(severity="High"),
+			_finding(severity="Medium"),
+		]
+		tldr = renderer._compose_tldr(findings, _doc())
+		sub = str(tldr["sub_markup"])
+		# Top finding is High; sub line counts other High findings (2).
+		assert "2 high-severity findings" in sub
+
+	def test_sub_line_singular_for_one_finding(self):
+		tldr = renderer._compose_tldr([_finding()], _doc())
+		sub = str(tldr["sub_markup"])
+		assert "1 high-severity finding." in sub
+		assert "findings." not in sub  # singular, no plural 's'
+
+
+class TestMarkupSafety:
+	def test_returns_markup_so_jinja_does_not_escape_spans(self):
+		tldr = renderer._compose_tldr([_finding()], _doc())
+		assert isinstance(tldr["headline_markup"], Markup)
+		assert isinstance(tldr["sub_markup"], Markup)
+
+	def test_user_supplied_title_is_html_escaped(self):
+		"""Finding titles come from analyzer output but can carry
+		user-controlled content (e.g. DocType names, action labels).
+		Markup.format() escapes plain-string args — confirm a stray
+		<script> in the title is escaped, not interpolated raw."""
+		f = _finding(
+			finding_type="Hook Bottleneck",
+			title="<script>alert('xss')</script>",
+			estimated_impact_ms=500.0,
+		)
+		tldr = renderer._compose_tldr([f], _doc())
+		head = str(tldr["headline_markup"])
+		assert "<script>alert" not in head
+		assert "&lt;script&gt;" in head
+
+
+class TestThresholdRespected:
+	def test_below_threshold_keeps_ms_unit(self):
+		f = _finding(estimated_impact_ms=800, affected_count=50)
+		tldr = renderer._compose_tldr(
+			[f], _doc(total_duration_ms=800),
+			large_duration_threshold_ms=1000.0,
+		)
+		head = str(tldr["headline_markup"])
+		assert "800ms" in head
+		assert "time-high" not in head
+
+	def test_above_threshold_renders_seconds(self):
+		f = _finding(estimated_impact_ms=2000, affected_count=50)
+		tldr = renderer._compose_tldr(
+			[f], _doc(total_duration_ms=5000),
+			large_duration_threshold_ms=1000.0,
+		)
+		head = str(tldr["headline_markup"])
+		assert '<span class="time-high">2.00s</span>' in head

--- a/optimus/tests/test_truncation_banner.py
+++ b/optimus/tests/test_truncation_banner.py
@@ -80,15 +80,21 @@ class TestTruncationBannerRenders:
 		# what to raise.
 		assert "Max Queries per Recording" in html
 
-	def test_banner_renders_above_exec_summary(self):
+	def test_banner_renders_above_tldr_hero(self):
 		"""Structural: the truncation banner must appear BEFORE the
-		exec-summary card in document order. Otherwise readers who
-		stop scrolling at the exec card won't see the warning."""
+		TL;DR hero in document order. Otherwise readers who stop
+		scrolling at the headline won't see the warning.
+		v0.7.x redesign: the exec-summary card was replaced by the
+		TL;DR hero (mock spec). The banner-must-come-before-the-most-
+		prominent-content rule still applies — the prominent block
+		just changed identity."""
 		from optimus import renderer
 
 		warning = "⚠ TRUNCATED: 100 queries (5% of the flow) exceeded ..."
 		doc = _fake_session_doc(analyzer_warnings=warning)
-		# Put ONE finding in so the exec-summary card renders.
+		# Put ONE finding in so the TL;DR has a finding-keyed headline
+		# (clean-session branch would also work for the order check,
+		# but exercising the populated path is closer to real reports).
 		row = types.SimpleNamespace()
 		row.finding_type = "N+1 Query"
 		row.severity = "High"
@@ -98,9 +104,6 @@ class TestTruncationBannerRenders:
 		row.affected_count = 50
 		row.action_ref = "0"
 		# v0.7.x: findings with no callsite are filtered before render.
-		# Give this finding a callsite so the exec-summary still picks
-		# it up (the test's intent is to verify banner-vs-summary order,
-		# not the callsite plumbing).
 		row.technical_detail_json = json.dumps({
 			"callsite": {"filename": "apps/myapp/foo.py", "lineno": 1, "function": "f"},
 		})
@@ -108,12 +111,12 @@ class TestTruncationBannerRenders:
 
 		html = renderer.render(doc, recordings=[])
 		banner_idx = html.find('class="truncation-banner"')
-		exec_idx = html.find('class="exec-summary')
+		tldr_idx = html.find('class="tldr"')
 		assert banner_idx > 0
-		assert exec_idx > 0
-		assert banner_idx < exec_idx, (
-			f"Truncation banner must render BEFORE exec-summary card. "
-			f"Got banner at {banner_idx}, exec at {exec_idx}."
+		assert tldr_idx > 0
+		assert banner_idx < tldr_idx, (
+			f"Truncation banner must render BEFORE the TL;DR hero. "
+			f"Got banner at {banner_idx}, TL;DR at {tldr_idx}."
 		)
 
 	def test_banner_absent_on_clean_session(self):

--- a/optimus/tests/test_v5_panels_render.py
+++ b/optimus/tests/test_v5_panels_render.py
@@ -127,6 +127,36 @@ def test_frontend_panel_renders_full_urls():
 	assert "SI-2026-00123" in html
 
 
+def test_frontend_panel_renders_partial_vitals():
+	# Regression: production page reported only `cls` (no fcp/lcp/ttfb).
+	# Pre-fix this raised UndefinedError inside the _vital macro and
+	# broke Regenerate Reports entirely.
+	from optimus import renderer
+
+	v5 = {
+		"infra_timeline": [],
+		"infra_summary": {},
+		"frontend_xhr_matched": [],
+		"frontend_vitals_by_page": {
+			"/desk/sales-invoice/A": {
+				"fcp_ms": 420, "lcp_ms": 2800, "cls": 0.02,
+				"ttfb_ms": 180, "dom_content_loaded_ms": 890,
+			},
+			"/desk/sales-invoice/B": {"cls": 0.135},
+			"/desk/sales-invoice/C": {},
+		},
+		"frontend_orphans": [],
+		"frontend_summary": {},
+	}
+
+	doc = _fake_session_doc(v5)
+	html = renderer.render(doc, recordings=[])
+
+	assert "/desk/sales-invoice/B" in html
+	assert "/desk/sales-invoice/C" in html
+	assert "vital-none" in html
+
+
 def test_raw_mode_keeps_docname_in_urls():
 	from optimus import renderer
 

--- a/optimus/tests/test_waterfall.py
+++ b/optimus/tests/test_waterfall.py
@@ -1,0 +1,132 @@
+# Copyright (c) 2026, Optimus contributors
+# For license information, please see license.txt
+
+"""Tests for `renderer._build_waterfall` — the v0.7.x redesign Phase
+C horizontal-bar action timeline.
+
+Top-N actions by duration, scaled to the displayed slice's max so
+short actions stay visible. Bar colour:
+- `hot` when a High-severity finding points at this action.
+- `bg` when the action is a background job.
+- otherwise: default (info blue).
+"""
+
+from optimus import renderer
+
+
+def _a(idx, **kw):
+	base = {
+		"idx": idx,
+		"action_label": f"action_{idx}",
+		"event_type": "HTTP Request",
+		"duration_ms": 100.0,
+	}
+	base.update(kw)
+	return base
+
+
+class TestEmpty:
+	def test_no_actions_returns_empty_list(self):
+		assert renderer._build_waterfall([], []) == []
+
+	def test_actions_all_zero_duration_returns_empty(self):
+		actions = [_a(0, duration_ms=0), _a(1, duration_ms=0)]
+		assert renderer._build_waterfall(actions, []) == []
+
+
+class TestSizing:
+	def test_returns_at_most_eight_rows_by_default(self):
+		actions = [_a(i, duration_ms=float(i + 1)) for i in range(20)]
+		out = renderer._build_waterfall(actions, [])
+		assert len(out) == 8
+
+	def test_max_rows_override(self):
+		actions = [_a(i, duration_ms=float(i + 1)) for i in range(10)]
+		out = renderer._build_waterfall(actions, [], max_rows=5)
+		assert len(out) == 5
+
+	def test_returns_fewer_when_input_is_smaller(self):
+		actions = [_a(0, duration_ms=100), _a(1, duration_ms=50)]
+		out = renderer._build_waterfall(actions, [])
+		assert len(out) == 2
+
+
+class TestSorting:
+	def test_sorted_by_duration_descending(self):
+		actions = [
+			_a(0, action_label="slow", duration_ms=900),
+			_a(1, action_label="fastest", duration_ms=50),
+			_a(2, action_label="medium", duration_ms=400),
+		]
+		out = renderer._build_waterfall(actions, [])
+		assert [r["name"] for r in out] == ["slow", "medium", "fastest"]
+
+
+class TestPctScaling:
+	def test_top_row_renders_at_100_percent(self):
+		actions = [
+			_a(0, duration_ms=1000),
+			_a(1, duration_ms=500),
+			_a(2, duration_ms=100),
+		]
+		out = renderer._build_waterfall(actions, [])
+		assert out[0]["pct"] == 100.0
+		assert out[1]["pct"] == 50.0
+		assert out[2]["pct"] == 10.0
+
+	def test_pct_scales_to_displayed_slice_max(self):
+		"""When max_rows=2 selects the top-2 from a larger list,
+		scaling uses those two's max — not the (unshown) overall
+		max — so the second row is comparable visually."""
+		actions = [
+			_a(0, duration_ms=200),
+			_a(1, duration_ms=100),
+			_a(2, duration_ms=10),  # would-be 5% on overall, hidden anyway
+		]
+		out = renderer._build_waterfall(actions, [], max_rows=2)
+		assert out[0]["pct"] == 100.0
+		assert out[1]["pct"] == 50.0
+
+
+class TestHotFlag:
+	def test_high_severity_finding_marks_action_hot(self):
+		actions = [_a(0, duration_ms=900)]
+		findings = [{"severity": "High", "action_ref": "0"}]
+		out = renderer._build_waterfall(actions, findings)
+		assert out[0]["hot"] is True
+
+	def test_medium_severity_does_not_mark_hot(self):
+		actions = [_a(0, duration_ms=900)]
+		findings = [{"severity": "Medium", "action_ref": "0"}]
+		out = renderer._build_waterfall(actions, findings)
+		assert out[0]["hot"] is False
+
+	def test_action_ref_mismatch_does_not_mark_hot(self):
+		actions = [_a(0, duration_ms=900), _a(1, duration_ms=500)]
+		findings = [{"severity": "High", "action_ref": "1"}]
+		out = renderer._build_waterfall(actions, findings)
+		by_idx = {r["name"]: r for r in out}
+		assert by_idx["action_0"]["hot"] is False
+		assert by_idx["action_1"]["hot"] is True
+
+
+class TestBgFlag:
+	def test_background_job_event_type_marks_bg(self):
+		actions = [
+			_a(0, duration_ms=900, event_type="RQ Job"),
+			_a(1, duration_ms=500, event_type="HTTP Request"),
+		]
+		out = renderer._build_waterfall(actions, [])
+		by_name = {r["name"]: r for r in out}
+		assert by_name["action_0"]["bg"] is True
+		assert by_name["action_1"]["bg"] is False
+
+	def test_hot_overrides_bg_visually(self):
+		"""Both flags can be True. Template colour priority is `hot`
+		over `bg` (red wins). The data layer reports both honestly;
+		the template renders the precedence."""
+		actions = [_a(0, duration_ms=900, event_type="RQ Job")]
+		findings = [{"severity": "High", "action_ref": "0"}]
+		out = renderer._build_waterfall(actions, findings)
+		assert out[0]["hot"] is True
+		assert out[0]["bg"] is True


### PR DESCRIPTION
…Light syntax

- Adopt the 19-key template_variable_contract via report_context.py (build_report_context + ~18 sub-builders + 4 helpers); migrate every template section to read from report_data.*; drop legacy flat keys in a subtractive pop.
- Rename Phase 2 -> Line-Level Drilldown across user-visible surfaces and public Python identifiers; legacy <a id="phase2"> alias precedes the renamed panel so external links resolve.
- Rename Background Job -> RQ Job everywhere; sweep em-dash -> hyphen.
- Propagate target DocType suffix to every actionable filepath / URL / description.
- Lens promo: lead with serif "Aerele Lens"; chip vertically centred.
- Remove editorial section numerals (03/04/05) for consistency.
- Phase K.0: Pygments-based syntax highlighting of code snippets (single-block-then-split per snippet for multi-line correctness).
- Phase K.2: sticky nav-pills so the Jump-to nav stays accessible during deep scroll.
- Phase K.5: nested-<details> call-tree panel sourced from the slowest action's call_tree_json; hot-frame highlight when child consumes >=50% of its parent.
- Code-snippet theme: GitHub Light palette for readability against the report's light editorial body.
- 1450 tests green / ruff clean.