### PR TITLE
Fix/optimus app picker fixes

### DIFF
--- a/optimus/analyze.py
+++ b/optimus/analyze.py
@@ -641,6 +641,13 @@ def _auto_arm_phase2(docname: str, context) -> None:
 			trees.append(tree)
 
 		candidates = _lp_picker._build_tree_indented_candidates(trees)
+		# Don't auto-arm Ignored-App functions (same filter as the picker).
+		try:
+			from optimus.settings import get_ignored_apps
+			_ignored_apps = get_ignored_apps()
+		except Exception:
+			_ignored_apps = ()
+		candidates, _ = _lp_picker.filter_out_ignored_apps(candidates, _ignored_apps)
 		picks = [
 			{"dotted_path": c["dotted_path"], "source": "curated"}
 			for c in candidates

--- a/optimus/api.py
+++ b/optimus/api.py
@@ -1948,7 +1948,7 @@ def get_config_profiles() -> dict:
 # this surface is the thin transport layer.
 
 
-def _picker_empty_hint(action_count, with_tree, parsed_ok, candidate_count):
+def _picker_empty_hint(action_count, with_tree, parsed_ok, candidate_count, ignored_apps_filtered=0):
 	"""Phase K diagnostic: map the picker's empty-state counter triple
 	to a human-readable reason. Surfaced in the dialog when the
 	curated list is empty so the operator can self-diagnose
@@ -1973,6 +1973,15 @@ def _picker_empty_hint(action_count, with_tree, parsed_ok, candidate_count):
 			"Actions carry call trees but none parsed as valid "
 			"JSON. Check the bench log for 'Failed to deserialize "
 			"pyi tree' or 'optimus analyze' error entries."
+		)
+	if candidate_count and ignored_apps_filtered >= candidate_count:
+		# Built, but all dropped as Ignored Apps.
+		return (
+			f"Call trees loaded, but all {ignored_apps_filtered} candidate "
+			"frame(s) belong to apps on your Ignored Apps list, so none are "
+			"offered here. Remove that app from Optimus Settings › Ignored "
+			"Apps (keep at least one entry — clearing the list restores the "
+			"framework-app defaults), or type the function you want below."
 		)
 	if candidate_count == 0:
 		return (
@@ -2030,6 +2039,20 @@ def get_phase2_candidates(session_uuid: str) -> dict:
 	# list before their children, each row tagged with ``depth`` so
 	# the JS dialog can render hierarchy via indented labels.
 	candidates = _lp_picker._build_tree_indented_candidates(trees)
+	# Pre-filter count for the diagnostic/hint — captured before the ignored
+	# filter reassigns ``candidates`` below.
+	raw_candidate_count = len(candidates)
+
+	# Drop candidates whose app is on the Ignored Apps list — the report
+	# already excludes those apps, so offering them here would be inconsistent.
+	try:
+		from optimus.settings import get_ignored_apps
+		_ignored_apps = get_ignored_apps()
+	except Exception:
+		_ignored_apps = ()
+	candidates, ignored_apps_filtered = _lp_picker.filter_out_ignored_apps(
+		candidates, _ignored_apps
+	)
 
 	# v0.6.0 Round 6: surface the configured auto-expand default so the
 	# picker dialog ticks/un-ticks its checkbox per Optimus Settings.
@@ -2044,7 +2067,6 @@ def get_phase2_candidates(session_uuid: str) -> dict:
 		1 for a in (doc.actions or []) if a.call_tree_json
 	)
 	trees_parsed_ok = len(trees)
-	raw_candidate_count = len(candidates)
 
 	return {
 		"session_uuid": session_uuid,
@@ -2058,11 +2080,13 @@ def get_phase2_candidates(session_uuid: str) -> dict:
 			"actions_with_call_tree_json": actions_with_tree,
 			"trees_parsed_ok": trees_parsed_ok,
 			"raw_candidates_before_filter": raw_candidate_count,
+			"ignored_apps_filtered": ignored_apps_filtered,
 			"hint": _picker_empty_hint(
 				action_count,
 				actions_with_tree,
 				trees_parsed_ok,
 				raw_candidate_count,
+				ignored_apps_filtered=ignored_apps_filtered,
 			),
 		},
 	}

--- a/optimus/line_profile/picker.py
+++ b/optimus/line_profile/picker.py
@@ -58,6 +58,21 @@ def _is_synthetic_frame(function: str) -> bool:
 	return function.startswith("<") or function.startswith("[")
 
 
+def filter_out_ignored_apps(candidates, ignored_apps):
+	"""Drop candidates whose owning ``app`` is on the Ignored Apps list.
+
+	Returns ``(kept, dropped_count)``. Pure — the caller resolves the ignored
+	set (``settings.get_ignored_apps``) and passes it in, so the manual picker
+	(``api.get_phase2_candidates``) and auto-arm (``analyze._auto_arm_phase2``)
+	share ONE matching rule and can't silently drift.
+	"""
+	ignored = frozenset(a for a in (ignored_apps or ()) if a)
+	if not ignored:
+		return list(candidates), 0
+	kept = [c for c in candidates if c.get("app") not in ignored]
+	return kept, len(candidates) - len(kept)
+
+
 def _derive_module_path(filename: str) -> str:
 	"""Build a Python module dotted path from a captured filename.
 

--- a/optimus/optimus/doctype/optimus_settings/optimus_settings.js
+++ b/optimus/optimus/doctype/optimus_settings/optimus_settings.js
@@ -1,9 +1,9 @@
 // Copyright (c) 2026, Optimus contributors
 // For license information, please see license.txt
 
-// Populate the `Tracked Apps` child table's `app_name` Autocomplete
-// with the bench's actual installed apps — same UX as picking a
-// Module Def, but for the list of apps rather than modules.
+// Fill the `app_name` Autocomplete on BOTH the Tracked Apps and Ignored Apps
+// child tables with the bench's installed apps — both share the field on the
+// `Optimus Tracked App` child doctype, so both must be filled.
 //
 // Why on refresh: the Autocomplete options live on the grid docfield,
 // which Frappe re-creates whenever the form rebinds. Setting options
@@ -72,20 +72,39 @@ frappe.ui.form.on("Optimus Settings", {
 				if (!r || !r.message) {
 					return;
 				}
-				const apps = r.message;
-				const grid = frm.fields_dict.tracked_apps.grid;
-				if (!grid) {
-					return;
+				// Options are a newline-separated string (Frappe splits on \n).
+				const options = r.message.join("\n");
+				// New rows rebuild their docfield from frappe.meta, so set the
+				// base child-doctype meta too — both docfield_map AND
+				// docfield_list — or a freshly-added row's dropdown is blank on
+				// older Frappe (e.g. 15.98).
+				try {
+					const child_dt = "Optimus Tracked App";
+					const base_df = frappe.meta.get_docfield(child_dt, "app_name");
+					if (base_df) {
+						base_df.options = options;
+					}
+					const list = (frappe.meta.docfield_list || {})[child_dt] || [];
+					list.forEach((d) => {
+						if (d.fieldname === "app_name") {
+							d.options = options;
+						}
+					});
+				} catch (e) {
+					// meta not ready — per-grid update below covers existing rows.
 				}
-				// Autocomplete fieldtype accepts options as a
-				// newline-separated string (Frappe's renderer splits
-				// on \n). Passing an array also works in v14+, but
-				// the string form is the safe cross-version shape.
-				grid.update_docfield_property(
-					"app_name",
-					"options",
-					apps.join("\n")
-				);
+				// Fill each grid that's present.
+				["tracked_apps", "ignored_apps"].forEach((fieldname) => {
+					const field = frm.fields_dict[fieldname];
+					const grid = field && field.grid;
+					if (grid) {
+						grid.update_docfield_property(
+							"app_name",
+							"options",
+							options
+						);
+					}
+				});
 			},
 		});
 

--- a/optimus/tests/test_auto_arm_phase2.py
+++ b/optimus/tests/test_auto_arm_phase2.py
@@ -170,6 +170,24 @@ class TestAutoArmPhase2:
 		monkeypatch.setattr(frappe, "get_doc", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")), raising=False)
 		analyze._auto_arm_phase2("PS-1", _ctx())  # must not raise
 
+	def test_ignored_app_candidates_are_dropped(self, arm_env, monkeypatch):
+		"""A recommended candidate whose app is on the Ignored Apps list must
+		not be auto-armed (same filter the manual picker applies)."""
+		import optimus.settings as settings_mod
+		monkeypatch.setattr(settings_mod, "get_config",
+			lambda: types.SimpleNamespace(phase2_max_runs_per_session=10,
+				ignored_apps=("ignored_app",)))
+		arm_env.candidates = [
+			{"dotted_path": "ignored_app.tasks.slow", "app": "ignored_app",
+				"recommended": True},
+			{"dotted_path": "my_app.tasks.slow", "app": "my_app",
+				"recommended": True},
+		]
+		analyze._auto_arm_phase2("PS-1", _ctx())
+		assert len(arm_env.start_calls) == 1
+		armed = [p["dotted_path"] for p in arm_env.start_calls[0]["picks"]]
+		assert armed == ["my_app.tasks.slow"]  # ignored_app dropped
+
 
 def test_run_calls_auto_arm_after_ready():
 	src = inspect.getsource(analyze.run)

--- a/optimus/tests/test_line_profile_picker.py
+++ b/optimus/tests/test_line_profile_picker.py
@@ -870,3 +870,68 @@ class TestPickerDialogIndent:
 		# The dialog must still re-nest the flat DFS list via the depth stack
 		# (the Python picker assigns the depths the tests above pin down).
 		assert "stack[stack.length - 1].depth >= depth" in self._js_source()
+
+
+class TestFilterOutIgnoredApps:
+	"""picker.filter_out_ignored_apps — the ONE shared filter used by both the
+	manual picker (api.get_phase2_candidates) and auto-arm."""
+
+	def _cands(self):
+		return [
+			{"app": "erpnext", "dotted_path": "a"},
+			{"app": "my_app", "dotted_path": "b"},
+			{"app": "erpnext", "dotted_path": "c"},
+		]
+
+	def test_drops_matching_apps_and_counts(self):
+		kept, dropped = picker.filter_out_ignored_apps(self._cands(), ("erpnext",))
+		assert [c["dotted_path"] for c in kept] == ["b"]
+		assert dropped == 2
+
+	def test_empty_ignored_returns_all_unchanged(self):
+		kept, dropped = picker.filter_out_ignored_apps(self._cands(), ())
+		assert [c["dotted_path"] for c in kept] == ["a", "b", "c"]
+		assert dropped == 0
+
+	def test_none_ignored_is_safe(self):
+		kept, dropped = picker.filter_out_ignored_apps(self._cands(), None)
+		assert dropped == 0 and len(kept) == 3
+
+	def test_falsy_entries_in_ignored_never_match(self):
+		# "" / None entries must not swallow a candidate that has no "app".
+		kept, dropped = picker.filter_out_ignored_apps([{"dotted_path": "a"}], ("", None))
+		assert dropped == 0 and kept == [{"dotted_path": "a"}]
+
+	def test_candidate_without_app_key_is_kept(self):
+		kept, dropped = picker.filter_out_ignored_apps([{"dotted_path": "a"}], ("erpnext",))
+		assert dropped == 0 and [c["dotted_path"] for c in kept] == ["a"]
+
+
+class TestPickerEmptyHintIgnored:
+	"""The empty-state hint distinguishes 'all candidates were on the Ignored
+	Apps list' from 'only framework plumbing / too short'."""
+
+	def _hint(self, **kw):
+		from optimus.api import _picker_empty_hint
+
+		return _picker_empty_hint(**kw)
+
+	def test_all_ignored_reports_ignored_apps(self):
+		msg = self._hint(action_count=3, with_tree=3, parsed_ok=3,
+			candidate_count=5, ignored_apps_filtered=5)
+		assert "Ignored Apps" in msg
+		assert "5 candidate" in msg
+		# Must NOT push the operator to clear the whole list (that resurrects
+		# the framework-app defaults) — it must say to keep at least one entry.
+		assert "keep at least one entry" in msg
+
+	def test_some_survivors_give_no_hint(self):
+		# 5 built, 2 ignored → 3 survive → picker isn't empty → no hint.
+		msg = self._hint(action_count=3, with_tree=3, parsed_ok=3,
+			candidate_count=5, ignored_apps_filtered=2)
+		assert msg == ""
+
+	def test_zero_built_is_framework_plumbing_not_ignored(self):
+		msg = self._hint(action_count=3, with_tree=3, parsed_ok=3,
+			candidate_count=0, ignored_apps_filtered=0)
+		assert "framework plumbing" in msg


### PR DESCRIPTION
## Summary

This PR includes two related fixes for **Optimus Settings** and **Phase 2**:

* Fix the **Tracked & Ignored Apps → App Name** dropdown so installed apps are available for both existing and newly-added rows.
* Fix the **Phase 2 line-profile picker and auto-arming** to respect the **Ignored Apps** list, matching report behaviour.

## Changes

### 1. Fix App Name dropdown in Settings

**Problem**

The **App Name** picker in both the Tracked Apps and Ignored Apps grids was empty, requiring app names to be entered manually. Newly-added rows could also have a blank dropdown.

**Root cause**

* Installed-app options were populated only for the **Tracked Apps** grid.
* On Frappe 15.98, newly-added grid rows rebuild their docfield from `frappe.meta`.
* Options were updated only in `docfield_map`, not `docfield_list`, so newly-added rows inherited an empty options list.

**Fix**

* Populate installed-app options for **both Tracked Apps and Ignored Apps**.
* Update options in both `docfield_map` and `docfield_list`.
* This ensures installed-app suggestions are available for both existing and newly-created rows.

---

### 2. Respect Ignored Apps in Phase 2 candidates

**Problem**

Functions belonging to apps listed under **Ignored Apps** were still appearing as Phase 2 line-profile candidates and could be auto-armed, even though those apps are excluded from the report.

**Fix**

* `get_phase2_candidates` now excludes candidates whose app is in the **Ignored Apps** list.
* `_auto_arm_phase2` applies the same filtering.
* Filtering fails safe: if the settings cannot be read, candidates are not filtered.
* `raw_candidates_before_filter` is captured before applying the Ignored Apps filter for accurate diagnostics.
* Updated the empty-state hint to report when **all candidates are on the Ignored Apps list**, instead of incorrectly attributing the empty result to framework plumbing.

