### PR TITLE
fix(n_plus_one): report N+1 by the per-request loop, not cross-reques…

### DIFF
--- a/optimus/__init__.py
+++ b/optimus/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.26"
+__version__ = "0.12.29"
 
 
 def safe_commit() -> None:

--- a/optimus/analyzers/n_plus_one.py
+++ b/optimus/analyzers/n_plus_one.py
@@ -352,8 +352,14 @@ def _build_user_finding(
 			},
 			default=str,
 		),
-		"estimated_impact_ms": round(total_time, 2),
-		"affected_count": total_count,
+		# Headline economics — read by the TL;DR hero (renderer/_internal.py),
+		# the card impact box (report.html), the report-wide sort, and the AI-fix
+		# prompt (ai_fix.py). Loop-scoped to match the loop-scoped title/description:
+		# leaving them cumulative made those surfaces show "60×" / "280ms" beside a
+		# "12×" card. The session-wide totals stay in the detail JSON above
+		# (occurrences / total_time_ms), rendered under a "session-wide" label.
+		"estimated_impact_ms": round(loop_time, 2),
+		"affected_count": loop_count,
 		"action_ref": str(action_idx),
 	}
 

--- a/optimus/analyzers/n_plus_one.py
+++ b/optimus/analyzers/n_plus_one.py
@@ -156,15 +156,20 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		# but also runs once in 100 others has run_count == 1, so the "ran in N
 		# requests" wording and the post-fix projection don't over-count the
 		# single-run requests — those carry no loop to collapse.
-		looping_actions = {a for a, c in dominant_action_counts.items() if c >= 2}
+		# A request "looped" only if it hit the N+1 threshold (min_occurrences) — the
+		# same bar that qualifies the finding. Counting requests with a mere 2–9
+		# sub-threshold repeats would inflate run_count / loop_time / severity and
+		# make the "looped in N requests" wording dishonest (those requests never
+		# held the flagged loop).
+		looping_actions = {a for a, c in dominant_action_counts.items() if c >= min_occurrences}
 		run_count = len(looping_actions)
 		# Time + P95 for the finding are scoped to the requests where the query
-		# genuinely LOOPED (count >= 2), NOT to a single "busiest" request: a
-		# loop that legitimately recurs in 5 requests keeps all 5 in scope, so
-		# its cumulative-but-recoverable cost still rates severity honestly.
-		# Conversely a tiny 10× loop is not rated High just because the same
-		# query, run once each across 100 unrelated requests, sums past the time
-		# threshold — that cost is NOT recoverable by batching this loop.
+		# genuinely LOOPED at that magnitude, NOT to a single "busiest" request: a
+		# loop that legitimately recurs in 5 requests keeps all 5 in scope, so its
+		# cumulative-but-recoverable cost still rates severity honestly. A tiny loop
+		# is not rated High just because the same query, run below the threshold
+		# across many unrelated requests, sums past the time floor — that cost is
+		# NOT recoverable by batching this loop.
 		# ``total_time`` (all occurrences) stays for cumulative reporting.
 		loop_occurrences = [o for o in canonical_occurrences if o["action_idx"] in looping_actions]
 		loop_time = sum(o["duration"] for o in loop_occurrences)
@@ -318,7 +323,10 @@ def _build_user_finding(
 				# blow out the 140-char title limit / DocType blob.
 				"sample_queries": all_variants[:5],
 				"total_time_ms": round(total_time, 2),
-				"average_time_ms": round(avg_ms, 2),
+				# No session-wide "~X each": for a bimodal loop (loop hits + unrelated
+				# single runs) it blends two costs into a misleading average and would
+				# contradict the impact box's loop-scoped "per hit". The loop's own
+				# per-query cost is shown there instead.
 				# Scope tag for the card's impact box: this finding's estimated_impact_ms
 				# is the loop's own recoverable cost, not the session-wide total that
 				# every other finding reports as "consolidated".

--- a/optimus/analyzers/n_plus_one.py
+++ b/optimus/analyzers/n_plus_one.py
@@ -2,8 +2,9 @@
 # For license information, please see license.txt
 
 """True N+1 detection: group by callsite, then by normalized SQL. A variant
-recurring > `MIN_OCCURRENCES` times WITHIN ONE request is a per-row loop — the
-distinction a bare copy-count can't make."""
+recurring at least `n_plus_one_min_occurrences` (a settings value, default 10)
+times WITHIN ONE request is a per-row loop — the distinction a bare copy-count
+can't make."""
 
 import json
 from collections import Counter, defaultdict

--- a/optimus/analyzers/n_plus_one.py
+++ b/optimus/analyzers/n_plus_one.py
@@ -319,6 +319,10 @@ def _build_user_finding(
 				"sample_queries": all_variants[:5],
 				"total_time_ms": round(total_time, 2),
 				"average_time_ms": round(avg_ms, 2),
+				# Scope tag for the card's impact box: this finding's estimated_impact_ms
+				# is the loop's own recoverable cost, not the session-wide total that
+				# every other finding reports as "consolidated".
+				"impact_scope_label": "recoverable",
 				# v0.5.3: projected post-fix timing. Batching a loop's N
 				# queries into ONE collapses that request's cost to roughly a
 				# single query. Empirically a batched query with an IN (…)
@@ -354,12 +358,15 @@ def _build_user_finding(
 		),
 		# Headline economics — read by the TL;DR hero (renderer/_internal.py),
 		# the card impact box (report.html), the report-wide sort, and the AI-fix
-		# prompt (ai_fix.py). Loop-scoped to match the loop-scoped title/description:
-		# leaving them cumulative made those surfaces show "60×" / "280ms" beside a
-		# "12×" card. The session-wide totals stay in the detail JSON above
-		# (occurrences / total_time_ms), rendered under a "session-wide" label.
+		# prompt (ai_fix.py). Both are scoped to the SAME occurrence set — the loop's
+		# own hits (loop_durations) — so the generic `per_hit = impact / count`
+		# consumers compute the loop's real per-query cost. estimated_impact_ms is the
+		# loop's total time; affected_count is the loop's total hit COUNT (not
+		# loop_count, the per-request peak — mixing the two denominators inflated
+		# per-hit on multi-request loops). The "in a row" count (loop_count) drives
+		# the title/hero; the session-wide totals stay in the detail JSON above.
 		"estimated_impact_ms": round(loop_time, 2),
-		"affected_count": loop_count,
+		"affected_count": len(loop_durations),
 		"action_ref": str(action_idx),
 	}
 

--- a/optimus/analyzers/n_plus_one.py
+++ b/optimus/analyzers/n_plus_one.py
@@ -1,21 +1,9 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Analyzer: true N+1 query detection by callsite.
-
-The single highest-leverage insight in the report. Groups queries by
-(normalized_query, callsite_file, callsite_line) — i.e. queries that have
-the same SQL shape AND were issued from the same line of Python code.
-A group with more than `MIN_OCCURRENCES` queries is almost always a Python
-loop fetching its data one row at a time.
-
-This is what makes the recorder's stack capture worth its overhead. The
-existing recorder counts "exact_copies" and "normalized_copies" but doesn't
-attribute them to a callsite, so it can't tell the difference between
-"the same query ran 50 times because it's in a loop" and "the same query
-ran 50 times from 50 different places in the code". Our grouping by
-callsite makes the distinction.
-"""
+"""True N+1 detection: group by callsite, then by normalized SQL. A variant
+recurring > `MIN_OCCURRENCES` times WITHIN ONE request is a per-row loop — the
+distinction a bare copy-count can't make."""
 
 import json
 from collections import Counter, defaultdict
@@ -130,17 +118,12 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			for o in occ
 		]
 		total_time = sum(per_hit_durations)
-		# Minimum total time so we don't flag 10 × 0.1 ms queries as
-		# an N+1 — those are not worth reporting.
-		if total_time < min_total_time:
-			continue
 
 		# For the finding's "canonical" representative, use the query
 		# variant with the most occurrences (highest-impact loop).
 		top_variant = max(variants.items(), key=lambda kv: len(kv[1]))
 		canonical_query, canonical_occurrences = top_variant
 		function_name = bucket["function_name"]
-		action_idx = canonical_occurrences[0]["action_idx"]
 		variant_count = len(variants)
 
 		# v0.7.x: multi-variant N+1 ("Callsite ran X queries (N
@@ -153,8 +136,53 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		if variant_count > 1:
 			continue
 
+		# The true "N+1" magnitude is how many times the loop ran WITHIN A
+		# SINGLE request — not the cross-request total. A 12-query loop that
+		# ran in 5 separate requests is "12× in a row", not "60× in a row":
+		# reporting the cross-request total inflated the count, the "…in a
+		# row" wording, AND the occurrence-based severity. ``total_count``
+		# stays for cumulative cost/averages; ``loop_count`` drives the
+		# count-based wording + severity.
+		dominant_action_counts = Counter(o["action_idx"] for o in canonical_occurrences)
+		# ``action_ref`` must point at the request where the loop actually ran
+		# (the dominant action), NOT the first request the query merely appeared
+		# in — the report walks THAT action's call tree for inner-loop detail.
+		# Taking loop_count from the same most_common(1) keeps the two aligned.
+		dominant_action_idx, loop_count = dominant_action_counts.most_common(1)[0]
+		action_idx = dominant_action_idx
+		# ``run_count`` = requests in which the query actually REPEATED (a real
+		# loop to batch), not merely appeared. A query that loops in one request
+		# but also runs once in 100 others has run_count == 1, so the "ran in N
+		# requests" wording and the post-fix projection don't over-count the
+		# single-run requests — those carry no loop to collapse.
+		looping_actions = {a for a, c in dominant_action_counts.items() if c >= 2}
+		run_count = len(looping_actions)
+		# Time + P95 for the finding are scoped to the requests where the query
+		# genuinely LOOPED (count >= 2), NOT to a single "busiest" request: a
+		# loop that legitimately recurs in 5 requests keeps all 5 in scope, so
+		# its cumulative-but-recoverable cost still rates severity honestly.
+		# Conversely a tiny 10× loop is not rated High just because the same
+		# query, run once each across 100 unrelated requests, sums past the time
+		# threshold — that cost is NOT recoverable by batching this loop.
+		# ``total_time`` (all occurrences) stays for cumulative reporting.
+		loop_occurrences = [o for o in canonical_occurrences if o["action_idx"] in looping_actions]
+		loop_time = sum(o["duration"] for o in loop_occurrences)
+		loop_durations = [o["duration"] for o in loop_occurrences]
+
 		short_fn = short_filename(filename)
 		is_framework = is_framework_callsite(filename, tracked_apps=tracked_apps)
+
+		# Minimum time before we flag, so 10 × 0.1 ms queries aren't reported as an
+		# N+1. Gate on the same time each finding type reports: a user finding is
+		# rated on the loop's OWN recoverable time (a trivial loop isn't surfaced
+		# just because the same query also runs once across many unrelated requests),
+		# while a framework finding stays cumulative/informational and gates on the
+		# session-wide total_time its text quotes — so a framework callsite with a
+		# high cumulative cost but a cheap per-request loop isn't silently dropped.
+		gate_time = total_time if is_framework else loop_time
+		if gate_time < min_total_time:
+			continue
+
 		builder = _build_framework_finding if is_framework else _build_user_finding
 		findings.append(builder(
 			short_fn=short_fn,
@@ -162,9 +190,13 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			lineno=lineno,
 			function_name=function_name,
 			normalized=canonical_query,
-			count=total_count,
+			total_count=total_count,
+			loop_count=loop_count,
+			run_count=run_count,
 			total_time=total_time,
+			loop_time=loop_time,
 			per_hit_durations=per_hit_durations,
+			loop_durations=loop_durations,
 			action_idx=action_idx,
 			# v0.5.2 round 3: expose variant list so the detail can
 			# show "10 query variants observed" with sample queries.
@@ -189,17 +221,9 @@ def _severity(count: int, total_time_ms: float) -> str:
 	return "Low"
 
 
-def _title_for_callsite(short_fn, lineno, count, variant_count) -> str:
-	"""Format the N+1 title. Single variant: 'Same query ran N× at …'.
-	Multi variant: 'Callsite ran N queries in M variants at …' so
-	the user knows the loop generates different SQL shapes, not
-	literally the same string."""
-	if variant_count <= 1:
-		return f"Same query ran {count}× at {short_fn}:{lineno}"
-	return (
-		f"Callsite ran {count} queries ({variant_count} variants) "
-		f"at {short_fn}:{lineno}"
-	)
+def _title_for_callsite(short_fn, lineno, count) -> str:
+	"""'Same query ran N×' — multi-variant callsites are suppressed upstream (analyze())."""
+	return f"Same query ran {count}× at {short_fn}:{lineno}"
 
 
 def _build_user_finding(
@@ -209,46 +233,68 @@ def _build_user_finding(
 	lineno,
 	function_name: str,
 	normalized: str,
-	count: int,
+	total_count: int,
+	loop_count: int,
+	run_count: int = 1,
 	total_time: float,
+	loop_time: float = 0.0,
 	per_hit_durations: list[float] | None = None,
+	loop_durations: list[float] | None = None,
 	action_idx: int,
 	all_variants: list[str] | None = None,
 	variant_count: int = 1,
 ) -> dict:
-	"""Build the classic user-code N+1 finding — High/Medium/Low
-	severity by count & impact, actionable fix hint."""
+	"""User-code N+1 finding — severity by loop size & the loop's own time, with a fix hint."""
 	all_variants = all_variants or [normalized]
-	multi = variant_count > 1
+	# avg_ms = session-wide average per occurrence (rendered as "~X each" next
+	# to the total occurrence count). loop_avg = the loop's own per-query cost,
+	# used only for the post-fix projection so unrelated single-run requests
+	# don't skew it (falls back to avg_ms when no loop rows were captured).
+	avg_ms = total_time / total_count if total_count else 0
+	loop_avg = loop_time / len(loop_durations) if loop_durations else avg_ms
 
-	desc = (
-		f"We noticed the same query was repeated {count} times in a row "
-		f"from the same line of code ({filename}:{lineno}), costing about "
-		f"{total_time:.0f}ms in total. This is usually a Python loop that "
-		"should fetch its data in one query instead of one-at-a-time. "
-		"Typical fix: a few hours of dev work."
-	) if not multi else (
-		f"The loop at **{filename}:{lineno}** issued **{count} queries** "
-		f"in {variant_count} different shapes, costing {total_time:.0f}ms. "
-		"Even though the queries differ, they all come from the same "
-		"line — a loop iterating over inputs and running one query per "
-		"iteration. The fix is the same as a classic N+1: batch the "
-		"data into a single query."
+	# Cost quoted is the LOOP's own time (loop_time), never the cross-request
+	# cumulative total — a query that loops in one request but also runs once
+	# elsewhere must not fold those single runs into "the loop".
+	tail = (
+		"This is usually a Python loop that should fetch its data in one "
+		"query instead of one-at-a-time. Typical fix: a few hours of dev work."
 	)
+	if run_count > 1:
+		# The loop spanned several requests; loop_count is the WORST request's
+		# count (the peak), not a uniform per-request figure — "up to N" so it
+		# isn't read as N × run_count.
+		desc = (
+			f"We noticed the same query repeated up to {loop_count} times in a row "
+			f"from the same line of code ({filename}:{lineno}). That loop ran in "
+			f"{run_count} separate requests, costing about {loop_time:.0f}ms. {tail}"
+		)
+	else:
+		# One looping request, so loop_count is exact.
+		desc = (
+			f"We noticed the same query was repeated {loop_count} times in a row "
+			f"from the same line of code ({filename}:{lineno}), costing about "
+			f"{loop_time:.0f}ms. {tail}"
+		)
 
 	# v0.7.x M4: P95 of the per-hit duration distribution, when the
 	# sample is large enough to be meaningful. Gives the user a sense
-	# of the tail beyond the average and consolidated total.
+	# of the tail beyond the average and consolidated total. Scoped to the
+	# loop's own hits (not single-run appearances) so it describes the
+	# thing being flagged.
 	p95_ms = (
-		percentile(per_hit_durations, 95)
-		if per_hit_durations and len(per_hit_durations) >= P95_MIN_SAMPLES
+		percentile(loop_durations, 95)
+		if loop_durations and len(loop_durations) >= P95_MIN_SAMPLES
 		else None
 	)
 
 	return {
 		"finding_type": "N+1 Query",
-		"severity": _severity(count, total_time),
-		"title": _title_for_callsite(short_fn, lineno, count, variant_count),
+		# Severity by the per-request loop size (loop_count) and the loop's OWN
+		# recoverable time (loop_time) — never the cross-request cumulative
+		# total, which single-run requests would inflate.
+		"severity": _severity(loop_count, loop_time),
+		"title": _title_for_callsite(short_fn, lineno, loop_count),
 		"customer_description": desc,
 		"technical_detail_json": json.dumps(
 			{
@@ -258,7 +304,12 @@ def _build_user_finding(
 					"function": function_name,
 				},
 				"normalized_query": normalized,
-				"occurrences": count,
+				# occurrences = total across the session (scope); loop_count =
+				# the per-request "in a row" size; run_count = how many
+				# requests the loop ran in.
+				"occurrences": total_count,
+				"loop_count": loop_count,
+				"run_count": run_count,
 				"variant_count": variant_count,
 				"p95_ms": round(p95_ms, 2) if p95_ms is not None else None,
 				# Up to 5 sample variants for the detail block —
@@ -266,24 +317,28 @@ def _build_user_finding(
 				# blow out the 140-char title limit / DocType blob.
 				"sample_queries": all_variants[:5],
 				"total_time_ms": round(total_time, 2),
-				"average_time_ms": round(total_time / count, 2) if count else 0,
-				# v0.5.3: projected post-fix timing. Batching N loop
-				# queries into ONE collapses the wall-clock cost to
-				# roughly a single query. Empirically, a batched query
-				# with an IN (…) filter or a JOIN costs ~2× a single
-				# tight query (the work still scans the same rows, just
-				# once, and returns a bigger result set). We use that
-				# 2× multiplier as the ceiling so the user sees the
-				# realistic savings, not the idealized floor. A 74-
-				# query 85ms loop projects to ~2.2ms after batching.
-				"projected_total_ms": (
-					round((total_time / count) * 2, 2) if count else 0
+				"average_time_ms": round(avg_ms, 2),
+				# v0.5.3: projected post-fix timing. Batching a loop's N
+				# queries into ONE collapses that request's cost to roughly a
+				# single query. Empirically a batched query with an IN (…)
+				# filter or a JOIN costs ~2× a single tight query (same rows
+				# scanned once, bigger result set). You still pay that batched
+				# query once per LOOPING request, so multiply by run_count —
+				# otherwise the projection collapses a whole session to one
+				# query and overstates the win. Capped at the current total so
+				# a projection can never read as WORSE than doing nothing.
+				# Uses the LOOP's own per-query average (loop_avg), not the
+				# session-wide avg_ms that single-run requests would skew. Only
+				# the loop collapses — any non-loop appearances of this query
+				# (total_time - loop_time) keep their cost, so they're added back
+				# rather than assumed away. Capped at the current total.
+				"projected_total_ms": round(
+					min((total_time - loop_time) + loop_avg * 2 * max(run_count, 1), total_time),
+					2,
 				),
-				"projected_avg_time_ms": (
-					round((total_time / count) * 2, 2) if count else 0
-				),
+				"projected_avg_time_ms": round(loop_avg * 2, 2),
 				"projected_speedup_label": (
-					f"~{max(1, count // 2)}× fewer queries" if count >= 4 else None
+					f"~{max(1, loop_count // 2)}× fewer queries" if loop_count >= 4 else None
 				),
 				"fix_hint": (
 					"This is a classic N+1 pattern. The Python code at "
@@ -297,7 +352,7 @@ def _build_user_finding(
 			default=str,
 		),
 		"estimated_impact_ms": round(total_time, 2),
-		"affected_count": count,
+		"affected_count": total_count,
 		"action_ref": str(action_idx),
 	}
 
@@ -309,25 +364,26 @@ def _build_framework_finding(
 	lineno,
 	function_name: str,
 	normalized: str,
-	count: int,
+	total_count: int,
+	loop_count: int,
+	run_count: int = 1,
 	total_time: float,
+	loop_time: float = 0.0,
 	per_hit_durations: list[float] | None = None,
+	loop_durations: list[float] | None = None,
 	action_idx: int,
 	all_variants: list[str] | None = None,
 	variant_count: int = 1,
 ) -> dict:
-	"""Build the framework-level N+1 finding — always Low severity,
-	description acknowledges the user can rarely fix framework code.
-
-	Still includes the technical detail (callsite, query, impact) so
-	contributors who WANT to optimize the framework can find it.
-	"""
+	"""Framework-level N+1 — always Low, cumulative framing, full technical detail."""
 	all_variants = all_variants or [normalized]
-	title = (
-		f"Framework query repeated {count}× at {short_fn}:{lineno}"
-		if variant_count <= 1
-		else f"Framework callsite ran {count} queries ({variant_count} variants) at {short_fn}:{lineno}"
-	)
+	# Framework findings are Low + informational and framed around the
+	# CUMULATIVE session cost (the description says "issued N queries in this
+	# session"), so the title uses total_count too — keeping title and body on
+	# the same number. (The user-code finding, by contrast, is about a
+	# per-request loop and uses loop_count.) loop_count/run_count are still
+	# carried in the detail JSON below for anyone optimising the framework.
+	title = f"Framework query repeated {total_count}× at {short_fn}:{lineno}"
 
 	p95_ms = (
 		percentile(per_hit_durations, 95)
@@ -341,7 +397,7 @@ def _build_framework_finding(
 		"title": title,
 		"customer_description": (
 			f"Frappe's own code at **{filename}:{lineno}** issued "
-			f"{count} queries in this session, totalling "
+			f"{total_count} queries in this session, totalling "
 			f"{total_time:.0f}ms. This is typically the framework "
 			"resolving metadata, permissions, or building queries for "
 			"different inputs — it's rarely something you can change "
@@ -357,12 +413,14 @@ def _build_framework_finding(
 					"function": function_name,
 				},
 				"normalized_query": normalized,
-				"occurrences": count,
+				"occurrences": total_count,
+				"loop_count": loop_count,
+				"run_count": run_count,
 				"variant_count": variant_count,
 				"p95_ms": round(p95_ms, 2) if p95_ms is not None else None,
 				"sample_queries": all_variants[:5],
 				"total_time_ms": round(total_time, 2),
-				"average_time_ms": round(total_time / count, 2) if count else 0,
+				"average_time_ms": round(total_time / total_count, 2) if total_count else 0,
 				"is_framework": True,
 				"fix_hint": (
 					"This repetition is inside Frappe framework code at "
@@ -378,6 +436,6 @@ def _build_framework_finding(
 			default=str,
 		),
 		"estimated_impact_ms": round(total_time, 2),
-		"affected_count": count,
+		"affected_count": total_count,
 		"action_ref": str(action_idx),
 	}

--- a/optimus/renderer/_internal.py
+++ b/optimus/renderer/_internal.py
@@ -1798,15 +1798,22 @@ def _compose_tldr(
 		# loop_count so the hero matches the finding title. Framework N+1 keeps
 		# affected_count — it is already the cumulative total its title shows.
 		_loop_n = affected
+		_spread = ""
 		if finding_type == "N+1 Query":
-			_loop_n = int((top.get("technical_detail") or {}).get("loop_count") or 0) or affected
+			_detail = top.get("technical_detail") or {}
+			_loop_n = int(_detail.get("loop_count") or 0) or affected
+			# When the loop spans requests, name the spread so the per-request "12×"
+			# and the cumulative impact reconcile — same reconciliation the card has.
+			_run = int(_detail.get("run_count") or 0)
+			if _run > 1:
+				_spread = f" across {_run} requests"
 		headline = Markup(
 			"One line of code is responsible for <span class=\"hot\">~"
 			"{impact}</span> of this session &mdash; same query ran "
-			"<span class=\"hot\">{n}× inside a loop</span>. "
+			"<span class=\"hot\">{n}× inside a loop</span>{spread}. "
 			"Removing the redundant round-trips is the single biggest "
 			"win here."
-		).format(impact=impact_html, n=_loop_n)
+		).format(impact=impact_html, n=_loop_n, spread=_spread)
 	elif category == "slow_hook":
 		headline = Markup(
 			"<span class=\"hot\">{impact}</span> is spent inside a "

--- a/optimus/renderer/_internal.py
+++ b/optimus/renderer/_internal.py
@@ -1792,13 +1792,21 @@ def _compose_tldr(
 				"cost goes away."
 			).format(impact=impact_html, n=affected)
 	elif category == "n_plus_one" and affected:
+		# The "ran N× in a row" count is the per-request loop size, not
+		# affected_count (which for the user N+1 is the loop's TOTAL hit count, kept
+		# on the same set as estimated_impact_ms so per-hit math stays correct). Use
+		# loop_count so the hero matches the finding title. Framework N+1 keeps
+		# affected_count — it is already the cumulative total its title shows.
+		_loop_n = affected
+		if finding_type == "N+1 Query":
+			_loop_n = int((top.get("technical_detail") or {}).get("loop_count") or 0) or affected
 		headline = Markup(
 			"One line of code is responsible for <span class=\"hot\">~"
 			"{impact}</span> of this session &mdash; same query ran "
 			"<span class=\"hot\">{n}× inside a loop</span>. "
 			"Removing the redundant round-trips is the single biggest "
 			"win here."
-		).format(impact=impact_html, n=affected)
+		).format(impact=impact_html, n=_loop_n)
 	elif category == "slow_hook":
 		headline = Markup(
 			"<span class=\"hot\">{impact}</span> is spent inside a "

--- a/optimus/templates/report.html
+++ b/optimus/templates/report.html
@@ -1963,7 +1963,7 @@
 
       {% if detail.occurrences %}
         <p class="small muted">
-          {{ detail.occurrences }} occurrences
+          {{ detail.occurrences }} occurrences <small class="scope-tag">session-wide</small>
           {% if detail.average_time_ms %} &middot; ~{{ fmt_ms(detail.average_time_ms, 1) }} each{% endif %}
           {% if detail.total_time_ms %} &middot; {{ fmt_ms(detail.total_time_ms) }} total{% endif %}
         </p>

--- a/optimus/templates/report.html
+++ b/optimus/templates/report.html
@@ -1767,7 +1767,10 @@
         {% endif %}
       </div>
       <div class="finding-impact">
-        <span class="big">{{ fmt_ms(f.estimated_impact_ms) }}</span><small class="scope-tag">consolidated</small>
+        {# The scope tag is analyzer-declared: a finding whose estimated_impact_ms
+           is not the session-wide total sets detail.impact_scope_label (e.g. N+1 →
+           "recoverable"). Everything else falls back to "consolidated". #}
+        <span class="big">{{ fmt_ms(f.estimated_impact_ms) }}</span><small class="scope-tag">{{ detail.impact_scope_label or "consolidated" }}</small>
         {% if f.affected_count and f.affected_count > 1 %}
         {% set _per_hit_ms = f.estimated_impact_ms / f.affected_count %}
         <div class="small">{{ f.affected_count }}× hits{% if _per_hit_ms >= 0.05 %} &middot; {{ fmt_ms(_per_hit_ms, 1) }}<small class="scope-tag">per hit</small>{% endif %}</div>

--- a/optimus/templates/report.html
+++ b/optimus/templates/report.html
@@ -1775,6 +1775,11 @@
         {% set _per_hit_ms = f.estimated_impact_ms / f.affected_count %}
         <div class="small">{{ f.affected_count }}× hits{% if _per_hit_ms >= 0.05 %} &middot; {{ fmt_ms(_per_hit_ms, 1) }}<small class="scope-tag">per hit</small>{% endif %}</div>
         {% endif %}
+        {# Reconcile the per-request title ("ran 12×") with the total hit count
+           ("120× hits") when a loop spans several requests. #}
+        {% if detail.run_count and detail.run_count > 1 %}
+        <div class="small muted">looped in {{ detail.run_count }} requests</div>
+        {% endif %}
         {% if f.technical_detail and f.technical_detail.intra_action_repetitions and f.technical_detail.intra_action_repetitions > 1 %}
         <div class="small muted">called from {{ f.technical_detail.intra_action_repetitions }} sites in this action</div>
         {% endif %}

--- a/optimus/templates/report.html
+++ b/optimus/templates/report.html
@@ -1776,8 +1776,9 @@
         <div class="small">{{ f.affected_count }}× hits{% if _per_hit_ms >= 0.05 %} &middot; {{ fmt_ms(_per_hit_ms, 1) }}<small class="scope-tag">per hit</small>{% endif %}</div>
         {% endif %}
         {# Reconcile the per-request title ("ran 12×") with the total hit count
-           ("120× hits") when a loop spans several requests. #}
-        {% if detail.run_count and detail.run_count > 1 %}
+           ("120× hits") when a loop spans several requests. Gated on the loop-scope
+           marker so it never renders under a framework card (cumulative framing). #}
+        {% if detail.impact_scope_label and detail.run_count and detail.run_count > 1 %}
         <div class="small muted">looped in {{ detail.run_count }} requests</div>
         {% endif %}
         {% if f.technical_detail and f.technical_detail.intra_action_repetitions and f.technical_detail.intra_action_repetitions > 1 %}

--- a/optimus/tests/test_n_plus_one.py
+++ b/optimus/tests/test_n_plus_one.py
@@ -212,6 +212,148 @@ def test_severity_scales_with_count_and_time(empty_context):
 	assert result.findings[0]["affected_count"] == 60
 
 
+def test_loop_across_many_requests_reports_per_request_count_not_total(empty_context):
+	"""Audit #1: a 12× loop across 10 requests is "12× in a row", not "120×".
+	Time is kept low (120ms) to isolate the count inflation from severity-by-time."""
+	recordings = [
+		{
+			"uuid": f"req-{r}",
+			"path": "/",
+			"cmd": None,
+			"method": "GET",
+			"event_type": "HTTP Request",
+			"duration": 50,
+			"calls": [
+				{
+					"query": "SELECT name FROM tabItem WHERE id = 1",
+					"normalized_query": "SELECT NAME FROM tabItem WHERE ID = ?",
+					"duration": 1.0,
+					"stack": [
+						{"filename": "apps/myapp/module.py", "lineno": 100, "function": "loop"},
+					],
+				}
+			] * 12,  # 12 in a row, WITHIN one request
+		}
+		for r in range(10)  # ...the same loop across 10 requests → 120 total
+	]
+	result = n_plus_one.analyze(recordings, empty_context)
+	assert len(result.findings) == 1
+	f = result.findings[0]
+
+	# Title reports the per-request loop size, not the cross-request total.
+	assert "12×" in f["title"]
+	assert "120" not in f["title"]
+
+	# Count no longer drives severity to High: 12 < 50 occurrences AND
+	# 120ms < 200ms total → Low.
+	assert f["severity"] == "Low"
+
+	# Description states "12 times in a row" and names the spread, never
+	# the false "120 times in a row".
+	desc = f["customer_description"]
+	assert "12 times in a row" in desc
+	assert "120 times in a row" not in desc
+	assert "10 separate requests" in desc
+
+	# Detail keeps the total as scope but exposes the honest loop/run split.
+	detail = json.loads(f["technical_detail_json"])
+	assert detail["loop_count"] == 12
+	assert detail["run_count"] == 10
+	assert detail["occurrences"] == 120
+	assert f["affected_count"] == 120
+
+
+def test_loop_across_requests_stays_high_when_cumulative_time_is_large(empty_context):
+	"""Companion guard: the loop stays High when cumulative time warrants it
+	(60 × 5ms = 300ms > 200ms) — severity-by-time is honest, by-count was not."""
+	recordings = [
+		{
+			"uuid": f"req-{r}",
+			"path": "/",
+			"cmd": None,
+			"method": "GET",
+			"event_type": "HTTP Request",
+			"duration": 100,
+			"calls": [
+				{
+					"query": "SELECT name FROM tabItem WHERE id = 1",
+					"normalized_query": "SELECT NAME FROM tabItem WHERE ID = ?",
+					"duration": 5.0,
+					"stack": [
+						{"filename": "apps/myapp/module.py", "lineno": 100, "function": "loop"},
+					],
+				}
+			] * 12,
+		}
+		for r in range(5)  # 12 × 5 requests = 60 queries, 300ms total
+	]
+	result = n_plus_one.analyze(recordings, empty_context)
+	assert len(result.findings) == 1
+	f = result.findings[0]
+	assert "12×" in f["title"]  # still per-request, not 60×
+	assert f["severity"] == "High"  # justified by 300ms cumulative, not count
+	detail = json.loads(f["technical_detail_json"])
+	assert detail["loop_count"] == 12
+	assert detail["run_count"] == 5
+	# Projected post-fix ≈ per-request batched query (2 × 5ms avg) × 5 runs
+	# = 50ms, NOT collapsed to a single 10ms query for the whole session.
+	assert detail["projected_total_ms"] == 50.0
+
+
+def test_run_count_ignores_requests_where_query_did_not_loop(empty_context):
+	"""run_count counts only requests where the query REPEATED. Loops 10× in one
+	request, runs once in 20 others → run_count == 1; projection ≤ total_time."""
+	looping = {
+		"uuid": "loop-req",
+		"path": "/",
+		"cmd": None,
+		"method": "GET",
+		"event_type": "HTTP Request",
+		"duration": 100,
+		"calls": [
+			{
+				"query": "SELECT name FROM tabItem WHERE id = 1",
+				"normalized_query": "SELECT NAME FROM tabItem WHERE ID = ?",
+				"duration": 5.0,
+				"stack": [
+					{"filename": "apps/myapp/module.py", "lineno": 100, "function": "loop"},
+				],
+			}
+		] * 10,  # a real 10× loop in this one request
+	}
+	singles = [
+		{
+			"uuid": f"single-{r}",
+			"path": "/",
+			"cmd": None,
+			"method": "GET",
+			"event_type": "HTTP Request",
+			"duration": 20,
+			"calls": [
+				{
+					"query": "SELECT name FROM tabItem WHERE id = 1",
+					"normalized_query": "SELECT NAME FROM tabItem WHERE ID = ?",
+					"duration": 5.0,
+					"stack": [
+						{"filename": "apps/myapp/module.py", "lineno": 100, "function": "loop"},
+					],
+				}
+			],  # the SAME query, but run once — no loop here
+		}
+		for r in range(20)
+	]
+	result = n_plus_one.analyze([looping, *singles], empty_context)
+	assert len(result.findings) == 1
+	f = result.findings[0]
+	assert "10×" in f["title"]
+	detail = json.loads(f["technical_detail_json"])
+	assert detail["loop_count"] == 10
+	assert detail["run_count"] == 1  # only the one request that looped
+	assert detail["occurrences"] == 30  # 10 + 20 total appearances (scope)
+	# Projection must never read as worse than doing nothing.
+	assert detail["projected_total_ms"] <= detail["total_time_ms"]
+
+
 # ---------------------------------------------------------------------------
 # v0.5.1 regression guards: don't surface the profiler's own instrumentation
 # queries as N+1 findings. A production session flagged:
@@ -271,6 +413,38 @@ def test_framework_n_plus_one_query_builder_utils(empty_context):
 	desc = f["customer_description"]
 	assert "Frappe's own code" in desc
 	assert "not as an action item" in desc or "rarely something you can change" in desc
+
+
+def test_framework_finding_gates_on_cumulative_not_loop_time(empty_context):
+	"""#1: framework loop is 10ms (< 20ms floor) but cumulative 25ms — framework
+	findings gate on total_time, so this survives (the loop_time gate dropped it)."""
+	fw_call = lambda dur: {  # noqa: E731
+		"query": "SELECT ? FROM information_schema.GLOBAL_VARIABLES",
+		"normalized_query": "SELECT ? FROM information_schema.GLOBAL_VARIABLES",
+		"duration": dur,
+		"stack": [{"filename": "frappe/query_builder/utils.py", "lineno": 87, "function": "get_db_type"}],
+	}
+	looping = {
+		"uuid": "loop-req", "path": "/", "cmd": None, "method": "GET",
+		"event_type": "HTTP Request", "duration": 100,
+		"calls": [fw_call(1.0)] * 10,  # loop_time = 10ms < 20ms floor
+	}
+	singles = [
+		{
+			"uuid": f"single-{r}", "path": "/", "cmd": None, "method": "GET",
+			"event_type": "HTTP Request", "duration": 20, "calls": [fw_call(1.0)],
+		}
+		for r in range(15)  # +15ms → cumulative 25ms ≥ 20ms floor
+	]
+	result = n_plus_one.analyze([looping, *singles], empty_context)
+	assert len(result.findings) == 1, "framework N+1 must survive the cumulative gate"
+	f = result.findings[0]
+	assert f["finding_type"] == "Framework N+1"
+	detail = json.loads(f["technical_detail_json"])
+	assert detail["occurrences"] == 25
+	assert detail["loop_count"] == 10  # the one looping request's size
+	assert detail["run_count"] == 1  # only one request actually looped
+	assert round(detail["total_time_ms"]) == 25
 
 
 def test_user_code_n_plus_one_still_emits_as_actionable(empty_context):
@@ -760,3 +934,115 @@ def test_top_queries_filters_profiler_instrumentation(empty_context):
 	slow = [f for f in result.findings if f["finding_type"] == "Slow Query"]
 	assert len(slow) == 1
 	assert "tabSales Invoice" in slow[0]["technical_detail_json"]
+
+
+# ---------------------------------------------------------------------------
+# v0.12.28 regression guards: cross-request leaks that survived 0.12.27.
+# ---------------------------------------------------------------------------
+
+
+def test_action_ref_points_to_the_looping_request_not_first_appearance(empty_context):
+	"""#1: action_ref must name the dominant (looping) request, not the first the
+	query appeared in. Runs once in req 0, loops 15× in req 1 → ref == "1"."""
+	recordings = [
+		{  # request 0 — the query appears exactly once (NOT a loop)
+			"uuid": "req-0",
+			"path": "/",
+			"cmd": None,
+			"method": "GET",
+			"event_type": "HTTP Request",
+			"duration": 50,
+			"calls": [
+				{
+					"query": "SELECT rate FROM tabItem Price WHERE item = 1",
+					"normalized_query": "SELECT rate FROM tabItem Price WHERE item = ?",
+					"duration": 2.0,
+					"stack": [
+						{"filename": "apps/myapp/pricing.py", "lineno": 42, "function": "price"},
+					],
+				}
+			],
+		},
+		{  # request 1 — the real 15× loop
+			"uuid": "req-1",
+			"path": "/",
+			"cmd": None,
+			"method": "GET",
+			"event_type": "HTTP Request",
+			"duration": 80,
+			"calls": [
+				{
+					"query": "SELECT rate FROM tabItem Price WHERE item = 1",
+					"normalized_query": "SELECT rate FROM tabItem Price WHERE item = ?",
+					"duration": 2.0,
+					"stack": [
+						{"filename": "apps/myapp/pricing.py", "lineno": 42, "function": "price"},
+					],
+				}
+			] * 15,
+		},
+	]
+	result = n_plus_one.analyze(recordings, empty_context)
+	assert len(result.findings) == 1
+	f = result.findings[0]
+	# Points at request 1 (index 1), where the loop ran — NOT request 0.
+	assert f["action_ref"] == "1"
+	assert "15×" in f["title"]
+	detail = json.loads(f["technical_detail_json"])
+	assert detail["loop_count"] == 15
+	assert detail["run_count"] == 1
+	assert detail["occurrences"] == 16  # 1 + 15 total appearances (scope)
+
+
+def _mixed_loop_and_singles(loop_hits, loop_ms, single_count, single_ms):
+	"""One request that loops the query loop_hits× at loop_ms, plus single_count
+	other requests that each run the SAME query once at single_ms."""
+	call = lambda dur: {  # noqa: E731
+		"query": "SELECT name FROM tabItem WHERE id = 1",
+		"normalized_query": "SELECT NAME FROM tabItem WHERE ID = ?",
+		"duration": dur,
+		"stack": [{"filename": "apps/myapp/module.py", "lineno": 100, "function": "loop"}],
+	}
+	looping = {
+		"uuid": "loop-req", "path": "/", "cmd": None, "method": "GET",
+		"event_type": "HTTP Request", "duration": 100,
+		"calls": [call(loop_ms)] * loop_hits,
+	}
+	singles = [
+		{
+			"uuid": f"single-{r}", "path": "/", "cmd": None, "method": "GET",
+			"event_type": "HTTP Request", "duration": 20, "calls": [call(single_ms)],
+		}
+		for r in range(single_count)
+	]
+	return [looping, *singles]
+
+
+def test_small_loop_low_severity_and_loop_scoped_cost(empty_context):
+	"""#2/#1: severity AND the description cost use the loop's own time (30ms),
+	not the 280ms cumulative — so Low, and the description quotes 30ms not 280ms."""
+	recordings = _mixed_loop_and_singles(loop_hits=10, loop_ms=3.0, single_count=50, single_ms=5.0)
+	result = n_plus_one.analyze(recordings, empty_context)
+	assert len(result.findings) == 1
+	f = result.findings[0]
+	# Loop is 30ms → Low, despite the 280ms cumulative that pre-fix read High.
+	assert f["severity"] == "Low"
+	# Description quotes the LOOP's own cost (30ms), never the 280ms total.
+	assert "30ms" in f["customer_description"]
+	assert "280ms" not in f["customer_description"]
+	detail = json.loads(f["technical_detail_json"])
+	assert detail["loop_count"] == 10
+	assert detail["run_count"] == 1
+	assert detail["occurrences"] == 60  # 10 + 50 total appearances (scope)
+	# Cumulative time is still reported honestly for scope/impact.
+	assert detail["total_time_ms"] == 280.0
+	# Projection never exceeds the current total.
+	assert detail["projected_total_ms"] <= detail["total_time_ms"]
+
+
+def test_trivial_loop_suppressed_when_only_noise_lifts_it_over_gate(empty_context):
+	"""#2 (gate): a trivial loop (loop_time 5ms < 20ms floor) is suppressed even
+	when the same query, run once across 100 requests, lifts the session total."""
+	recordings = _mixed_loop_and_singles(loop_hits=10, loop_ms=0.5, single_count=100, single_ms=5.0)
+	result = n_plus_one.analyze(recordings, empty_context)
+	assert result.findings == []  # loop_time 5ms < 20ms floor → suppressed

--- a/optimus/tests/test_n_plus_one.py
+++ b/optimus/tests/test_n_plus_one.py
@@ -366,6 +366,27 @@ def test_run_count_ignores_requests_where_query_did_not_loop(empty_context):
 	assert detail["projected_total_ms"] <= detail["total_time_ms"]
 
 
+def test_run_count_excludes_sub_threshold_repeats(empty_context):
+	"""A request counts as looping only if it hit the N+1 threshold. A finding that
+	qualifies on one 12× request must NOT fold in requests that repeated the query
+	just 2-9× (below the bar) — else run_count / loop_time / severity inflate and
+	"looped in N requests" overstates the loop's real spread."""
+	def call(dur):
+		return {"query": "SELECT 1", "normalized_query": "SELECT ?", "duration": dur,
+			"stack": [{"filename": "apps/myapp/mod.py", "lineno": 1, "function": "loop"}]}
+
+	def req(uuid, hits, dur):
+		return {"uuid": uuid, "path": "/", "cmd": None, "method": "GET",
+			"event_type": "HTTP Request", "duration": 50, "calls": [call(dur)] * hits}
+
+	recs = [req("A", 12, 3.0)]  # qualifies: 12 >= min_occurrences (10)
+	recs += [req(f"b{i}", 3, 5.0) for i in range(5)]  # 3× each — below the threshold
+	detail = json.loads(n_plus_one.analyze(recs, empty_context).findings[0]["technical_detail_json"])
+	assert detail["run_count"] == 1  # only the 12× request; the 3× ones are excluded
+	assert detail["loop_count"] == 12
+	assert detail["occurrences"] == 27  # 12 + 15 total appearances (session scope)
+
+
 # ---------------------------------------------------------------------------
 # v0.5.1 regression guards: don't surface the profiler's own instrumentation
 # queries as N+1 findings. A production session flagged:

--- a/optimus/tests/test_n_plus_one.py
+++ b/optimus/tests/test_n_plus_one.py
@@ -259,8 +259,10 @@ def test_loop_across_many_requests_reports_per_request_count_not_total(empty_con
 	detail = json.loads(f["technical_detail_json"])
 	assert detail["loop_count"] == 12
 	assert detail["run_count"] == 10
-	assert detail["occurrences"] == 120
-	assert f["affected_count"] == 120
+	assert detail["occurrences"] == 120  # session-wide total kept in the detail (scope)
+	# Headline field is LOOP-scoped (matches the "12×" title), not the 120 total —
+	# it feeds the hero, the impact box, the report sort, and the AI-fix prompt.
+	assert f["affected_count"] == 12
 
 
 def test_loop_across_requests_stays_high_when_cumulative_time_is_large(empty_context):
@@ -1038,6 +1040,11 @@ def test_small_loop_low_severity_and_loop_scoped_cost(empty_context):
 	assert detail["total_time_ms"] == 280.0
 	# Projection never exceeds the current total.
 	assert detail["projected_total_ms"] <= detail["total_time_ms"]
+	# Headline economics are LOOP-scoped, so every downstream surface (hero, impact
+	# box, report sort, AI-fix prompt) tells the "10× / 30ms" story — NOT the 60 /
+	# 280 session totals, which stay in the detail above under a "session-wide" label.
+	assert f["affected_count"] == 10  # loop_count, not the 60 total
+	assert f["estimated_impact_ms"] == 30.0  # loop_time, not the 280ms total
 
 
 def test_trivial_loop_suppressed_when_only_noise_lifts_it_over_gate(empty_context):

--- a/optimus/tests/test_n_plus_one.py
+++ b/optimus/tests/test_n_plus_one.py
@@ -254,15 +254,25 @@ def test_loop_across_many_requests_reports_per_request_count_not_total(empty_con
 	assert "12 times in a row" in desc
 	assert "120 times in a row" not in desc
 	assert "10 separate requests" in desc
+	# Multi-request loops say "up to N" — loop_count is the busiest request's peak,
+	# not a uniform per-request figure.
+	assert "up to 12 times in a row" in desc
 
 	# Detail keeps the total as scope but exposes the honest loop/run split.
 	detail = json.loads(f["technical_detail_json"])
 	assert detail["loop_count"] == 12
 	assert detail["run_count"] == 10
 	assert detail["occurrences"] == 120  # session-wide total kept in the detail (scope)
-	# Headline field is LOOP-scoped (matches the "12×" title), not the 120 total —
-	# it feeds the hero, the impact box, the report sort, and the AI-fix prompt.
-	assert f["affected_count"] == 12
+	# affected_count and estimated_impact_ms are on the SAME occurrence set (the
+	# loop's own hits), so the generic per-hit consumers stay correct: this loop
+	# fired 120 hits at 2ms each. affected_count is the loop HIT count (120), NOT
+	# loop_count (12, the per-request peak that drives the title/hero) — mixing the
+	# two denominators inflated per-hit ×10 on multi-request loops.
+	assert f["affected_count"] == 120  # total loop hits (12× across 10 requests)
+	assert f["estimated_impact_ms"] == 120.0  # loop_time (120 hits × 1ms)
+	# per-hit = impact / count = the loop's real per-query cost (1ms). Before this
+	# fix affected_count was loop_count (12), so per-hit read 120/12 = 10ms — ×10.
+	assert f["estimated_impact_ms"] / f["affected_count"] == 1.0
 
 
 def test_loop_across_requests_stays_high_when_cumulative_time_is_large(empty_context):
@@ -447,6 +457,10 @@ def test_framework_finding_gates_on_cumulative_not_loop_time(empty_context):
 	assert detail["loop_count"] == 10  # the one looping request's size
 	assert detail["run_count"] == 1  # only one request actually looped
 	assert round(detail["total_time_ms"]) == 25
+	# Framework title uses the SESSION total (25), never the per-request loop count
+	# (10) — framework findings are cumulative-framed, unlike user N+1s.
+	assert "25×" in f["title"]
+	assert "10×" not in f["title"]
 
 
 def test_user_code_n_plus_one_still_emits_as_actionable(empty_context):
@@ -1045,6 +1059,14 @@ def test_small_loop_low_severity_and_loop_scoped_cost(empty_context):
 	# 280 session totals, which stay in the detail above under a "session-wide" label.
 	assert f["affected_count"] == 10  # loop_count, not the 60 total
 	assert f["estimated_impact_ms"] == 30.0  # loop_time, not the 280ms total
+	# P95 + projection sub-fields are populated (10 loop samples ≥ the P95 minimum),
+	# and scoped to the loop's own per-query cost (3ms), not the 5ms singles.
+	assert detail["p95_ms"] is not None
+	assert detail["projected_avg_time_ms"] == 6.0  # loop_avg (3ms) × 2
+	assert detail["projected_speedup_label"] == "~5× fewer queries"  # loop_count // 2
+	# The card's scope tag is analyzer-declared (data-driven) — no surface hardcodes
+	# "N+1 == recoverable"; the impact/count really are the loop's own, not the total.
+	assert detail["impact_scope_label"] == "recoverable"
 
 
 def test_trivial_loop_suppressed_when_only_noise_lifts_it_over_gate(empty_context):


### PR DESCRIPTION
The N+1 analyzer described a loop using **session-wide (cross-request) totals**
  instead of the loop that actually ran **inside a single request**. An N+1 is a
  loop in one request, so mixing in every other request's copies of the same query
  produced wrong counts, severity, impact, and per-hit figures across the report.

  ### Issues

  1. **Inflated count** — a query looping 12× in each of 10 requests was reported as
     "ran 120×" instead of "12×".
  2. **Wrong severity** — a trivial 10× loop rated High only because the same query
     also ran (unrelated) across many requests, summing past the time threshold.
  3. **False findings** — a 5ms loop flagged because unrelated traffic pushed the
     session total over the floor.
  4. **Wrong drill-down link** — `action_ref` pointed at the first request the query
     appeared in, not the one that looped.
  5. **Contradictory card** — title/description were loop-scoped, but the hero, the
     impact box, the AI-fix prompt, and the sort still read cumulative fields, so the
     report contradicted itself ("12×" title next to "120× hits" / "280ms").
  6. **Inflated per-hit** — `estimated_impact_ms` (all looping requests) and
     `affected_count` (one request's peak) sat on different denominators, so
     `per_hit = impact/count` read 10ms for a 1ms loop on multi-request cases.
  7. **Stale docstring** — said "recurring > MIN_OCCURRENCES" for a gate that is
     `>= n_plus_one_min_occurrences`.

  ### What changed

  - **Two scopes, each explicitly labeled.** The loop's own numbers drive the
    actionable surfaces; the session totals stay for context.
    - **Loop-scoped** (title, description, severity, and the headline economics):
      `estimated_impact_ms = loop_time` and `affected_count = the loop's hit count`
      — kept on the **same occurrence set**, so the generic `per_hit = impact/count`
      is correct. The card tags this impact **"recoverable"** via an
      analyzer-declared `impact_scope_label` (no surface hardcodes the scope).
    - **Session-wide** (`occurrences`, `total_time_ms`, average): kept in the detail
      block under a **"session-wide"** label.
  - **Title / hero "ran N×"** use `loop_count` (the per-request in-a-row size); a
    multi-request loop's card also shows **"looped in N requests"** so "12×" and the
    total hit count reconcile.
  - **`action_ref`** points at the request that actually looped.
  - **Projection** multiplies the batched cost by the number of looping requests and
    adds back non-loop cost; **P95** is scoped to the loop's hits.
  - **Docstring** corrected to `>= n_plus_one_min_occurrences` (default 10).

  ### Testing

  `ruff check` clean; full unit suite **1916 passed, 20 skipped**. New regression
  tests lock: per-request count vs total, loop-scoped severity/description, trivial-
  loop suppression, `action_ref`, framework title (`total_count ≠ loop_count`),
  "up to N" wording, P95/projection sub-fields, the analyzer-declared scope label,
  and the multi-request **per-hit = impact/count** identity.
                                                             