### PR TITLE
Remove em dashes across the app

### DIFF
--- a/.github/helper/install.sh
+++ b/.github/helper/install.sh
@@ -91,7 +91,7 @@ _end
 _step "symlink optimus into apps/ + register in apps.txt"
 # Symlink the optimus checkout into apps/. Using a symlink (rather than
 # ``bench get-app``) lets the workflow test the EXACT working-tree state
-# — including uncommitted changes — instead of whatever ``main`` happens
+# including uncommitted changes instead of whatever ``main`` happens
 # to be at the moment.
 ln -snf "${OPTIMUS_REPO_DIR}" apps/optimus
 
@@ -101,7 +101,7 @@ ln -snf "${OPTIMUS_REPO_DIR}" apps/optimus
 # The concatenation gave a single line "frappeoptimus", which
 # ``bench new-site`` tried to ``import_module('frappeoptimus.commands')``
 # → ModuleNotFoundError. The fix: ``printf '\noptimus\n'`` instead of
-# ``echo "optimus"`` — the leading \n forces a line break regardless
+# ``echo "optimus"``: the leading \n forces a line break regardless
 # of whether apps.txt already ends with one (a blank line in apps.txt
 # is ignored by Frappe's app-discovery loop).
 if ! grep -qxF "optimus" sites/apps.txt; then
@@ -147,7 +147,7 @@ _step "bench install-app optimus + set-config + migrate"
 bench --site "${TEST_SITE}" install-app optimus
 bench --site "${TEST_SITE}" set-config developer_mode 1
 # v0.12.31: ``bench set-config -p in_test true`` failed with
-# ValueError("malformed node or string ... Name(id='true', ...)") —
+# ValueError("malformed node or string ... Name(id='true', ...)")
 # the ``-p`` flag runs ``ast.literal_eval`` on the value, which
 # accepts Python literals (``True`` / ``False`` / ``None`` /
 # numbers / strings / lists / dicts) but NOT lowercase ``true``.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,13 @@ name: CI
 #
 # Trigger split is deliberate and is the whole efficiency story: running on
 # BOTH ``push: ['**']`` and ``pull_request: ['**']`` (the pre-CI ``tests.yml``
-# behaviour) fired every job TWICE for any branch with an open PR — the
+# behaviour) fired every job TWICE for any branch with an open PR the
 # concurrency group is keyed on ``github.ref`` which differs between a push
 # (refs/heads/<b>) and a PR (refs/pull/N/merge), so cancel-in-progress could
 # not dedupe them. Here:
-#   * pull_request (any branch) — the merge gate; the only run a feature
+#   * pull_request (any branch) the merge gate; the only run a feature
 #     branch with an open PR produces.
-#   * push to main only         — post-merge / trunk signal; the only run a
+#   * push to main only post-merge / trunk signal; the only run a
 #     merge to main produces.
 # A given commit therefore runs each check exactly once.
 #
@@ -20,7 +20,7 @@ name: CI
 # honest; the jobs are fast enough that the cost is negligible.
 #
 # Installs use ``uv`` (astral-sh/setup-uv) rather than ``python -m pip``: the
-# dominant CI cost here is dependency install (~33s — ``line_profiler`` ships a
+# dominant CI cost here is dependency install (~33s ``line_profiler`` ships a
 # C extension), not the test run (~6-10s), so sharding the suite would barely
 # move wall-clock. uv's resolver + a wheel cache keyed on pyproject.toml attack
 # that install cost directly and cache the built line_profiler wheel across
@@ -33,7 +33,7 @@ on:
     branches: [main]
   workflow_dispatch:
 
-# Cancel a superseded in-flight run when a new commit lands on the same PR —
+# Cancel a superseded in-flight run when a new commit lands on the same PR
 # saves CI minutes on rapid-push branches. Scoped to pull_request events only:
 # every push-to-main run shares the ``refs/heads/main`` ref, so an
 # unconditional cancel would let one merge abort the previous merge's trunk
@@ -74,7 +74,7 @@ jobs:
       - name: Lint (uses pyproject.toml [tool.ruff] config)
         run: ruff check optimus/
 
-      # Format-check is deferred — the codebase predates the [tool.ruff.format]
+      # Format-check is deferred the codebase predates the [tool.ruff.format]
       # config and a large reformat is its own piece of work. Add a
       # ``ruff format --check optimus/`` step here once that lands.
 
@@ -91,7 +91,7 @@ jobs:
         # (Python 3.14.2 locally) and the deployment target for every bench in
         # scope. The sys.monitoring / line_profiler tool-2 handling that
         # diverges across Python 3.12+ is exercised natively on 3.14, so
-        # multi-version coverage added CI minutes without adding signal — hence
+        # multi-version coverage added CI minutes without adding signal hence
         # a single version, no matrix (which also keeps the check name a clean
         # ``CI / tests`` rather than ``tests (Python 3.14)``).
         uses: actions/setup-python@v5
@@ -108,7 +108,7 @@ jobs:
         # ``-e .`` installs the project's runtime deps declared in
         # pyproject.toml. The second line adds pytest + the small set of
         # test-only deps the suite imports. Frappe itself is intentionally NOT
-        # installed — the conftest baseline stub satisfies module-top frappe
+        # installed the conftest baseline stub satisfies module-top frappe
         # imports at collection time. uv provides build isolation, so no
         # separate pip/wheel/setuptools bootstrap step is needed for the
         # line_profiler C-extension build.
@@ -119,7 +119,7 @@ jobs:
       - name: Run pytest
         # ``set -eo pipefail`` is required: without it, the ``| tee`` at the
         # end of the pipeline returns 0 (tee always succeeds) and pytest's
-        # non-zero exit code is silently discarded — the step would report
+        # non-zero exit code is silently discarded the step would report
         # green even when tests fail. GitHub Actions' default step shell runs
         # ``bash -e {0}`` (no pipefail), so the explicit ``set -eo pipefail``
         # before the ``| tee`` is required.
@@ -184,7 +184,7 @@ jobs:
         # INFORMATIONAL coverage: no ``--cov-fail-under``, so this job goes red
         # only if the suite itself fails, never on a coverage number. A
         # threshold is a deliberate follow-up once the baseline is known.
-        # ``set -eo pipefail`` for the same reason as the tests job — the
+        # ``set -eo pipefail`` for the same reason as the tests job the
         # ``| tee`` would otherwise mask a failing suite.
         run: |
           set -eo pipefail
@@ -193,8 +193,8 @@ jobs:
             2>&1 | tee coverage.log
 
       - name: Publish coverage summary
-        # ``awk`` prints from pytest-cov's ``coverage:`` banner to EOF — i.e.
-        # the whole per-file table + the TOTAL line — onto the run's Summary
+        # ``awk`` prints from pytest-cov's ``coverage:`` banner to EOF i.e.
+        # the whole per-file table + the TOTAL line onto the run's Summary
         # tab. ``if: always()`` so the table still appears on a failing run.
         if: always()
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -2,10 +2,10 @@ name: Integration
 
 # Real-bench integration tests. Slower than the pure-pytest ``CI`` workflow
 # (``ci.yml``), so the trigger surface is narrower:
-#   * pull requests targeting main — gate merges on real-Frappe behaviour
-#   * push to main                  — catch regressions on the trunk
-#   * scheduled daily               — catch Frappe v16 upstream drift
-#   * manual dispatch                — replay a flake / debug a CI bug
+#   * pull requests targeting main gate merges on real-Frappe behaviour
+#   * push to main catch regressions on the trunk
+#   * scheduled daily catch Frappe v16 upstream drift
+#   * manual dispatch replay a flake / debug a CI bug
 #
 # This workflow does NOT replace ``ci.yml``; the two run in parallel.
 # Branch protection enforces both green for merge.
@@ -13,14 +13,14 @@ name: Integration
 # NB: intentionally NO ``paths-ignore``. This job is a required check in the
 # main branch protection rule; a required check skipped on a docs-only PR
 # never reports and would block the PR forever. Always-run keeps the gate
-# honest — and integration only runs on main-targeted PRs / pushes anyway.
+# honest and integration only runs on main-targeted PRs / pushes anyway.
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
   schedule:
-    # 04:00 UTC daily — outside the typical European / Indian working day,
+    # 04:00 UTC daily outside the typical European / Indian working day,
     # before North American developers wake up. A failed scheduled run
     # surfaces via the repo's GitHub Actions notifications.
     - cron: '0 4 * * *'
@@ -30,7 +30,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   # pull_request only: push-to-main and the scheduled cron both run on the
   # ``refs/heads/main`` ref, so an unconditional cancel would let a merge abort
-  # an in-flight trunk build — or a push abort the daily drift-detection run.
+  # an in-flight trunk build or a push abort the daily drift-detection run.
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
@@ -75,7 +75,7 @@ jobs:
         # a 3.12 venv. 3.14 matches the upstream-mandated minimum and
         # the dev bench's interpreter (Python 3.14.2 locally).
         #
-        # NB: the pure-pytest ``ci.yml`` workflow also runs on 3.14 — it
+        # NB: the pure-pytest ``ci.yml`` workflow also runs on 3.14 it
         # doesn't install Frappe (the conftest stubs it), so it doesn't
         # need the ``bench init`` toolchain. This integration workflow needs
         # the upstream-mandated 3.14 because it actually runs ``bench init``
@@ -91,13 +91,13 @@ jobs:
         # tripped a yarn-install warning ("Node 24") and would
         # subsequently fail Frappe's own ``yarn run`` build steps that
         # check engines strictly. Pinning 24 matches the upstream-
-        # mandated minimum — same pattern as the Python 3.12 → 3.14
+        # mandated minimum same pattern as the Python 3.12 → 3.14
         # bump in the sibling commit. Frappe's asset pipeline needs
         # Node even with --skip-assets; ``bench init`` shells out to
         # ``yarn install`` for the Frappe framework's own JS deps
         # before building the bench skeleton.
         #
-        # NB: no ``cache: 'yarn'`` here — that directive requires a
+        # NB: no ``cache: 'yarn'`` here that directive requires a
         # ``yarn.lock`` in the optimus repo at setup-node time, but
         # optimus is a Frappe app, not a Node project; the yarn.lock
         # we care about ships inside ``apps/frappe`` which only exists
@@ -135,7 +135,7 @@ jobs:
         # ``frappe.tests.utils.FrappeTestCase``. We invoke per-module
         # so a single failing module doesn't abort siblings. v0.12.15:
         # the 9 modules now run through a shell loop driven by a single
-        # list — adding a future module is a one-line addition.
+        # list adding a future module is a one-line addition.
         env:
           RUNNER_TEMP: ${{ runner.temp }}
           INTEGRATION_MODULES: |-
@@ -158,7 +158,7 @@ jobs:
           # `set -e`, which made the FIRST failing module abort all
           # siblings (despite a comment claiming otherwise). The
           # accumulator below runs EVERY module then fails the workflow
-          # if any failed — so a single push surfaces every failure at
+          # if any failed so a single push surfaces every failure at
           # once, not just the first.
           while IFS= read -r module; do
             [ -z "${module}" ] && continue
@@ -187,7 +187,7 @@ jobs:
           {
             echo "## Integration test summary"
             # The runner step writes one log per module as
-            # ``integration-<module>.log`` — glob them all (nullglob so a
+            # ``integration-<module>.log``: glob them all (nullglob so a
             # crash-before-any-log yields an honest empty summary, not a
             # literal-glob error).
             shopt -s nullglob

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,25 @@ All notable changes to the Optimus app.
 
 The format is loosely based on [Keep a Changelog](https://keepachangelog.com/),
 and this project follows [SemVer](https://semver.org/) (pre-1.0, so minor
-versions may contain breaking changes — see migration notes below).
+versions may contain breaking changes see migration notes below).
 
 ---
 
-## [0.12.41] — 2026-08-31
+## [0.12.42] - 2026-09-04
+
+### Changed
+
+- **Remove em dashes across the app.** Comments, docstrings, settings help text, the
+  report template, and user-facing strings now use standard punctuation (a colon for
+  labels, headings and definitions; parentheses for a bracketed list) or simply drop
+  the dash where the sentence reads on naturally. Cells that mean "no value" render
+  blank instead of a dash, and CHANGELOG release headers use the standard
+  `## [x.y.z] - date` form. The renderer's own `_strip_em` routine, which strips em
+  dashes from user-entered notes at render time, is unchanged.
+
+---
+
+## [0.12.41] - 2026-08-31
 
 ### Fixed
 
@@ -22,21 +36,21 @@ versions may contain breaking changes — see migration notes below).
   application code") wasn't actually implemented. Rewrote `is_framework_callsite`'s
   exclusion mode to consult `frappe.get_installed_apps()` (resolved ONCE per
   analyze via `base.installed_apps_allowlist()` and threaded into every classifying
-  analyzer — n_plus_one, redundant_calls, explain_flags, top_queries — and into
+  analyzer n_plus_one, redundant_calls, explain_flags, top_queries and into
   call_tree's hot-frame leaderboard): a callsite whose app root is an installed
   Frappe app (and not a framework/stock app) is the developer's code; everything
   else the developer can't patch. This makes an installed app named `redis`
   actionable, a real `redis` library non-actionable, and an *unknown* library
   correctly non-actionable with no denylist to maintain. Framework apps
   (`frappe`/`erpnext`/…) are still checked first, and Server Scripts stay
-  actionable via an explicit carve-out (so the allowlist can't demote them —
+  actionable via an explicit carve-out (so the allowlist can't demote them
   the regression that started this). Off-bench (frappe unavailable, e.g. the
   pure-Python unit suite) it falls back to the previous hardcoded heuristic, so
   existing tests are unchanged. Verified on `dev.local`. **The hot-frame side keys
   the allowlist on the RESOLVED app root** (`_last_app_segment`, the same
-  resolution the SQL side and the donut use) — not the raw first path segment,
+  resolution the SQL side and the donut use) not the raw first path segment,
   which would read `apps`/`home` for an `apps/`-prefixed or absolute path and
-  silently drop the user's own frames from the leaderboard / Slow Hot Path — and
+  silently drop the user's own frames from the leaderboard / Slow Hot Path and
   only fires in exclusion mode (a free-text tracked app that isn't installed is
   kept), with a truthy guard so an empty set falls back to the heuristic. Regression
   tests exercise the on-bench (`installed_apps` populated) path the pure-Python
@@ -57,14 +71,14 @@ versions may contain breaking changes — see migration notes below).
 
 ---
 
-## [0.12.40] — 2026-08-31
+## [0.12.40] - 2026-08-31
 
 ### Changed
 
 - **The SQL and hot-frame classifiers now share one third-party library list.**
   `call_tree._THIRD_PARTY_LIB_SEGMENTS` had drifted to a subset of
   `base._THIRD_PARTY_LIB_NAMES` (missing `rq`, `werkzeug`, `gunicorn`, `pytz`,
-  `dateutil`, `pyinstrument`) even though a comment claimed they mirrored — a
+  `dateutil`, `pyinstrument`) even though a comment claimed they mirrored a
   maintenance hazard that already bit once. Pointed `call_tree` at
   `base._THIRD_PARTY_LIB_NAMES` directly so the two surfaces can never disagree on
   whether a library is user code. Behavior-neutral: the six names were already
@@ -73,14 +87,14 @@ versions may contain breaking changes — see migration notes below).
 
 ---
 
-## [0.12.39] — 2026-08-31
+## [0.12.39] - 2026-08-31
 
 ### Fixed
 
 - **New-doc name resolution was dead for HTTP/Desk saves.** The feature that shows
   a doc's real save-assigned name (instead of the browser's `new-…` placeholder)
   did a read-modify-write of frappe's own `RECORDER_REQUEST_HASH` in
-  `after_request` — but for HTTP, `after_request` runs in `application()`'s
+  `after_request`: but for HTTP, `after_request` runs in `application()`'s
   `finally` **before** `frappe.recorder.dump()` (which runs later in the WSGI
   `ClosingIterator`, after the response), so the recorder hash wasn't written yet:
   the `hget` returned `None` and the resolved name was silently dropped (the
@@ -88,7 +102,7 @@ versions may contain breaking changes — see migration notes below).
   green). A stale code comment even asserted the opposite ordering. Rewrote it to
   write the resolved `{doctype, name}` to an **Optimus-owned sidecar key**
   (`redis_keys.resolved_doc`, mirroring the `infra` sidecar) and **merge it at
-  analyze time** — which removes the ordering dependency entirely and takes the
+  analyze time**: which removes the ordering dependency entirely and takes the
   read-modify-write off the request hot path. Corrected the `hooks.py` ordering
   comment. Added source-inspection regression guards
   (`TestResolvedDocSidecarWiring`) that close the coverage gap that let this ship
@@ -97,7 +111,7 @@ versions may contain breaking changes — see migration notes below).
 
 ---
 
-## [0.12.38] — 2026-08-28
+## [0.12.38] - 2026-08-28
 
 ### Added
 
@@ -110,21 +124,21 @@ versions may contain breaking changes — see migration notes below).
 - **Tracked Apps now scopes the call_tree findings, not just the SQL findings.**
   When *Optimus Settings ▸ Tracked Apps* is set, the inclusion-mode classifier
   already restricted the N+1 / redundant-call / EXPLAIN / top-query findings to
-  those apps — but the call_tree findings (Repeated Hot Frame, Slow Hot Path, Hook
+  those apps but the call_tree findings (Repeated Hot Frame, Slow Hot Path, Hook
   Bottleneck, Slow Background Job) and the hot-frames leaderboard ignored it and
   still surfaced frames from every app. Plumbed the tracked-apps set into
   call_tree's two frame gatekeepers (`_is_pure_helper_frame` /
   `_is_walker_plumbing_frame`) so a frame outside the tracked apps is treated as
-  out-of-scope plumbing — the walker descends past it to your code, exactly as it
+  out-of-scope plumbing the walker descends past it to your code, exactly as it
   already does for framework frames. Reuses the same `is_framework_callsite`
   inclusion decision the SQL side uses, so both surfaces agree. Empty Tracked
   Apps → profile everything (unchanged default). Verified end-to-end: with
   `Tracked Apps = ["myapp"]`, only `myapp` frames appear as findings and in the
-  hot-frames leaderboard. **Server Scripts are exempt** — they're the developer's
+  hot-frames leaderboard. **Server Scripts are exempt**: they're the developer's
   own optimizable code and live in the database, not in any app, so their findings
   stay actionable on both surfaces even when Tracked Apps is set. **Not yet
   scoped:** the Phase-2 line-profile candidate picker still offers hot frames from
-  any app — a follow-up.
+  any app a follow-up.
 
 ### Changed
 
@@ -138,7 +152,7 @@ versions may contain breaking changes — see migration notes below).
 
 - **Reverted the report masthead's top-right document name.** The header's
   top-right corner showed the touched document (doctype as the heading + document
-  name below it); reverted to the previous behaviour — it now shows the session
+  name below it); reverted to the previous behaviour it now shows the session
   title. The per-action "Document:" breadcrumb further down the report is
   unchanged. (Removed the `primary_doc` computation and the `.masthead-docname`
   markup/CSS.)
@@ -146,7 +160,7 @@ versions may contain breaking changes — see migration notes below).
 - **Reverted the callsite classifier to the proven `main` approach.** The
   in-progress rewrite on this branch (the 0.12.37 classifier unification plus the
   bench-apps backstop / installed-apps rescue) traded simplicity for edge-case
-  handling and, under review, introduced regressions of its own — most notably
+  handling and, under review, introduced regressions of its own most notably
   demoting real Server Script N+1s to non-actionable Observations on live sites.
   Rather than layer more special-casing on top (an angle-bracket sentinel
   carve-out, an out-of-bench lib fallback, a shared `_is_third_party_path`), we
@@ -165,11 +179,11 @@ versions may contain breaking changes — see migration notes below).
   standard `/home/frappe/…` server home, and `acme/acme/payments/…` were all
   demoted to non-actionable Observations. Now framework apps match on the
   **resolved app root** only (the boundary-anchored `apps/<app>/` segment via
-  `_last_app_segment`, else the top segment) — never mid-path — plus a user-app
+  `_last_app_segment`, else the top segment) never mid-path plus a user-app
   guard so a vendored lib under `apps/<app>/…/requests/…` stays the user's code.
   Real framework roots, `site-packages`, pyinstrument-stripped libs, and
   out-of-bench absolute lib paths still classify correctly. (One narrow residual:
-  a lib vendored under a *pyinstrument-stripped* user path — no `apps/` prefix —
+  a lib vendored under a *pyinstrument-stripped* user path no `apps/` prefix
   is still substring-matched; rare and ambiguous.)
 
 - **Third-party libraries could leak into the hot-frame leaderboard.** In default
@@ -183,7 +197,7 @@ versions may contain breaking changes — see migration notes below).
 - **Slow-path / hook / background-job findings inside Server Scripts were silently
   dropped on real sites.** The Slow-Hot-Path walker's Server Script carve-out
   (`_is_walker_plumbing_frame`) matched `<serverscript-` (trailing hyphen), but
-  Frappe's `safe_exec` emits `<serverscript>` (bare) or `<serverscript>: <name>` —
+  Frappe's `safe_exec` emits `<serverscript>` (bare) or `<serverscript>: <name>`:
   never the hyphenated form. So on live sites the carve-out never fired, Server
   Script frames were treated as plumbing, and no Slow Hot Path / Hook Bottleneck /
   Slow Background Job finding ever surfaced inside a Server Script body (a
@@ -197,7 +211,7 @@ versions may contain breaking changes — see migration notes below).
   powers Tracked Apps inclusion mode) resolved the app with a first-match
   `.find("apps/")`, so a bench installed under `/opt/apps/frappe-bench/apps/<app>/`
   (or a multi-bench server holding several benches under one `apps/` dir) bucketed
-  frames under the bogus `frappe-bench` prefix — and, worse, Tracked Apps failed
+  frames under the bogus `frappe-bench` prefix and, worse, Tracked Apps failed
   to match a tracked app on such a bench (its findings were hidden as framework).
   Both now go through one boundary-anchored, last-`apps/`-wins parser
   (`_last_app_segment`), so the real app resolves and an app whose own name ends
@@ -207,12 +221,12 @@ versions may contain breaking changes — see migration notes below).
 - **Widened the third-party library list so N+1s inside common libraries are not
   blamed on the developer.** `main`'s classifier only shows a library frame as a
   (non-actionable) Observation if the library is on a hardcoded list, and that
-  list was short — so a query looping inside `pandas`, `redis`, `requests`,
+  list was short so a query looping inside `pandas`, `redis`, `requests`,
   `numpy`, `jinja2`, `cryptography`, `psycopg2`, `boto3`, … was reported as an
   actionable user N+1 the developer can't fix. Expanded the library list
   (`base._THIRD_PARTY_LIB_NAMES`) to cover the common
   data/DB/cache/HTTP/serialization/crypto libraries, matched on the **resolved
-  app root** (first segment) like `call_tree._THIRD_PARTY_LIB_SEGMENTS` — **not**
+  app root** (first segment) like `call_tree._THIRD_PARTY_LIB_SEGMENTS`: **not**
   a substring anywhere. This matters because frappe's recorder strips the `apps/`
   prefix, so a SQL callsite is `<app>/<app>/…`; a substring match would blame a
   user module merely *named* like a library (`myapp/myapp/requests/api.py`) as
@@ -228,7 +242,7 @@ versions may contain breaking changes — see migration notes below).
   `run_count`); a pre-loop-scoping finding whose `estimated_impact_ms` is the
   cross-request cumulative total is left unlabelled rather than misdescribed.
 
-## [0.12.37] — 2026-08-26
+## [0.12.37] - 2026-08-26
 
 ### Fixed
 
@@ -236,19 +250,19 @@ versions may contain breaking changes — see migration notes below).
   is user code.** `call_tree._is_pure_helper_frame` (hot-frame findings) gained an
   installed-apps backstop and a larger third-party denylist, but
   `base.is_framework_callsite` (N+1 / redundant-call / EXPLAIN findings) kept a
-  smaller, separate list and no backstop — so an N+1 inside a lib like `requests`,
+  smaller, separate list and no backstop so an N+1 inside a lib like `requests`,
   `numpy`, `redis`, `jinja2`, or `click` was reported as an actionable *user* N+1
   by one path while the same frame was dropped as framework plumbing by the other.
   The two hand-maintained denylists are now **one canonical
   `base.THIRD_PARTY_LIB_SEGMENTS`** (the union of both, matched identically on the
   exact top path segment), and `is_framework_callsite` gained the same
-  installed-apps rescue call_tree has — ordered after the framework-app check so
+  installed-apps rescue call_tree has ordered after the framework-app check so
   `frappe`/`erpnext` stay framework, and a no-op off-bench. An installed app named
   like a library (`babel`, `redis`) is still correctly treated as user code on
   both surfaces. Also corrects now-stale comments that described substring
   matching (the lists have matched exact top segments since 0.12.x).
 
-## [0.12.36] — 2026-08-26
+## [0.12.36] - 2026-08-26
 
 ### Fixed
 
@@ -258,7 +272,7 @@ versions may contain breaking changes — see migration notes below).
   impact renderer with no finding-type guard. So an observation-only finding
   (e.g. **Framework N+1**, which the verb map even labels "Eliminate the N+1
   query (framework code)") could sort into the top-3 and render under "Fix these
-  first" with `est. saving` = its cumulative time — directly contradicting its
+  first" with `est. saving` = its cumulative time directly contradicting its
   own TL;DR hero ("usually not something you can change") and Observations card.
   The same list is also the *ungrouped* one, so two findings that root-cause-group
   into a single card (an N+1 and a Slow Query at the same callsite) double-listed
@@ -275,7 +289,7 @@ versions may contain breaking changes — see migration notes below).
   regression test now misconfigures the setting to 1 and asserts a
   once-per-request query across 50 requests still produces no finding.
 
-## [0.12.35] — 2026-08-25
+## [0.12.35] - 2026-08-25
 
 ### Fixed
 
@@ -285,26 +299,26 @@ versions may contain breaking changes — see migration notes below).
   `babel`, `markdown`, `click`, `redis`) *before* the installed-apps backstop, so
   a site with an app literally named `babel`/`markdown` had its pyinstrument-
   stripped frames dropped as plumbing. The installed-apps set is now consulted
-  first as a positive rescue — an installed app is the user's own code and always
+  first as a positive rescue an installed app is the user's own code and always
   wins over the heuristic lib match.
 
-## [0.12.34] — 2026-08-25
+## [0.12.34] - 2026-08-25
 
 ### Added
 
 - **The "Document:" breadcrumb resolves a new doc's real name.** When a flow
   creates a document, the insert request only knows Frappe's throwaway
   `new-<doctype>-<random>` placeholder, while the later submit/cancel already
-  carry the permanent name (e.g. `SAL-ORD-2026-00042`) — so the same document
+  carry the permanent name (e.g. `SAL-ORD-2026-00042`) so the same document
   read inconsistently across a session. `after_request` now captures the real
   name the save assigned (from the response) and stashes it on the recording
   (`resolved_target_doc`); the renderer replaces the placeholder with it. Only
   new-doc saves in an active session write it, it rides on the recording (no new
   Redis key), and old sessions gracefully fall back to the placeholder. Note:
-  this real name shows in **both** reports — consistent with submit/cancel, which
+  this real name shows in **both** reports consistent with submit/cancel, which
   already did; ask if you want document names redacted from the Safe report.
 
-## [0.12.33] — 2026-08-25
+## [0.12.33] - 2026-08-25
 
 ### Fixed
 
@@ -326,7 +340,7 @@ versions may contain breaking changes — see migration notes below).
   - `_finding_to_dict` normalizes a non-object `technical_detail_json` (a stray
     `null`/list) to an empty dict, so one malformed finding can't crash the render.
 
-## [0.12.32] — 2026-08-25
+## [0.12.32] - 2026-08-25
 
 ### Fixed
 
@@ -335,17 +349,17 @@ versions may contain breaking changes — see migration notes below).
   `table.data td code` guard now bounds every code cell to its column and wraps
   it at any character across *all* data tables (XHR timing, Web Vitals, orphaned
   XHRs, DB tables, flat queries, …). The load-bearing bit is `display:
-  inline-block` — `max-width` is inert on a bare inline `<code>`, which is why the
+  inline-block`: `max-width` is inert on a bare inline `<code>`, which is why the
   bug kept recurring when patched one table at a time. The XHR-timing table also
   gets an explicit URL-column width so it can't be squeezed to a sliver.
 
-## [0.12.31] — 2026-08-25
+## [0.12.31] - 2026-08-25
 
 ### Fixed
 
 - **Re-rendering an old report could mislabel a user N+1 as unfixable framework
   code.** 0.12.30 routed the TL;DR hero on `impact_scope_label`, a field absent
-  from sessions analyzed before it shipped — so a legacy user N+1 fell into the
+  from sessions analyzed before it shipped so a legacy user N+1 fell into the
   framework branch on **Regenerate reports**. The hero now routes on the stable
   `finding_type` (present on every finding), and the card backfills
   `impact_scope_label` from it, so hero and card agree on legacy re-renders.
@@ -367,7 +381,7 @@ versions may contain breaking changes — see migration notes below).
   (per request/job) instead of the process lifetime, so a worker picks up an
   install/uninstall on its next job.
 
-## [0.12.30] — 2026-08-24
+## [0.12.30] - 2026-08-24
 
 ### Fixed
 
@@ -376,7 +390,7 @@ versions may contain breaking changes — see migration notes below).
   decorator line (CPython 3.11+), so the narrowed self-time snippet rendered the
   decorator rather than the signature. The card now shows the decorator line(s)
   *through* the `def` and moves the highlight + `file:line` onto the `def`
-  (e.g. `sales_order.py:795 · calculate_discount`). Render-only — re-run the
+  (e.g. `sales_order.py:795 · calculate_discount`). Render-only re-run the
   flow or use **Regenerate reports** to see it on existing sessions.
 - **Framework N+1 could hijack the TL;DR hero with actionable wording.** A Low
   Framework N+1 (Frappe's own code, not user-fixable) could sort into the hero
@@ -403,9 +417,9 @@ versions may contain breaking changes — see migration notes below).
   `>= 2`; `<1ms` instead of a misleading `0ms`; dead `avg_ms` / `variant_count` /
   `all_variants` removed; shared `_p95`. Behaviour-preserving.
 
-## [0.12.26] — 2026-05-25
+## [0.12.26] - 2026-05-25
 
-**Renderer extraction COMPLETE — `finding_enrichment` phase 3 is the
+**Renderer extraction COMPLETE `finding_enrichment` phase 3 is the
 final extraction. The renderer-package roadmap is fully closed.**
 
 The HIGH-coupling subset that v0.12.16 documented as "deferred until
@@ -428,36 +442,36 @@ a clean independent extraction; today's PR moves the remaining 5 +
 8 functions + 1 constant from `_internal.py` →
 `optimus/renderer/finding_enrichment.py`:
 
-- `_find_call_line_in_function_body` — AST-walker for finding a
+- `_find_call_line_in_function_body`: AST-walker for finding a
   callee's call line inside a parent function. Uses `_resolve_source_path`
   (lazy from `source.py`).
-- `_retarget_phase1_callsites_to_drilldown_leaf` — re-aim phase-1
+- `_retarget_phase1_callsites_to_drilldown_leaf`: re-aim phase-1
   finding callsites at the call site of the deepest user-code frame
   in their drill-down chain. Uses `_find_call_line_in_function_body`
   + `_read_source_snippet` + `_bench_relative_display`.
-- `_finding_to_dict` (~200 LOC) — the main render-dict builder.
+- `_finding_to_dict` (~200 LOC) the main render-dict builder.
   Flattens a `Optimus Finding` child row, parses the JSON detail
   blob, synthesises a unified `callsite` shape, lazily attaches
   source snippets, handles Server Script Desk-link rewriting,
   builds the LLM-fix block.
-- `_attach_representative_callsites` — attach a representative
+- `_attach_representative_callsites`: attach a representative
   callsite (+ `is_representative` flag) to SQL red-flag findings
   by matching their normalized query against the recording calls.
   Uses `walk_callsite` (lazy from `optimus.analyzers.base`),
   `_resolve_source_path`, `_bench_relative_display`,
   `_read_source_snippet`.
-- `_markdown_to_safe_html` — render Markdown → sanitised HTML for
+- `_markdown_to_safe_html`: render Markdown → sanitised HTML for
   embedding in the report. Lazy `frappe.utils.markdown` /
   `sanitize_html` + `_highlight_diff_html` (from `syntax.py`).
-- `_read_function_body_snippet` — read a whole function body
+- `_read_function_body_snippet`: read a whole function body
   starting from its `def` line. Used for self-time hot-path
   findings. Lazy `_resolve_source_path` + `_SNIPPET_TRUNCATE_CHARS`
   (from `source.py`) + `optimus.server_script_source` lazy import.
-- `_expand_self_time_snippets` — for Slow Hot Path findings with
+- `_expand_self_time_snippets`: for Slow Hot Path findings with
   empty `drilldown_chain`, narrow the smoking-gun snippet to the
   function's signature line and flag `self_time_no_pinpoint`.
   Uses `_read_function_body_snippet`.
-- `_SQL_REDFLAG_FINDING_TYPES` constant — used by
+- `_SQL_REDFLAG_FINDING_TYPES` constant used by
   `_attach_representative_callsites`.
 
 Out of `optimus/renderer/_internal.py` (now ~2,265 LOC; was ~2,928),
@@ -467,17 +481,17 @@ from ~375 LOC → ~995 LOC).
 ### Implementation
 
 - **Lazy imports of sibling submodules** inside each function body
-  rather than at module-top. Same pattern as phase 2 — keeps the
+  rather than at module-top. Same pattern as phase 2 keeps the
   submodule free of circular import risk (`_internal.py` re-imports
   ALL phase-1/2/3 names from `finding_enrichment.py`).
 - **Standard back-import block** at the top of `_internal.py`
   re-imports all 8 new names + the constant so call sites
   (including `analyze.py:_finding_to_dict` + `:_markdown_to_safe_html`
   via `renderer.X` package shim) resolve unchanged.
-- **Structural-snapshot canary stays byte-identical** — no fixture
+- **Structural-snapshot canary stays byte-identical**: no fixture
   regeneration needed. Confirmed by 14 tests in
   `test_renderer_structure_snapshot.py`.
-- **Public-API contract preserved** — the
+- **Public-API contract preserved**: the
   `test_renderer_structure_snapshot.py:TestPublicAPIPreserved` block
   tests `_finding_to_dict`, `_markdown_to_safe_html`,
   `_read_function_body_snippet`, all still resolve via `renderer.X`
@@ -499,12 +513,12 @@ from ~375 LOC → ~995 LOC).
 
 The only thing left in `_internal.py` is the `render()` orchestrator
 itself + its immediate inline helpers. The README's "keep integrated"
-guidance for that final 800-LOC function still holds — splitting
+guidance for that final 800-LOC function still holds splitting
 it across submodules would create circular dependencies.
 
 ### Unchanged
 
-- Behaviour identical — every call site resolves the same function
+- Behaviour identical every call site resolves the same function
   through the back-import shim.
 - `analyze.py` callers of `renderer._finding_to_dict` and
   `renderer._markdown_to_safe_html` stay green without changes.
@@ -515,22 +529,22 @@ No behaviour change. Pure refactor. Unit suite stays at 1870.
 
 ---
 
-## [0.12.25] — 2026-05-25
+## [0.12.25] - 2026-05-25
 
-**Janitor proactive envelope-version census — per-key visibility
+**Janitor proactive envelope-version census per-key visibility
 complement to v0.12.18's sentinel sweep.**
 
 The v0.12.18 release shipped `_sweep_schema_drift` (sentinel-level
 signal: "schema version on disk differs from the code's"). This
 release adds the follow-up signal: "OK how many cached values are
-actually stale?". Useful immediately after a schema bump — operators
+actually stale?". Useful immediately after a schema bump operators
 see "5 of 12 session_meta values are still at envelope v0" and can
 plan cleanup vs. let-them-age-out without waiting for per-read
 `redis.schema_drift` events to accumulate one-by-one.
 
 ### Added
 
-- **NEW `janitor._sweep_envelope_versions()`** — per-key census
+- **NEW `janitor._sweep_envelope_versions()`**: per-key census
   across the `session_meta` cache (the v0.12.21 rollout target).
   Scans `profiler:session:*:meta`, reads each value via
   `frappe.cache.get_value`, unwraps via `redis_schema.unwrap_value`,
@@ -548,13 +562,13 @@ plan cleanup vs. let-them-age-out without waiting for per-read
   the sibling-sweep pattern).
 - **NEW `optimus/tests/test_janitor_envelope_census.py`** (~150
   LOC, 11 tests across 3 classes):
-  - `TestEmitDecisionMatrix` (6 tests) — the emit-or-skip decision
+  - `TestEmitDecisionMatrix` (6 tests) the emit-or-skip decision
     distilled to a pure function (`_emit_decision`). Empty bench,
     all-current, legacy-only, drift-only, mixed, only-legacy.
-  - `TestSweepSourceMatchesDecisionMatrix` (3 tests) — source-grep
+  - `TestSweepSourceMatchesDecisionMatrix` (3 tests) source-grep
     canaries: `total == 0` guard present, `(legacy + drift) == 0`
     gate present, event name is `janitor.envelope_version_census`.
-  - `TestSweepWiringInDailyCron` (2 tests) — source-grep canaries
+  - `TestSweepWiringInDailyCron` (2 tests) source-grep canaries
     on the wiring and the scan pattern.
 
 ### Why source-inspection tests (no in-process mocking)
@@ -566,7 +580,7 @@ Mocking that pipeline in pure-pytest is fragile (the conftest's
 `mock.patch.object` replacements don't survive cross-test isolation
 in the full suite when other tests have left state behind). The
 integration suite (`tests_integration/`) is the right place for the
-end-to-end execution test against real Redis — out of scope today.
+end-to-end execution test against real Redis out of scope today.
 
 The pure-function `_emit_decision` covers the logic-level contract;
 the source-grep canaries cover the wiring contract. Together they
@@ -579,7 +593,7 @@ adds a new daily-cron pass. Unit suite stays at 1859 + 11 new = 1870.
 
 ---
 
-## [0.12.24] — 2026-05-25
+## [0.12.24] - 2026-05-25
 
 **`session.py` local key helpers retired in favour of
 `optimus.redis_keys.session_*` aliases.**
@@ -594,7 +608,7 @@ LP capture.
 
 ### Changed
 
-- **`optimus/session.py`** — 5 local key helpers (`_active_key`,
+- **`optimus/session.py`**: 5 local key helpers (`_active_key`,
   `_meta_key`, `_recordings_key`, `_pending_jobs_key`, `_jobs_key`)
   replaced with module-level aliases to the v0.12.0 redis_keys
   equivalents:
@@ -630,10 +644,10 @@ On-disk Redis values from pre-v0.12.24 benches resolve unchanged.
 
 ### Unchanged
 
-- The v0.12.0 `test_redis_audit.py` drift checker — keys built via
+- The v0.12.0 `test_redis_audit.py` drift checker keys built via
   the alias are reached through `redis_keys.session_*`, which the
   audit's allow-list already covers.
-- Behaviour identical — every cache write/read produces the same
+- Behaviour identical every cache write/read produces the same
   key, just resolved through the centralized module.
 
 ### Compatibility
@@ -642,9 +656,9 @@ Pure cleanup. No behaviour change. Unit suite stays at 1859.
 
 ---
 
-## [0.12.23] — 2026-05-25
+## [0.12.23] - 2026-05-25
 
-**Renderer extraction — NEW `source_resolution.py` submodule. Prep work
+**Renderer extraction NEW `source_resolution.py` submodule. Prep work
 for finding_enrichment phase 3.**
 
 The HIGH-coupling finding-enrichment subset (`_finding_to_dict`,
@@ -659,20 +673,20 @@ family.
 
 Six functions from `_internal.py` → `optimus/renderer/source_resolution.py`:
 
-- `_action_dotted_entry(action)` — derive an action's dotted entry-
+- `_action_dotted_entry(action)`: derive an action's dotted entry-
   point path (RQ Job: method; HTTP `/api/method/<dotted>`: dotted).
-- `_skip_decorators_to_def(abs_filename, start_lineno, fn_name)` —
+- `_skip_decorators_to_def(abs_filename, start_lineno, fn_name)`:
   walk past `@decorator` lines to land on `def <fn_name>` (Python
   3.11+ `co_firstlineno` points at the first decorator, not the def).
-- `_resolve_dotted_to_code(dotted)` — `(abs_filename, lineno,
+- `_resolve_dotted_to_code(dotted)`: `(abs_filename, lineno,
   func_name)` from a dotted module path. Uses `importlib` (NOT
-  `frappe.get_attr` — no live-site dependency).
-- `_bench_relative_display(abs_path)` — `apps/<app>/...` display form
+  `frappe.get_attr`: no live-site dependency).
+- `_bench_relative_display(abs_path)`: `apps/<app>/...` display form
   via `frappe.utils.get_bench_path`. Falls back to absolute.
-- `_action_entry_callsite(action, *, cache)` — full resolution:
+- `_action_entry_callsite(action, *, cache)`: full resolution:
   action → dotted → code → `{filename, _abs, lineno, function,
   source_snippet}`.
-- `_resolve_frame_key_to_callsite(function_key, *, cache)` — same
+- `_resolve_frame_key_to_callsite(function_key, *, cache)`: same
   but starting from a repeated-hot-frame key (`short_path::func`).
 
 Out of `optimus/renderer/_internal.py` (now ~2,919 LOC; was ~3,170),
@@ -684,7 +698,7 @@ into NEW `optimus/renderer/source_resolution.py` (~260 LOC).
   stdlib + sibling renderer submodules' `_read_source_snippet` /
   `_resolve_source_path` from `source.py`).
 - Lazy import of `frappe.utils.get_bench_path` inside
-  `_bench_relative_display` preserved — keeps the module importable
+  `_bench_relative_display` preserved keeps the module importable
   in non-bench contexts (pure-pytest).
 - Standard back-import block at the top of `_internal.py` re-imports
   all 6 names so call sites (including ~6 in-`_internal.py` callers
@@ -697,9 +711,9 @@ into NEW `optimus/renderer/source_resolution.py` (~260 LOC).
 `finding_enrichment` phase 3 needs these helpers as a stable
 dependency. Two paths were possible:
 
-1. **Move them with phase 3** — would put 6 helpers + 5 finding-
+1. **Move them with phase 3**: would put 6 helpers + 5 finding-
    enrichment functions in the same PR, 11 moves at once.
-2. **Move them first** (this PR) — clean 6-function extraction
+2. **Move them first** (this PR) clean 6-function extraction
    today; phase 3 becomes a clean 5-function extraction tomorrow.
 
 Option 2 wins on reviewability and on testability (any regression in
@@ -708,13 +722,13 @@ independently validated).
 
 ### Docs
 
-- `optimus/renderer/README.md` — current-layout block bumped to 9
+- `optimus/renderer/README.md`: current-layout block bumped to 9
   submodules; new `source_resolution.py` row added with the 6-
   function inventory.
 
 ### Unchanged
 
-- Behaviour identical — every call site resolves the same function
+- Behaviour identical every call site resolves the same function
   through the back-import shim.
 - 59 unit tests across `test_action_entry_callsite.py` (which
   exercises 5 of the 6 moved helpers via `renderer.X`) stay green
@@ -728,14 +742,14 @@ No behaviour change. Pure refactor. Unit suite stays at 1859.
 
 ---
 
-## [0.12.22] — 2026-05-25
+## [0.12.22] - 2026-05-25
 
-**Docs — `docs/HMAC-ENVELOPE.md` specifies the future-scheme design
+**Docs `docs/HMAC-ENVELOPE.md` specifies the future-scheme design
 (v2 HMAC-SHA512, v3 AES-SIV, v4+ key rotation) using v0.12.14's
 1-byte version marker as the extension point.**
 
 The v0.12.14 release shipped the 1-byte HMAC scheme marker without
-specifying what future schemes look like — the marker was an extension
+specifying what future schemes look like the marker was an extension
 point but the extension semantics weren't documented. A future
 operator who needs SHA-512 (FIPS 140-3 compliance) or AES-SIV
 (encryption at rest in Redis) would have had to re-derive the design
@@ -743,21 +757,21 @@ from scratch. This release pre-designs those paths.
 
 ### Added
 
-- **NEW `docs/HMAC-ENVELOPE.md`** — documents:
+- **NEW `docs/HMAC-ENVELOPE.md`**: documents:
   - The v0 (legacy, pre-v0.12.14) + v1 (current) byte layouts.
   - The backward-compat read path's single-HMAC-step + first-byte
     disambiguation, with the rationale for `\x01` as the marker
     (pickle never emits it; producer-compat table for msgpack /
     JSON / raw bytes).
-  - **Scheme v2 (HMAC-SHA512) implementation sketch** — handles
+  - **Scheme v2 (HMAC-SHA512) implementation sketch**: handles
     the 32 → 64 byte signature length change via two-attempt
     verify, preserves v0/v1 compat. Includes a defence-in-depth
     guard against attacker-crafted v0 blobs whose body starts with
     a future scheme marker.
-  - **Scheme v3 (AES-SIV authenticated encryption) sketch** — same
+  - **Scheme v3 (AES-SIV authenticated encryption) sketch**: same
     envelope shape as v1; SIV tag replaces HMAC; deterministic-
     encryption fits the multi-read Redis pattern.
-  - **Scheme v4+ (key rotation)** — marker low-bits carry a
+  - **Scheme v4+ (key rotation)**: marker low-bits carry a
     key-id; operator-driven extension requiring per-key-id secret
     resolution in `_hmac_secret`.
   - The existing v0.12.14 canary-test suite (~13 tests) + the
@@ -769,7 +783,7 @@ from scratch. This release pre-designs those paths.
     could automate the re-sign post-bump.
   - **Out-of-scope deferrals**: nonce-based AEAD (AES-GCM /
     ChaCha20-Poly1305 don't fit the deterministic-retrieval
-    pattern); asymmetric signatures (Ed25519 — overkill for the
+    pattern); asymmetric signatures (Ed25519 overkill for the
     intra-bench trust model).
 
 ### Why pre-design
@@ -794,9 +808,9 @@ No code change. Documentation-only PR. Unit suite stays at 1859.
 
 ---
 
-## [0.12.21] — 2026-05-25
+## [0.12.21] - 2026-05-25
 
-**Redis-schema rollout continues — `session_meta` is the fifth value
+**Redis-schema rollout continues `session_meta` is the fifth value
 migrated to the v0.12.0 `wrap_value` / `unwrap_value` envelope.**
 
 The session metadata dict (set by `api.start`, updated through the
@@ -820,31 +834,31 @@ Previous phases: `settings_cache` (v0.12.11), `retention_backlog` +
 
 ### Why session_meta
 
-- **Hot path** — read on every recording's request/job hook;
+- **Hot path**: read on every recording's request/job hook;
   envelope overhead must be invisible. Single Redis GET +
   isinstance check.
-- **Stable dict shape** — fields documented in the docstring; the
+- **Stable dict shape**: fields documented in the docstring; the
   shape is the same v0.3.0+ contract, perfect for envelope.
-- **Single writer / single reader pair** — both inside `session.py`,
+- **Single writer / single reader pair**: both inside `session.py`,
   no cross-module coordination needed.
 
 ### Added
 
 - **NEW `optimus/tests/test_envelope_rollout_phase4.py`** (~155
   LOC, 5 tests):
-  - `test_set_session_meta_stores_envelope` — write-path canary.
-  - `test_get_session_meta_unwraps_new_envelope` — happy path.
-  - `test_get_session_meta_handles_legacy_bare_dict` — the
+  - `test_set_session_meta_stores_envelope`: write-path canary.
+  - `test_get_session_meta_unwraps_new_envelope`: happy path.
+  - `test_get_session_meta_handles_legacy_bare_dict`: the
     migration-safety contract: pre-v0.12.21 bare dicts resolve
     unchanged.
-  - `test_get_session_meta_returns_none_for_missing_key` — cache
+  - `test_get_session_meta_returns_none_for_missing_key`: cache
     miss case.
-  - `test_get_session_meta_returns_none_for_corrupt_non_dict` —
+  - `test_get_session_meta_returns_none_for_corrupt_non_dict`:
     defensive non-dict normalisation.
 
 ### Docs
 
-- `docs/REDIS-SCHEMA.md` — `profiler:session:<uuid>:meta` row
+- `docs/REDIS-SCHEMA.md`: `profiler:session:<uuid>:meta` row
   updated to reflect the envelope shape + the defensive
   normalisation note.
 
@@ -852,7 +866,7 @@ Previous phases: `settings_cache` (v0.12.11), `retention_backlog` +
 
 - **Forward** (new readers, old writers): supported via
   `unwrap_value`'s legacy-detection branch.
-- **Backward** (old readers, new writers): NOT supported — an old
+- **Backward** (old readers, new writers): NOT supported an old
   reader would call `.get("session_uuid")` on the envelope dict and
   get `None` (the envelope dict has `_v` + `data`, not the meta
   fields), then treat the session as inactive. The session's
@@ -863,8 +877,8 @@ Previous phases: `settings_cache` (v0.12.11), `retention_backlog` +
 
 ### Unchanged
 
-- `optimus/redis_schema.py` — envelope helpers ship as-is.
-- `session_recordings` (the per-session set of recording UUIDs) —
+- `optimus/redis_schema.py`: envelope helpers ship as-is.
+- `session_recordings` (the per-session set of recording UUIDs)
   stays unmigrated. Sets aren't a natural fit for the value envelope
   (the envelope wraps a single value; sets are member collections).
   Per-member wrapping would add overhead per recording without
@@ -875,21 +889,21 @@ Integration suite unchanged at 39.
 
 ---
 
-## [0.12.20] — 2026-05-25
+## [0.12.20] - 2026-05-25
 
-**LP key-helper unification — Phase-2 line_profile capture now uses
+**LP key-helper unification Phase-2 line_profile capture now uses
 `optimus.redis_keys.lp_*` instead of its local key helpers.**
 
 The v0.12.0 release centralised every Redis key pattern in
 `optimus/redis_keys.py` and added drift-detection (`test_redis_audit.py`),
 but `optimus/line_profile/capture.py` kept its own `_active_key` /
 `_picks_key` / `_source_key` / `_samples_key` / `_budget_hit_key`
-helpers — deferred from v0.12.0 as cleanup. This release closes that
+helpers deferred from v0.12.0 as cleanup. This release closes that
 gap. Pure cleanup; zero behaviour change.
 
 ### Changed
 
-- **`optimus/line_profile/capture.py`** — top-of-module
+- **`optimus/line_profile/capture.py`**: top-of-module
   `from optimus import redis_keys as _redis_keys` added; the 5 local
   key helpers retired; ~16 call sites migrated to
   `_redis_keys.lp_active(user)` / `_redis_keys.lp_picks(run_uuid)` /
@@ -899,26 +913,26 @@ gap. Pure cleanup; zero behaviour change.
 
 ### Why this matters
 
-- **Single source of truth** — `optimus/redis_keys.py` is the
+- **Single source of truth**: `optimus/redis_keys.py` is the
   documented "every key built here, every key found via
   `test_redis_audit.py`" location. The LP local helpers were the
   last surviving exception (per `[[reference_optimus_redis_schema]]`).
-- **Drift protection** — the v0.12.0 audit test's inline-key regex
+- **Drift protection**: the v0.12.0 audit test's inline-key regex
   scanned for f-string `profiler:*` patterns; the LP local helpers
   were f-strings, which is why they tripped the audit and got
   flagged on the deferred-work list.
-- **Byte-identical keys** — `_redis_keys.lp_active(user)` produces
+- **Byte-identical keys**: `_redis_keys.lp_active(user)` produces
   the EXACT same string (`profiler:lp:active:<user>`) the local
   helper did. On-disk Redis values from pre-v0.12.20 benches resolve
   unchanged.
 
 ### Unchanged
 
-- All v0.12.0 unit tests (`test_redis_audit.py` etc.) — they didn't
+- All v0.12.0 unit tests (`test_redis_audit.py` etc.) they didn't
   need to change because the key strings stayed identical.
-- `redis_keys.lp_*` functions in `optimus/redis_keys.py` — the
+- `redis_keys.lp_*` functions in `optimus/redis_keys.py`: the
   receiving side stays as the v0.12.0 documented shape.
-- Behaviour identical — every cache write/read produces the same
+- Behaviour identical every cache write/read produces the same
   key, just resolved through the centralized module.
 
 ### Compatibility
@@ -927,13 +941,13 @@ Pure cleanup. No behaviour change. Unit suite stays at 1854.
 
 ---
 
-## [0.12.19] — 2026-05-25
+## [0.12.19] - 2026-05-25
 
-**Renderer extraction — `finding_enrichment` phase 2 (drill-down chain
+**Renderer extraction `finding_enrichment` phase 2 (drill-down chain
 attachers) ships alongside the existing phase 1. Same submodule.**
 
-The drill-down chain cluster — `_find_node_in_tree`,
-`_walk_drilldown_chain`, `_attach_drilldown_chains` — is a self-
+The drill-down chain cluster `_find_node_in_tree`,
+`_walk_drilldown_chain`, `_attach_drilldown_chains`: is a self-
 contained sub-cluster of the larger finding_enrichment family that
 the v0.12.16 docstring documented as "still in `_internal.py`". Today
 it moves into `finding_enrichment.py` alongside the phase 1 helpers.
@@ -942,15 +956,15 @@ Same submodule because their architectural identity matches; the
 
 ### Moved
 
-- **`_find_node_in_tree(tree, basename, function)`** — depth-first
+- **`_find_node_in_tree(tree, basename, function)`**: depth-first
   walk a pyinstrument call tree for a `(basename, function)` match.
   Stdlib-only.
-- **`_walk_drilldown_chain(tree, callsite, ...)`** — hottest-child
+- **`_walk_drilldown_chain(tree, callsite, ...)`**: hottest-child
   traversal below a finding's origin frame. Uses
   `_find_node_in_tree` + lazy imports of
   `optimus.renderer.call_tree_renderer._ct_is_other_frame` and
   `optimus.analyzers.base.is_framework_callsite`.
-- **`_attach_drilldown_chains(findings, actions, tracked_apps)`** —
+- **`_attach_drilldown_chains(findings, actions, tracked_apps)`**:
   in-place attachment of the chain onto each finding's
   `technical_detail`. Uses `_walk_drilldown_chain` + `json.loads` for
   tree deserialisation.
@@ -966,7 +980,7 @@ into existing `optimus/renderer/finding_enrichment.py` (extended from
   theoretically grow a dependency on finding_enrichment in the
   future; the lazy form makes that direction safe.
 - `is_framework_callsite` already lazy-loaded inside the original
-  function body — preserved.
+  function body preserved.
 - The standard back-import block at the top of `_internal.py`
   re-imports `_find_node_in_tree`, `_walk_drilldown_chain`,
   `_attach_drilldown_chains` so call sites in `render()` resolve
@@ -994,21 +1008,21 @@ Still in `_internal.py` pending phase 3:
 
 ### Docs
 
-- `optimus/renderer/README.md` — current-layout block updated
+- `optimus/renderer/README.md`: current-layout block updated
   (`finding_enrichment.py` now lists phase 1+2 contents); roadmap
   table marks `finding_enrichment` as ◐ phase 1+2 done, ~365 LOC
   remaining.
 
 ### Unchanged
 
-- Behaviour identical — every call site through `_internal.py`'s
+- Behaviour identical every call site through `_internal.py`'s
   shim resolves the function the same way.
 - All 62 unit tests across `test_drilldown_chain.py` +
   `test_finding_card_smoking_gun.py` (which exercise the moved
   functions via the `renderer.X` package surface) stay green without
   modification.
 - `test_renderer_structure_snapshot.py` (14 tests) stays green
-  without fixture regeneration — output HTML is byte-equivalent.
+  without fixture regeneration output HTML is byte-equivalent.
 
 ### Compatibility
 
@@ -1016,15 +1030,15 @@ No behaviour change. Pure refactor. Unit suite stays at 1854.
 
 ---
 
-## [0.12.18] — 2026-05-25
+## [0.12.18] - 2026-05-25
 
-**Janitor proactive schema-drift sweep — the daily cron now compares
+**Janitor proactive schema-drift sweep the daily cron now compares
 the persisted `optimus:schema_version` sentinel against the current
 `SCHEMA_VERSION` and emits one telemetry event per drift detection.**
 
 The v0.12.0 release introduced the `optimus:schema_version` sentinel
 written at app-import as the foundation for future migration paths.
-The sentinel was deliberately not READ by anything except the test —
+The sentinel was deliberately not READ by anything except the test
 "reactive cleanup-on-read is sufficient for the foundation. A future
 release can add a janitor pass that enumerates `profiler:*` keys and
 migrates / purges those with mismatched versions" (v0.12.0 docstring
@@ -1034,7 +1048,7 @@ shape would need per-value migrators).
 
 ### Added
 
-- **NEW `janitor._sweep_schema_drift()`** — pure-function sweep that
+- **NEW `janitor._sweep_schema_drift()`**: pure-function sweep that
   reads the sentinel via `read_schema_sentinel`, compares against
   `SCHEMA_VERSION`, and on real drift:
   - Writes the current sentinel via `write_schema_sentinel` so the
@@ -1044,7 +1058,7 @@ shape would need per-value migrators).
     current_version}`.
   - No-ops on the happy path (sentinel == current).
   - No-ops with sentinel-write only (no telemetry) on the fresh-
-    install path (sentinel is None) — that's the normal startup
+    install path (sentinel is None) that's the normal startup
     transition, not interesting enough to alert on.
 - **`sweep_old_sessions` wired** to call `_sweep_schema_drift` after
   the existing `_sweep_old_telemetry`. Wrapped in its own try/except
@@ -1052,16 +1066,16 @@ shape would need per-value migrators).
   (matching the sibling-sweep pattern).
 - **NEW `optimus/tests/test_janitor_schema_drift.py`** (~200 LOC,
   6 tests):
-  - `test_no_op_when_sentinel_matches_current` — happy path.
-  - `test_fresh_install_writes_sentinel_no_telemetry` — fresh
+  - `test_no_op_when_sentinel_matches_current`: happy path.
+  - `test_fresh_install_writes_sentinel_no_telemetry`: fresh
     install transition silently writes the sentinel.
-  - `test_post_upgrade_drift_emits_telemetry` — sentinel < current
+  - `test_post_upgrade_drift_emits_telemetry`: sentinel < current
     fires the telemetry warning.
-  - `test_post_downgrade_drift_emits_telemetry` — sentinel >
+  - `test_post_downgrade_drift_emits_telemetry`: sentinel >
     current fires symmetrically (catches operator downgrade).
-  - `test_sentinel_write_failure_swallowed` — Redis hiccup during
+  - `test_sentinel_write_failure_swallowed`: Redis hiccup during
     sentinel write doesn't propagate; telemetry still fires.
-  - `test_sweep_old_sessions_calls_sweep_schema_drift` — wiring
+  - `test_sweep_old_sessions_calls_sweep_schema_drift`: wiring
     canary on the cron entry point.
 
 ### Why visibility (not migration)
@@ -1077,10 +1091,10 @@ events flood the telemetry table.
 
 ### Unchanged
 
-- `optimus/redis_schema.py` — `read_schema_sentinel` /
+- `optimus/redis_schema.py`: `read_schema_sentinel` /
   `write_schema_sentinel` / `SCHEMA_VERSION` / `wrap_value` /
   `unwrap_value` all ship as-is.
-- `_sweep_orphan_redis_state`, `_sweep_old_telemetry` — the existing
+- `_sweep_orphan_redis_state`, `_sweep_old_telemetry`: the existing
   daily sweeps stay unchanged.
 
 ### Compatibility
@@ -1096,19 +1110,19 @@ Integration suite unchanged at 39.
 
 ---
 
-## [0.12.17] — 2026-05-25
+## [0.12.17] - 2026-05-25
 
-**Redis-schema rollout continues — `explain_cache` is the fourth
+**Redis-schema rollout continues `explain_cache` is the fourth
 value migrated to the v0.12.0 `wrap_value` / `unwrap_value` envelope.**
 
 Previous phases covered `settings_cache` (v0.12.11),
 `retention_backlog` + `onboarding_seen` (v0.12.13). This release adds
-`explain_cache` — the cross-session cache of EXPLAIN query results
+`explain_cache`: the cross-session cache of EXPLAIN query results
 that powers the analyzer's slow-query / missing-index detection.
 
 ### Changed
 
-- **`optimus/analyze.py`** — the EXPLAIN cache write/read pair around
+- **`optimus/analyze.py`**: the EXPLAIN cache write/read pair around
   line 1352-1380 now uses the envelope:
   - WRITE: `frappe.cache.set_value(shared_key,
     _redis_schema.wrap_value(result), expires_in_sec=cache_ttl)`.
@@ -1120,13 +1134,13 @@ that powers the analyzer's slow-query / missing-index detection.
 
 ### Why explain_cache
 
-- **Highest-frequency cache by call count** — every analyze run that
+- **Highest-frequency cache by call count**: every analyze run that
   touches a slow query checks here; the hit rate determines whether
   re-analyze is fast (~5s) or slow (~30s, runs EXPLAIN again).
-- **Most complex shape rolled out so far** — payload is
+- **Most complex shape rolled out so far**: payload is
   `list[dict]` (EXPLAIN row results from MariaDB); validates that
   the envelope preserves nested structure cleanly.
-- **TTL-bounded** — pre-v0.12.17 cached entries fall off the cache
+- **TTL-bounded**: pre-v0.12.17 cached entries fall off the cache
   naturally within `optimus_explain_cache_ttl_seconds` (default
   3600s); the legacy-shape backward-compat branch covers the brief
   window after deploy.
@@ -1135,15 +1149,15 @@ that powers the analyzer's slow-query / missing-index detection.
 
 - **NEW `optimus/tests/test_envelope_rollout_phase3.py`** (~110
   LOC, 5 tests):
-  - `TestExplainCacheEnvelopeRoundTrip` (3 tests) —
+  - `TestExplainCacheEnvelopeRoundTrip` (3 tests)
     list-of-dicts round-trip, empty-list round-trip, legacy
     bare-list pass-through (the migration-safety contract).
-  - `TestAnalyzeSourceUsesEnvelope` (2 tests) — source-grep canaries
+  - `TestAnalyzeSourceUsesEnvelope` (2 tests) source-grep canaries
     on the write + read sites.
 
 ### Docs
 
-- `docs/REDIS-SCHEMA.md` — `profiler:explain:<cache_key>` row updated
+- `docs/REDIS-SCHEMA.md`: `profiler:explain:<cache_key>` row updated
   to reflect the new envelope shape + legacy-compat note.
 
 ### Compatibility
@@ -1160,40 +1174,40 @@ that powers the analyzer's slow-query / missing-index detection.
 
 ### Unchanged
 
-- `optimus/redis_schema.py` — envelope helpers ship as-is.
+- `optimus/redis_schema.py`: envelope helpers ship as-is.
 - The remaining bare-shaped values (`analyze_inflight`, LP
   `picks`/`source`/`samples`/`active`, the session hash family, the
-  Frontend buckets) — future PRs roll out one at a time.
+  Frontend buckets) future PRs roll out one at a time.
 
 Unit suite: 1843 → 1848 (+5 from the new phase-3 test module).
 Integration suite unchanged at 39.
 
 ---
 
-## [0.12.16] — 2026-05-25
+## [0.12.16] - 2026-05-25
 
-**Renderer extraction — `finding_enrichment` phase 1 (the low-coupling
+**Renderer extraction `finding_enrichment` phase 1 (the low-coupling
 subset) is the eighth submodule out of `_internal.py`.**
 
 The full `finding_enrichment` cluster spans ~11 functions
 non-contiguously across ~1500 LOC of `_internal.py`. The previous
 batch documented this as a "defer to focused PR" item because of the
-high coupling. This release ships the **tight subset** — the 3 pure-
-function helpers that have minimal back-coupling — leaving the
+high coupling. This release ships the **tight subset**: the 3 pure-
+function helpers that have minimal back-coupling leaving the
 HIGH-coupling subset (`_finding_to_dict` family + AST walker + chain
 attachers) for a future PR.
 
 ### Moved
 
-- **`_root_cause_key(finding)`** — `(basename, function)` deepest-
+- **`_root_cause_key(finding)`**: `(basename, function)` deepest-
   user-code anchor for a finding. Stdlib-only.
-- **`_group_findings_by_root_cause(findings)`** — collapse findings
+- **`_group_findings_by_root_cause(findings)`**: collapse findings
   sharing a root cause into one primary + `sub_findings` list. Uses
   `_root_cause_key` + `_GROUPING_SEVERITY_RANK`.
-- **`_normalize_callsite(callsite)`** — normalize dict-or-string
+- **`_normalize_callsite(callsite)`**: normalize dict-or-string
   callsite shapes to a single `{filename, lineno, function}` dict.
   Stdlib-only.
-- **Constant `_GROUPING_SEVERITY_RANK`** — severity-rank lookup
+- **Constant `_GROUPING_SEVERITY_RANK`**: severity-rank lookup
   (different from `doc_event_renderer._SEVERITY_RANK`; different
   values + use).
 
@@ -1214,7 +1228,7 @@ The following stay in `_internal.py` pending a focused future PR with
 proper coupling-graph design:
 
 - `_finding_to_dict` (~200 LOC, the renderer's main finding-to-dict
-  builder — calls many internal helpers).
+  builder calls many internal helpers).
 - `_walk_drilldown_chain` + `_attach_drilldown_chains`.
 - `_attach_representative_callsites` (calls source-resolution
   helpers `_action_dotted_entry`, `_skip_decorators_to_def`,
@@ -1234,13 +1248,13 @@ for. Neither is a one-batch task.
 
 ### Docs
 
-- `optimus/renderer/README.md` — current-layout block bumped to 8
+- `optimus/renderer/README.md`: current-layout block bumped to 8
   submodules; roadmap table marks `finding_enrichment` as ◐ (phase 1
   done; rest deferred). Updated cluster-size estimate.
 
 ### Unchanged
 
-- Behaviour identical — every call site through `_internal.py`'s
+- Behaviour identical every call site through `_internal.py`'s
   shim resolves the function the same way.
 - All unit tests pass without modification (the 3 moved functions
   weren't directly imported by name in any test file outside
@@ -1252,9 +1266,9 @@ No behaviour change. Pure refactor. Unit suite stays at 1843.
 
 ---
 
-## [0.12.15] — 2026-05-25
+## [0.12.15] - 2026-05-25
 
-**Workflow cleanup — `.github/workflows/integration.yml`'s 9 hard-coded
+**Workflow cleanup `.github/workflows/integration.yml`'s 9 hard-coded
 `bench run-tests --module` invocations replaced with a single shell
 loop driven by an `INTEGRATION_MODULES` env list.**
 
@@ -1266,7 +1280,7 @@ shape stayed consistent.
 
 ### Changed
 
-- **`.github/workflows/integration.yml`** — the `Run the integration
+- **`.github/workflows/integration.yml`**: the `Run the integration
   suite` step now declares its modules in one place:
   ```yaml
   env:
@@ -1284,10 +1298,10 @@ shape stayed consistent.
   A shell `while read` loop iterates the list and invokes `bench
   run-tests` per module. Adding a future module is a one-line edit
   to the env list.
-- **Failure accumulation** — the pre-v0.12.15 implementation used
+- **Failure accumulation**: the pre-v0.12.15 implementation used
   `set -e`, which made the FIRST failing module abort all siblings
   (despite the YAML comment claiming otherwise). The new accumulator
-  pattern runs EVERY module then fails the workflow if any failed —
+  pattern runs EVERY module then fails the workflow if any failed
   a single push surfaces every failure at once. **Behaviour
   improvement**: more signal per CI run when a refactor breaks two
   unrelated test modules.
@@ -1297,10 +1311,10 @@ shape stayed consistent.
 - Per-module log artifacts (`integration-<module>.log`) still upload
   on failure via the existing artifact-upload step. No log path
   changes.
-- The 9 module names — same set, same order, exact same module paths.
+- The 9 module names same set, same order, exact same module paths.
 - All other workflow steps (services, caches, install, summary,
-  artifact upload) — untouched.
-- Frappe v16 bench bootstrap path via `.github/helper/install.sh` —
+  artifact upload) untouched.
+- Frappe v16 bench bootstrap path via `.github/helper/install.sh`:
   unchanged.
 
 ### Compatibility
@@ -1312,9 +1326,9 @@ Unit suite unchanged at 1843. Integration suite unchanged at 39.
 
 ---
 
-## [0.12.14] — 2026-05-25
+## [0.12.14] - 2026-05-25
 
-**HMAC envelope versioning — `sign_blob` / `unsign_blob` now embed a
+**HMAC envelope versioning `sign_blob` / `unsign_blob` now embed a
 1-byte scheme version between the signature and the payload.**
 
 The v0.12.0 `wrap_value` rollout addressed value-shape versioning at
@@ -1334,12 +1348,12 @@ release adds the extension point so future bumps land cleanly.
   on read.
 - **`optimus/session.py:unsign_blob`** handles two body shapes after
   the 32-byte signature:
-  - **v1 (current, v0.12.14+)** — body starts with
+  - **v1 (current, v0.12.14+)**: body starts with
     `_HMAC_SCHEME_V1`; strip the marker, return `body[1:]`.
-  - **v0 (legacy, pre-v0.12.14)** — body is the raw payload; return
+  - **v0 (legacy, pre-v0.12.14)**: body is the raw payload; return
     `body` as-is.
 
-  The single HMAC verification step handles both cases — for v1 the
+  The single HMAC verification step handles both cases for v1 the
   HMAC was computed over `\\x01 + payload` AND that's exactly what the
   body is; for v0 the HMAC was computed over the payload AND the body
   is just the payload. Post-verify, the body's first byte
@@ -1357,7 +1371,7 @@ uses `\x01` as a leading opcode:
 So a legacy pre-v0.12.14 pickle payload's first byte can never
 accidentally trigger the v1 strip branch in `unsign_blob`. Future
 producers (msgpack, JSON, raw binary) just need to avoid `\x01` as a
-leading byte — or write through the v1 path so the marker is
+leading byte or write through the v1 path so the marker is
 explicit.
 
 ### Added
@@ -1371,7 +1385,7 @@ explicit.
     return the original payload; pickle-shaped legacy blobs work
     too (the `\x80` first byte stays as-is, no incorrect strip).
   - **`TestNewShapeByteLayout`** (1 test): canary on the byte
-    layout — `[32-byte HMAC] + \\x01 + payload`, length =
+    layout `[32-byte HMAC] + \\x01 + payload`, length =
     `32 + 1 + len(payload)`.
   - **`TestTamperingDetection`** (3 tests): tampered signature →
     None; tampered version byte → None (HMAC covers it); tampered
@@ -1397,11 +1411,11 @@ explicit.
 
 ### Unchanged
 
-- `_has_stable_hmac_secret()` and `_hmac_secret()` — secret
+- `_has_stable_hmac_secret()` and `_hmac_secret()`: secret
   resolution unchanged.
-- `_SIG_LEN = 32` — signature length unchanged (still SHA-256).
+- `_SIG_LEN = 32`: signature length unchanged (still SHA-256).
 - The Phase K no-secret pass-through path (returns raw blob when
-  `frappe.conf.encryption_key` is absent) — unchanged. The version
+  `frappe.conf.encryption_key` is absent) unchanged. The version
   marker is only inserted when the HMAC actually fires.
 
 Unit suite: 1830 → 1843 (+13 from the new envelope-versioning test
@@ -1409,27 +1423,27 @@ module). Integration suite unchanged at 39.
 
 ---
 
-## [0.12.13] — 2026-05-25
+## [0.12.13] - 2026-05-25
 
-**Redis-schema rollout continues — `retention_backlog` and
+**Redis-schema rollout continues `retention_backlog` and
 `onboarding_seen` are the second and third values migrated to the
 v0.12.0 `wrap_value` / `unwrap_value` envelope.**
 
 v0.12.11 shipped the first migration (`settings_cache`). This release
 continues the rollout to two more values, both simple-shape (int +
-string) — which exercises the legacy-detection branch in
+string) which exercises the legacy-detection branch in
 `unwrap_value` more thoroughly than the dict-shaped `settings_cache`
 did.
 
 ### Changed
 
-- **`optimus/janitor.py`** — both `retention_backlog` write sites
+- **`optimus/janitor.py`**: both `retention_backlog` write sites
   (after-cap + after-clear) now wrap their int payload via
   `redis_schema.wrap_value(backlog)` / `redis_schema.wrap_value(0)`.
   No in-app reader exists yet (operator-facing metric only), so the
   rollout is write-only for now; the future-safety value is that any
   consumer reading directly from Redis gets the envelope shape.
-- **`optimus/api.py`** — `mark_onboarding_seen` writes via
+- **`optimus/api.py`**: `mark_onboarding_seen` writes via
   `wrap_value("1")` and `check_onboarding_seen` reads via
   `unwrap_value(...)`. Both shapes (new envelope + legacy bare string)
   resolve to a truthy `bool(payload)` so the toast-dismissed semantics
@@ -1450,7 +1464,7 @@ did.
 
 ### Docs
 
-- `docs/REDIS-SCHEMA.md` — `optimus:retention_backlog` and
+- `docs/REDIS-SCHEMA.md`: `optimus:retention_backlog` and
   `profiler:onboarding_seen:<user>` rows updated to reflect the new
   envelope shape + legacy-compat note.
 
@@ -1460,19 +1474,19 @@ did.
   `onboarding_seen` via `unwrap_value`'s legacy-detection branch.
   Not relevant for `retention_backlog` (write-only).
 - **Backward** (old readers, new writers): NOT supported for
-  `onboarding_seen` — an old reader would do `bool(envelope_dict)`
+  `onboarding_seen`: an old reader would do `bool(envelope_dict)`
   which is always truthy (dicts are truthy in Python). The
   practical effect on a mid-deploy bench is that some users might
   see "onboarding already dismissed" even when the underlying value
   was just set; the toast stays hidden either way, so no user
   visible issue. For `retention_backlog`, old code reading via
-  `int(envelope_dict)` would crash — but there's no in-app reader.
+  `int(envelope_dict)` would crash but there's no in-app reader.
 
 ### Unchanged
 
-- `optimus/redis_schema.py` — envelope helpers ship as-is.
-- All other Redis values — the session hash family, the LP pick
-  keys, `explain_cache`, `analyze_inflight` — all still bare-shaped.
+- `optimus/redis_schema.py`: envelope helpers ship as-is.
+- All other Redis values the session hash family, the LP pick
+  keys, `explain_cache`, `analyze_inflight`: all still bare-shaped.
   Future PRs roll out one at a time as the cost/benefit warrants.
 
 Unit suite: 1823 → 1830 (+7 from the new envelope-rollout-phase-2
@@ -1480,9 +1494,9 @@ test module). Integration suite unchanged at 39.
 
 ---
 
-## [0.12.12] — 2026-05-25
+## [0.12.12] - 2026-05-25
 
-**Renderer extraction — `line_drilldown` is the seventh submodule out
+**Renderer extraction `line_drilldown` is the seventh submodule out
 of `_internal.py`. Structural snapshot stays byte-identical.**
 
 The line_drilldown cluster was the README's "single biggest remaining
@@ -1497,19 +1511,19 @@ finding-enrichment helpers it serves (`_retarget_phase1_callsites_to_drilldown_l
 
 - **Semi-public surface** (called by `analyze.py` via the
   package shim):
-  - `_build_line_drilldown_callsite_index(session_doc)` — builds
+  - `_build_line_drilldown_callsite_index(session_doc)`: builds
     the `(basename, function_name) → hottest-line` lookup powering
     the finding-card "Line-Level Drilldown hot line: …" callout.
 - **Public render entry-point**:
-  - `_render_line_drilldown_panel(session_doc)` — the section HTML
+  - `_render_line_drilldown_panel(session_doc)`: the section HTML
     builder. Empty string when the session has no phase-2 runs.
 - **Internal helpers**:
-  - `_make_line_drilldown_lookup` — Jinja adapter for tuple-keyed
+  - `_make_line_drilldown_lookup`: Jinja adapter for tuple-keyed
     lookups.
-  - `_phase2_invoked` — per-function "did it run?" check (delegates
+  - `_phase2_invoked`: per-function "did it run?" check (delegates
     to `optimus.line_profile.analyzer._function_invoked`).
-  - `_render_phase2_function_table` — per-function HTML table.
-  - `_render_phase2_diff_table` — cross-run delta HTML table.
+  - `_render_phase2_function_table`: per-function HTML table.
+  - `_render_phase2_diff_table`: cross-run delta HTML table.
 - **Back-compat aliases** (pre-v0.7.x renames):
   - `_build_phase2_callsite_index = _build_line_drilldown_callsite_index`
   - `_make_phase2_lookup = _make_line_drilldown_lookup`
@@ -1540,12 +1554,12 @@ The README's 840-LOC estimate bundled `_find_call_line_in_function_body`
 practice, both are called by code that stays in `_internal.py` (the
 `render()` orchestrator's finding-enrichment phase). Moving them now
 would require a back-import that's then immediately re-imported into
-the orchestrator — defeating the goal of a clean cluster boundary.
+the orchestrator defeating the goal of a clean cluster boundary.
 The finding_enrichment extraction will own those helpers.
 
 ### Docs
 
-- `optimus/renderer/README.md` — current-layout block bumped to 7
+- `optimus/renderer/README.md`: current-layout block bumped to 7
   submodules; roadmap table marks `line_drilldown` as ✓ done.
   Updated `finding_enrichment` row to note the additional helpers it
   now owns. 1 cluster remains (plus `render()` orchestrator which is
@@ -1553,7 +1567,7 @@ The finding_enrichment extraction will own those helpers.
 
 ### Unchanged
 
-- Behaviour identical — every call site through `_internal.py`'s
+- Behaviour identical every call site through `_internal.py`'s
   shim resolves the function the same way.
 - `analyze.py` still calls `renderer._build_line_drilldown_callsite_index`
   unchanged via the package re-export.
@@ -1568,9 +1582,9 @@ No behaviour change. Pure refactor. Unit suite stays at 1823.
 
 ---
 
-## [0.12.11] — 2026-05-25
+## [0.12.11] - 2026-05-25
 
-**Redis-schema versioning — first value migrated to the `wrap_value`
+**Redis-schema versioning first value migrated to the `wrap_value`
 / `unwrap_value` envelope.**
 
 The v0.12.0 release shipped the versioning foundation
@@ -1581,14 +1595,14 @@ not wrap any existing value. This release starts the rollout:
 
 ### Why settings_cache first
 
-* **Hot path** — `get_config()` is called from every request hook;
+* **Hot path**: `get_config()` is called from every request hook;
   the envelope overhead has to be invisible.
-* **Single writer + single reader** — both inside
+* **Single writer + single reader**: both inside
   `optimus/settings.py`, no cross-module coordination.
-* **Stable dict shape** — `OptimusConfig.__dict__` is well-defined.
+* **Stable dict shape**: `OptimusConfig.__dict__` is well-defined.
   Future schema bumps would touch the dataclass fields, which is
   exactly the situation the envelope was designed for.
-* **Cache invalidation already in place** — the Optimus Settings
+* **Cache invalidation already in place**: the Optimus Settings
   DocType controller's `on_update` deletes the key, so the next
   request rebuilds the value with the new envelope shape
   automatically. Rollout proves itself live on the first save after
@@ -1609,23 +1623,23 @@ not wrap any existing value. This release starts the rollout:
 
 - **NEW `optimus/tests/test_settings_envelope_rollout.py`** (~200 LOC,
   4 tests, all pure-pytest with a dict-backed `_FakeCache`):
-  - `test_fresh_write_stores_envelope_not_bare_dict` — write-path
+  - `test_fresh_write_stores_envelope_not_bare_dict`: write-path
     canary; asserts the post-write cache value is shaped
     `{"_v": SCHEMA_VERSION, "data": {...}}`.
-  - `test_hit_on_enveloped_value_returns_config` — new-shape read
+  - `test_hit_on_enveloped_value_returns_config`: new-shape read
     path; cache HIT reconstructs OptimusConfig without re-resolving.
-  - `test_hit_on_legacy_bare_dict_returns_config` — **the
+  - `test_hit_on_legacy_bare_dict_returns_config`: **the
     migration-safety contract**. Pre-v0.12.11 writers stored bare
     dicts; new readers must NOT crash. Catches a regression where
     `unwrap_value`'s legacy-detection branch goes away.
-  - `test_drift_falls_through_to_resolve` — a future-schema
+  - `test_drift_falls_through_to_resolve`: a future-schema
     envelope (`_v=999`) triggers fall-through to `_resolve` AND a
     `redis.schema_drift` telemetry event; the next write produces a
     fresh current-version envelope so the cache doesn't stay broken.
 
 ### Docs
 
-- `docs/REDIS-SCHEMA.md` — `optimus_settings_cached` row updated to
+- `docs/REDIS-SCHEMA.md`: `optimus_settings_cached` row updated to
   reflect the new envelope shape; legacy-compat note added.
 
 ### Compatibility
@@ -1645,10 +1659,10 @@ not wrap any existing value. This release starts the rollout:
 
 ### Unchanged
 
-- `optimus/redis_schema.py` — the envelope helpers ship as-is; no
+- `optimus/redis_schema.py`: the envelope helpers ship as-is; no
   edits to the wrap/unwrap logic. Only the call-site code changed.
-- All other Redis values — `retention_backlog`, `analyze_inflight`,
-  `onboarding_seen`, `explain_cache`, the session hash, etc. — all
+- All other Redis values `retention_backlog`, `analyze_inflight`,
+  `onboarding_seen`, `explain_cache`, the session hash, etc. all
   still bare-shaped. Future PRs roll out one at a time.
 
 Unit suite: 1819 → 1823 (+4 from the new envelope-rollout test
@@ -1656,13 +1670,13 @@ module). Integration suite unchanged at 39.
 
 ---
 
-## [0.12.10] — 2026-05-25
+## [0.12.10] - 2026-05-25
 
-**Renderer extraction — `doc_event_renderer` is the sixth submodule
+**Renderer extraction `doc_event_renderer` is the sixth submodule
 out of `_internal.py`. Structural snapshot stays byte-identical.**
 
 Per the v0.10.0 renderer-package roadmap, the doc-event lifecycle
-cluster was the next target — Moderate coupling per the README
+cluster was the next target Moderate coupling per the README
 (touches lifecycle-binding logic) but cleanly module-import-time
 self-contained.
 
@@ -1670,11 +1684,11 @@ self-contained.
 
 - **Public surfaces** (called from the render orchestrator in
   `_internal.py`):
-  - `_extract_target_doc(form_dict)` — best-effort pull of
+  - `_extract_target_doc(form_dict)`: best-effort pull of
     `{doctype, name}` from a request's form_dict.
   - `_attach_action_context(actions, findings, recordings_by_uuid)`
-    — in-place enrichment of `target_doc` + `hook_events`.
-  - `_build_doc_event_breakdown(findings)` — pure-function transform
+    in-place enrichment of `target_doc` + `hook_events`.
+  - `_build_doc_event_breakdown(findings)`: pure-function transform
     that groups findings by DocType → lifecycle event.
 - **Internal helpers** (only called within the cluster):
   - `_module_from_filename`, `_doctype_from_controller_path`,
@@ -1690,7 +1704,7 @@ into NEW `optimus/renderer/doc_event_renderer.py` (~423 LOC).
 
 - `_SEVERITY_RANK` is a local constant in the new submodule (the
   same name exists in `_internal.py` as `_GROUPING_SEVERITY_RANK`
-  with different values — unrelated; renamed-in-original avoided
+  with different values unrelated; renamed-in-original avoided
   collision). The new submodule's `_SEVERITY_RANK` matches the
   pre-extraction local-scope name + values.
 - Standard `from optimus.renderer.doc_event_renderer import …`
@@ -1702,14 +1716,14 @@ into NEW `optimus/renderer/doc_event_renderer.py` (~423 LOC).
 
 ### Docs
 
-- `optimus/renderer/README.md` — current-layout block bumped to 6
+- `optimus/renderer/README.md`: current-layout block bumped to 6
   submodules; follow-up roadmap table marks `doc_event_renderer` as
   ✓ done. 3 clusters remain (`line_drilldown`, `finding_enrichment`,
   `render()` orchestrator).
 
 ### Unchanged
 
-- Behaviour identical — every call site through `_internal.py`'s
+- Behaviour identical every call site through `_internal.py`'s
   shim resolves the function the same way.
 - All 57 unit tests across `test_doc_event_lifecycle.py` +
   `test_action_context.py` (which resolve via `renderer.X`) stay
@@ -1721,15 +1735,15 @@ No behaviour change. Pure refactor. Unit suite stays at 1819.
 
 ---
 
-## [0.12.9] — 2026-05-25
+## [0.12.9] - 2026-05-25
 
-**Bug fix — `api.regenerate_reports` now enforces its documented
+**Bug fix `api.regenerate_reports` now enforces its documented
 "Ready or Failed sessions only" contract.**
 
 v0.12.4 surfaced (via the new integration test) that
 `api.regenerate_reports` had **no `status` gate** in its
 implementation. The docstring claimed "Allowed on Ready OR Failed
-sessions" but the code accepted any status — Recording, Stopping,
+sessions" but the code accepted any status Recording, Stopping,
 Analyzing all re-rendered. Re-rendering an in-flight session would
 attach an incomplete report to a still-running analyze, which the
 pipeline would then overwrite on completion. Confusing for
@@ -1748,10 +1762,10 @@ they wanted to re-render after a renderer fix.
 ### Added
 
 - **`optimus/tests/test_regenerate_reports_api.py::test_status_gate_rejects_non_terminal_sessions`**
-  — pure-pytest source-inspection test that confirms the gate is
+  pure-pytest source-inspection test that confirms the gate is
   present and the error message points at `retry_analyze`.
 - **`optimus/tests_integration/test_regenerate_reports_idempotent.py::test_regenerate_refuses_non_terminal_status`**
-  — integration test that demotes a session to `Analyzing` and
+  integration test that demotes a session to `Analyzing` and
   asserts the endpoint raises with an operator-friendly message.
 
 ### Compatibility
@@ -1759,7 +1773,7 @@ they wanted to re-render after a renderer fix.
 Soft breaking. Any external automation that called
 `regenerate_reports` against an Analyzing / Recording / Stopping
 session would now see a `ValidationError`. In practice no operator
-flow does this — the UI button is only visible on Ready / Failed
+flow does this the UI button is only visible on Ready / Failed
 sessions per the existing `test_button_visible_on_ready_and_failed`
 test. Anyone shelling out to the endpoint directly (rare) would have
 been getting incomplete / overwritten reports before this fix.
@@ -1774,27 +1788,27 @@ suite: 39 (38 + 1 new test in the existing module).
 
 ---
 
-## [0.12.8] — 2026-05-25
+## [0.12.8] - 2026-05-25
 
-**Renderer extraction — `call_tree_renderer` is the fifth submodule
+**Renderer extraction `call_tree_renderer` is the fifth submodule
 out of `_internal.py`. Structural snapshot stays byte-identical.**
 
 Per the v0.10.0 renderer-package roadmap
 (`optimus/renderer/README.md`), the call-tree panel cluster was the
 next lowest-coupling target. Moves:
 
-* `_CALL_TREE_MAX_DEPTH`, `_CALL_TREE_HARD_CAP` — depth constants.
-* `_CT_OTHER_RE` — synthetic-placeholder regex.
-* `_ct_is_other_frame`, `_ct_is_sql_leaf`, `_ct_is_user_frame` — node
+* `_CALL_TREE_MAX_DEPTH`, `_CALL_TREE_HARD_CAP`: depth constants.
+* `_CT_OTHER_RE`: synthetic-placeholder regex.
+* `_ct_is_other_frame`, `_ct_is_sql_leaf`, `_ct_is_user_frame`: node
   classifiers.
-* `_render_call_tree_node`, `_render_call_tree_panel` — the rendering
+* `_render_call_tree_node`, `_render_call_tree_panel`: the rendering
   pair.
 
 Out of `optimus/renderer/_internal.py` (now ~4,213 LOC; was ~4,420),
 into NEW `optimus/renderer/call_tree_renderer.py` (~225 LOC). The 4
 extracted functions only call each other plus a lazy
 `optimus.analyzers.base.FRAMEWORK_APPS` import inside `_ct_is_user_frame`
-— self-contained cluster as flagged in the README's coupling table.
+self-contained cluster as flagged in the README's coupling table.
 
 ### Implementation
 
@@ -1806,8 +1820,8 @@ extracted functions only call each other plus a lazy
 - The standard `from optimus.renderer.call_tree_renderer import …`
   block lives at the top of `_internal.py` (right after the
   v0.10.0 visualization-module import block). Every name in the
-  extracted cluster is re-imported — including the constants and
-  the regex — so package-level `__init__.py`'s dir-walk re-export
+  extracted cluster is re-imported including the constants and
+  the regex so package-level `__init__.py`'s dir-walk re-export
   still surfaces them under the legacy `optimus.renderer.X` paths
   the unit suite uses (`test_call_tree_render.py`).
 - Output HTML is byte-equivalent: the structural-snapshot canary
@@ -1816,18 +1830,18 @@ extracted functions only call each other plus a lazy
 
 ### Docs
 
-- `optimus/renderer/README.md` — current-layout block updated;
+- `optimus/renderer/README.md`: current-layout block updated;
   follow-up roadmap table marks `call_tree_renderer` as ✓ done in
   v0.12.8; 4 clusters remain (`line_drilldown`, `doc_event_renderer`,
   `finding_enrichment`, `render()` orchestrator).
 
 ### Unchanged
 
-- The render path itself — every caller of `_render_call_tree_panel`
+- The render path itself every caller of `_render_call_tree_panel`
   / `_render_call_tree_node` (test code + the one call site in
   `_internal.py`'s `render` function) keeps working through the
   re-import shim.
-- `optimus/tests/test_call_tree_render.py` — pure-pytest unit tests
+- `optimus/tests/test_call_tree_render.py`: pure-pytest unit tests
   resolve the names via `renderer._render_call_tree_panel` etc.
   through the package `__init__.py` re-export; no change needed.
 
@@ -1838,9 +1852,9 @@ Structural snapshot stays byte-identical (no fixture update).
 
 ---
 
-## [0.12.7] — 2026-05-25
+## [0.12.7] - 2026-05-25
 
-**Integration test — `janitor.sweep_old_sessions` actually deletes.
+**Integration test `janitor.sweep_old_sessions` actually deletes.
 Seventh and final row of the v0.11.0 deferred-tests table is now
 ticked. The integration extraction roadmap is complete.**
 
@@ -1861,18 +1875,18 @@ terminal-state filter is correct.
   `janitor.sweep_old_sessions()`, and asserts the post-sweep state.
   `tearDown` tracks every UUID created so anything the sweep DIDN'T
   delete (negative controls) gets wiped:
-  - `test_sweep_deletes_session_older_than_retention` — the canary.
+  - `test_sweep_deletes_session_older_than_retention`: the canary.
     100-day-old Ready session → deleted. Without this, the Optimus
     Session table grows unbounded.
-  - `test_sweep_keeps_session_within_retention` — negative control.
+  - `test_sweep_keeps_session_within_retention`: negative control.
     30-day-old Ready session → kept. Catches over-aggressive
     deletion.
-  - `test_sweep_keeps_active_sessions_regardless_of_age` —
+  - `test_sweep_keeps_active_sessions_regardless_of_age`:
     terminal-state contract. 100-day-old Analyzing session → kept.
     The daily sweep filters `status IN (Ready, Failed)` exclusively;
     non-terminal states are the 5-minute `sweep_stale_sessions`'s
     job.
-  - `test_sweep_cascades_attached_file_deletion` — disk-hygiene
+  - `test_sweep_cascades_attached_file_deletion`: disk-hygiene
     contract. Deletes the session AND its `raw_report_file` File
     row. Orphan File rows would inflate disk usage forever even
     though the parent session is gone.
@@ -1885,19 +1899,19 @@ terminal-state filter is correct.
   rows) plus their attached File rows.
 - The synthetic File-row insertion clears `frappe.local.request`
   before insert so Frappe's `validate_file_extension` hits its
-  no-request bypass — same pattern `analyze._save_report_file`
+  no-request bypass same pattern `analyze._save_report_file`
   uses for the same reason.
 
 ### Docs
 
-- `optimus/tests_integration/README.md` — row 7 of the extraction
+- `optimus/tests_integration/README.md`: row 7 of the extraction
   roadmap ticked. **All 7 deferred-tests rows now complete.**
 
 ### Unchanged
 
-- `optimus/janitor.py` — function under test stays as-is.
+- `optimus/janitor.py`: function under test stays as-is.
 - All unit-suite janitor tests (`test_janitor.py`,
-  `test_janitor_telemetry.py`, etc.) — they stay as the pure-pytest
+  `test_janitor_telemetry.py`, etc.) they stay as the pure-pytest
   backstop.
 
 ### Compatibility
@@ -1909,22 +1923,22 @@ No behaviour change. Pure test addition. Integration-suite total:
 
 The v0.11.0 deferred-tests roadmap is now fully complete:
 
-1. ✓ v0.12.1 — `test_atomic_lua_merge_concurrent.py`
-2. ✓ v0.12.2 — `test_telemetry_flush_doctype_sink.py`
-3. ✓ v0.12.3 — `test_ai_privacy_exclusion_on_api.py`
-4. ✓ v0.12.4 — `test_regenerate_reports_idempotent.py`
-5. ✓ v0.12.5 — `test_phase2_tool_orphan_recovery.py`
-6. ✓ v0.12.6 — `test_safe_report_self_contained_on_real_bench.py`
-7. ✓ v0.12.7 — `test_janitor_sweeps_actually_delete.py`
+1. ✓ v0.12.1 `test_atomic_lua_merge_concurrent.py`
+2. ✓ v0.12.2 `test_telemetry_flush_doctype_sink.py`
+3. ✓ v0.12.3 `test_ai_privacy_exclusion_on_api.py`
+4. ✓ v0.12.4 `test_regenerate_reports_idempotent.py`
+5. ✓ v0.12.5 `test_phase2_tool_orphan_recovery.py`
+6. ✓ v0.12.6 `test_safe_report_self_contained_on_real_bench.py`
+7. ✓ v0.12.7 `test_janitor_sweeps_actually_delete.py`
 
 Every high-impact integration scenario the v0.7.x architecture
 review identified now has a real-bench canary.
 
 ---
 
-## [0.12.6] — 2026-05-25
+## [0.12.6] - 2026-05-25
 
-**Integration test — safe-report self-containment on the real bench.
+**Integration test safe-report self-containment on the real bench.
 Sixth row of the v0.11.0 deferred-tests table is now ticked.**
 
 The safe-report HTML is the **dev-shop interchange format**: a
@@ -1942,17 +1956,17 @@ file after Frappe's `file_manager` writes it.
   (~200 LOC, 3 tests). Each test creates a minimal synthetic Optimus
   Session, calls `api.regenerate_reports(uuid)`, reads
   `raw_report_file` via the File doc, and asserts:
-  - `test_on_disk_report_has_no_remote_resource_urls` — mirrors the
+  - `test_on_disk_report_has_no_remote_resource_urls`: mirrors the
     unit-suite canary at the integration boundary: no `src=https?:`,
     no `<link href=https?:`, no `@import`, no `url(http`. Includes
     a positive sanity check (at least one human-facing anchor link
     exists) so the negative checks don't trivially pass on an empty
     page.
-  - `test_on_disk_report_has_no_inline_or_external_javascript` —
+  - `test_on_disk_report_has_no_inline_or_external_javascript`:
     no `<script` tag in any form (the safe report is JS-free, which
     is part of why it's safe to open in an arbitrary browser).
   - `test_on_disk_report_does_not_reference_live_bench_asset_urls`
-    — no `/assets/`, no `/files/`, no `/api/method/` in
+    no `/assets/`, no `/files/`, no `/api/method/` in
     `src`/`href` positions. Bench-local asset references would
     render in a live-bench browser but break the moment the file is
     moved off-bench.
@@ -1967,15 +1981,15 @@ file after Frappe's `file_manager` writes it.
 
 ### Docs
 
-- `optimus/tests_integration/README.md` — row 6 of the extraction
+- `optimus/tests_integration/README.md`: row 6 of the extraction
   roadmap ticked. 1 row remains
   (`test_janitor_sweeps_actually_delete.py`).
 
 ### Unchanged
 
-- `optimus/api.py` `regenerate_reports` — endpoint under test stays
+- `optimus/api.py` `regenerate_reports`: endpoint under test stays
   as-is.
-- `optimus/analyze.py` `_save_report_file` — file-write path
+- `optimus/analyze.py` `_save_report_file`: file-write path
   unchanged.
 - Unit-suite self-containment canaries
   (`test_report_a11y.py`, `test_lens_promo.py`, etc.) stay as the
@@ -1988,9 +2002,9 @@ No behaviour change. Pure test addition. Integration-suite total:
 
 ---
 
-## [0.12.5] — 2026-05-25
+## [0.12.5] - 2026-05-25
 
-**Integration test — Phase-2 tool-2 orphan recovery. Fifth row of the
+**Integration test Phase-2 tool-2 orphan recovery. Fifth row of the
 v0.11.0 deferred-tests table is now ticked.**
 
 On Python 3.12+ line_profiler drives the process-global
@@ -2015,19 +2029,19 @@ path live.
   post-probe state. `setUp` + `tearDown` hard-reset tool 2 to free
   so a leak from one test cannot poison the rest of the suite.
   - `test_probe_reclaims_leaked_line_profiler_tool_2_on_simulated_worker_respawn`
-    — the canary. Register tool 2 as `"line_profiler"` with LINE
+    the canary. Register tool 2 as `"line_profiler"` with LINE
     events on, call probe, assert tool 2 is now unowned + events
     cleared. Without the probe, this leak would line-trace every
     later request → CPU peg + freeze.
-  - `test_probe_is_noop_when_tool_2_is_already_free` — happy path.
+  - `test_probe_is_noop_when_tool_2_is_already_free`: happy path.
     Probe does NOT grab the tool slot itself (catches a regression
     where the probe might accidentally register as owner).
   - `test_probe_warns_but_does_not_reclaim_non_line_profiler_owner`
-    — boundary contract. Register tool 2 as
+    boundary contract. Register tool 2 as
     `"third-party-debugger"`, call probe, assert ownership is
     PRESERVED. Without this constraint, the probe would silently
     break a third-party profiler / IDE debugger.
-  - `test_probe_emits_no_telemetry_on_happy_path` — quiet-on-success
+  - `test_probe_emits_no_telemetry_on_happy_path`: quiet-on-success
     contract. The probe runs at every worker import; emitting
     telemetry on the no-op path would flood
     `Optimus Telemetry Event` with worker-restart noise. Confirms
@@ -2038,7 +2052,7 @@ path live.
 ### Per-test isolation
 
 - **`setUp` + `tearDown` hard-reset tool 2** via
-  `sys.monitoring.set_events(PID, 0)` + `free_tool_id(PID)` — same
+  `sys.monitoring.set_events(PID, 0)` + `free_tool_id(PID)`: same
   pattern as the unit suite's `_guarantee_no_leak_escapes` autouse
   fixture. A leaked tool from one test silently slows every later
   test in the suite, so this guard is non-negotiable.
@@ -2046,24 +2060,24 @@ path live.
   `event_name="startup_probe_tool2"`** so the no-telemetry happy-path
   assertion is tight.
 - **Skips on Python < 3.12** via `pytest.mark.skipif(not _HAS_MON)`
-  — `sys.monitoring` is the 3.12+ entry point that drives the whole
+  `sys.monitoring` is the 3.12+ entry point that drives the whole
   pathway under test.
 
 ### Docs
 
-- `optimus/tests_integration/README.md` — row 5 of the extraction
+- `optimus/tests_integration/README.md`: row 5 of the extraction
   roadmap ticked. 2 rows remain
   (`test_safe_report_self_contained_on_real_bench.py`,
   `test_janitor_sweeps_actually_delete.py`).
 
 ### Unchanged
 
-- `optimus/__init__.py` `_startup_probe_tool2` — the function under
+- `optimus/__init__.py` `_startup_probe_tool2`: the function under
   test stays as-is.
-- `optimus/line_profile/capture.py` `release_monitoring_tool` —
+- `optimus/line_profile/capture.py` `release_monitoring_tool`:
   unchanged.
 - All v0.7.x unit-suite tool-2 tests
-  (`optimus/tests/test_line_profile_monitoring.py`) — they stay as
+  (`optimus/tests/test_line_profile_monitoring.py`) they stay as
   the pure-pytest backstop.
 
 ### Compatibility
@@ -2073,9 +2087,9 @@ No behaviour change. Pure test addition. Integration-suite total:
 
 ---
 
-## [0.12.4] — 2026-05-25
+## [0.12.4] - 2026-05-25
 
-**Integration test — `api.regenerate_reports` is byte-stable across
+**Integration test `api.regenerate_reports` is byte-stable across
 consecutive calls. Fourth row of the v0.11.0 deferred-tests table is
 now ticked.**
 
@@ -2085,7 +2099,7 @@ re-running the analyze pipeline. Its purpose is to let an operator
 pick up a renderer / template upgrade on a historical session without
 the cost of re-analysis. That makes it **load-bearing for upgrades**:
 v0.7.0 template polish, v0.10.0 renderer split, every later round of
-finding-card refinement — all shipped on the assumption that
+finding-card refinement all shipped on the assumption that
 operators could regenerate old sessions and see the new UI.
 
 The pure-pytest unit test
@@ -2097,7 +2111,7 @@ nothing about the output. What it can't prove:
 * That two consecutive `regenerate_reports` calls produce
   **byte-identical** HTML. Future non-determinism (a fresh UUID, a
   dict-iteration order change, a `time.time()` snapshot) would
-  silently start producing diff'd HTML — breaking `regenerate` as a
+  silently start producing diff'd HTML breaking `regenerate` as a
   way to roll forward and breaking any safe-report diffing workflow.
 * That the endpoint actually attaches HTML to
   `Optimus Session.raw_report_file` and the URL resolves.
@@ -2119,23 +2133,23 @@ This integration test fills that gap.
   minimal synthetic Optimus Session (reqd fields only) + explicit
   cleanup of attached File rows in tearDown.
   - `test_two_consecutive_regenerates_produce_byte_identical_html`
-    — the canary. `api.regenerate_reports(uuid)` twice, no changes
+    the canary. `api.regenerate_reports(uuid)` twice, no changes
     in between; the two `file_doc.get_content()` results must be
     byte-identical. Catches future non-determinism in the renderer.
   - `test_regenerate_attaches_html_to_raw_report_file_and_url_resolves`
-    — the side-effect contract: `raw_report_file` URL set,
+    the side-effect contract: `raw_report_file` URL set,
     File row is private + attached_to_doctype="Optimus Session" +
     content starts with `<!DOCTYPE` or `<html`.
-  - `test_regenerate_byte_diff_when_session_field_changes` — the
+  - `test_regenerate_byte_diff_when_session_field_changes`: the
     canary's complement. Render once, snapshot. Mutate `title` via
     `frappe.db.set_value`. Render again, snapshot. The two HTMLs
     must DIFFER, and the new title must appear in HTML 2 but not
     HTML 1. Catches silent caching.
-  - `test_regenerate_works_on_failed_status_session` — sets
+  - `test_regenerate_works_on_failed_status_session`: sets
     `status="Failed"`, calls regenerate, asserts it succeeds +
     attaches a fresh file. Validates the docstring claim that
     Failed sessions are explicitly allowed ("unblocks a demo when
-    a render-time bug was fixed" — api.py:1147-1150).
+    a render-time bug was fixed" api.py:1147-1150).
 - Workflow line in `.github/workflows/integration.yml` to run the new
   module against the bench-bootstrapped `test_site`.
 
@@ -2147,14 +2161,14 @@ This integration test fills that gap.
   a fixed timestamp via `mock.patch`. Module-attribute lookup at
   render time means the patch takes effect immediately for every
   render through the API endpoint.
-- **`tearDown` explicit cleanup** — `frappe.db.delete("File",
+- **`tearDown` explicit cleanup**: `frappe.db.delete("File",
   {attached_to_doctype: "Optimus Session", attached_to_name: name})`
   to wipe every File row regenerate created (one per call), then
   `frappe.delete_doc("Optimus Session", name, force=1)`.
 
 ### Discovery
 
-- `api.regenerate_reports` has **no `status` gate** — any session
+- `api.regenerate_reports` has **no `status` gate**: any session
   status (Ready, Failed, Analyzing, etc.) re-renders. The docstring
   says "Allowed on Ready OR Failed" but the code doesn't enforce it.
   Out of scope for this PR; documented in the test that exercises
@@ -2162,7 +2176,7 @@ This integration test fills that gap.
 
 ### Docs
 
-- `optimus/tests_integration/README.md` — row 4 of the extraction
+- `optimus/tests_integration/README.md`: row 4 of the extraction
   roadmap ticked. 3 rows remain
   (`test_phase2_tool_orphan_recovery.py`,
   `test_safe_report_self_contained_on_real_bench.py`,
@@ -2170,14 +2184,14 @@ This integration test fills that gap.
 
 ### Unchanged
 
-- `optimus/api.py` — the endpoint under test stays as-is.
-- `optimus/renderer/_internal.py` — `_now_iso` is patched per-test;
+- `optimus/api.py`: the endpoint under test stays as-is.
+- `optimus/renderer/_internal.py`: `_now_iso` is patched per-test;
   production behaviour unchanged.
-- `optimus/analyze.py` — `_render_and_attach_reports` /
+- `optimus/analyze.py`: `_render_and_attach_reports` /
   `_save_report_file` stay as-is.
-- `optimus/report_context.py` — `build_report_context` stays as-is.
+- `optimus/report_context.py`: `build_report_context` stays as-is.
 - All v0.7.0 unit-suite regenerate tests
-  (`optimus/tests/test_regenerate_reports_api.py`) — they stay as
+  (`optimus/tests/test_regenerate_reports_api.py`) they stay as
   the pure-pytest source-inspection backstop.
 
 ### Compatibility
@@ -2187,9 +2201,9 @@ No behaviour change. Pure test addition. Integration-suite total:
 
 ---
 
-## [0.12.3] — 2026-05-25
+## [0.12.3] - 2026-05-25
 
-**Integration test — `api.suggest_fix` honours
+**Integration test `api.suggest_fix` honours
 `ai_excluded_finding_types`. Third row of the v0.11.0 deferred-tests
 table is now ticked.**
 
@@ -2202,7 +2216,7 @@ and a `requests.post`-never-called spy. They can't prove:
 
 * That the **whitelisted endpoint** `api.suggest_fix(session_uuid,
   finding_ref, regenerate)` actually honours the exclusion before any
-  AI dispatch — there's a separate refusal site at `api.py:1333-1347`
+  AI dispatch there's a separate refusal site at `api.py:1333-1347`
   with its own user-readable error message.
 * That the live Optimus Settings cache invalidation (the doc's
   `on_update` deletes `redis_keys.settings_cache()`) propagates so the
@@ -2217,31 +2231,31 @@ That gap is what this integration test fills.
 ### Added
 
 - **NEW `optimus/tests_integration/test_ai_privacy_exclusion_on_api.py`**
-  — 5 tests covering the v0.9.0 exclusion gate at the live API
+  5 tests covering the v0.9.0 exclusion gate at the live API
   boundary against real MariaDB + the live Optimus Settings cache:
-  - `test_excluded_finding_type_throws_with_clear_error_message` —
+  - `test_excluded_finding_type_throws_with_clear_error_message`:
     `api.suggest_fix(session_uuid, "0")` on a "Slow Query" finding
     while "Slow Query" is in the exclusion list → raises
     `frappe.ValidationError` with a message that contains both
     "exclusion list" and "Optimus Settings" (verbatim substrings
     from the user-facing message at api.py:1343-1346).
-  - `test_excluded_finding_type_emits_telemetry_refusal_event` —
+  - `test_excluded_finding_type_emits_telemetry_refusal_event`:
     after the refusal raises, `telemetry.flush()` lands exactly one
     row in `Optimus Telemetry Event` with
     `event_name="ai.fix_call_refused_by_exclusion"`,
     `severity="warning"`, and `last_context` mentioning the
     refused finding type.
-  - `test_exclusion_is_case_sensitive_at_api_boundary` — exclusion
+  - `test_exclusion_is_case_sensitive_at_api_boundary`: exclusion
     = "slow query" (lowercase), finding type = "Slow Query"
     (capitalised). With `ai_fix.suggest_fix` patched to a benign
     stub, the endpoint reaches the stub (gate doesn't fire on case
     mismatch) and returns its payload. Zero refusal telemetry rows
     afterwards.
-  - `test_empty_exclusion_list_does_not_refuse` — exclusion = ""
+  - `test_empty_exclusion_list_does_not_refuse`: exclusion = ""
     (empty Small Text). Endpoint reaches the stubbed AI dispatch
     and returns its payload. Zero refusal telemetry rows.
   - `test_settings_save_invalidates_cache_so_api_picks_up_new_exclusion`
-    — start with exclusion = ""; first call succeeds (stub
+    start with exclusion = ""; first call succeeds (stub
     invoked). Save Optimus Settings with exclusion = "Slow Query"
     → the doc's `on_update` deletes `redis_keys.settings_cache()`.
     Second call → raises the exclusion error WITHOUT invoking
@@ -2257,7 +2271,7 @@ That gap is what this integration test fills.
   with sibling tests in the same process.
 - **`setUpClass` patches `ai_fix.is_available` to True** so the
   endpoint's early "AI fix suggestions aren't configured" guard
-  doesn't preempt the exclusion gate. Production is unaffected — the
+  doesn't preempt the exclusion gate. Production is unaffected the
   patch is scoped to this TestCase only.
 - **`setUp` snapshots `telemetry_enabled`, `telemetry_sink_doctype`,
   `ai_enabled`, `ai_suggest_findings`, `ai_excluded_finding_types`**
@@ -2285,7 +2299,7 @@ That gap is what this integration test fills.
 
 ### Docs
 
-- `optimus/tests_integration/README.md` — row 3 of the extraction
+- `optimus/tests_integration/README.md`: row 3 of the extraction
   roadmap ticked. 4 rows remain
   (`test_regenerate_reports_idempotent.py`,
   `test_phase2_tool_orphan_recovery.py`,
@@ -2294,14 +2308,14 @@ That gap is what this integration test fills.
 
 ### Unchanged
 
-- `optimus/api.py` — the endpoint under test stays exactly as-is.
-- `optimus/ai_fix.py` — the helpers under test (`is_finding_type_excluded`,
+- `optimus/api.py`: the endpoint under test stays exactly as-is.
+- `optimus/ai_fix.py`: the helpers under test (`is_finding_type_excluded`,
   `is_available`, `AI_ELIGIBLE_FINDING_TYPES`) stay as-is.
-- `optimus/settings.py` — resolve / cache logic unchanged.
+- `optimus/settings.py`: resolve / cache logic unchanged.
 - `Optimus Settings` / `Optimus Session` / `Optimus Finding` DocType
-  JSONs — schemas are the v0.9.0 / pre-existing shapes.
+  JSONs schemas are the v0.9.0 / pre-existing shapes.
 - All v0.9.0 unit-suite ai-privacy tests
-  (`optimus/tests/test_ai_privacy.py`) — they stay as the pure-pytest
+  (`optimus/tests/test_ai_privacy.py`) they stay as the pure-pytest
   backstop.
 
 ### Compatibility
@@ -2311,9 +2325,9 @@ No behaviour change. Pure test addition. Integration-suite total:
 
 ---
 
-## [0.12.2] — 2026-05-25
+## [0.12.2] - 2026-05-25
 
-**Integration test — telemetry flush → Optimus Telemetry Event DocType
+**Integration test telemetry flush → Optimus Telemetry Event DocType
 end-to-end. Second row of the v0.11.0 deferred-tests table is now
 ticked.**
 
@@ -2334,30 +2348,30 @@ integration test fills.
 ### Added
 
 - **NEW `optimus/tests_integration/test_telemetry_flush_doctype_sink.py`**
-  — 5 tests covering the v0.8.0 telemetry pipeline against real
+  5 tests covering the v0.8.0 telemetry pipeline against real
   MariaDB + the live Optimus Settings cache invalidation:
-  - `test_emit_then_flush_persists_doctype_row` — canonical
+  - `test_emit_then_flush_persists_doctype_row`: canonical
     round-trip. Emit once, flush, assert one row exists with the right
     `event_name`, `severity`, `count=1`, populated `first_seen` /
     `last_seen` / `optimus_version` / `python_version` /
     `frappe_version`.
-  - `test_repeated_emits_dedup_to_single_row_with_count` — 5 emits
+  - `test_repeated_emits_dedup_to_single_row_with_count`: 5 emits
     with the same `event_name` + `exc=None` (deterministic signature)
     → one DocType row with `count=5`. Validates the signature-dedup
     grouping at flush time.
-  - `test_flush_no_op_when_master_disabled` — toggle
+  - `test_flush_no_op_when_master_disabled`: toggle
     `telemetry_enabled` OFF via `frappe.get_single('Optimus Settings')
     → save`, emit, flush. Returns 0; no DocType row created. Confirms
     the master gate is honoured at flush time AND that the
     `on_update` cache-invalidation hook fires so `flush()` sees the
     new value.
-  - `test_persisted_row_has_scrubbed_traceback` — raise a real
+  - `test_persisted_row_has_scrubbed_traceback`: raise a real
     `ValueError`, emit with that exception, flush. The persisted
     `last_traceback` must contain `<bench>/apps/optimus/` (the
     scrubbed marker for the optimus frame) AND must NOT contain
     `/Users/` / `/home/` / `/private/` raw absolute prefixes.
     Locks in the PII-scrub round-trip through MariaDB.
-  - `test_second_flush_increments_count_via_upsert` — emit 3 + flush,
+  - `test_second_flush_increments_count_via_upsert`: emit 3 + flush,
     emit 4 + flush; assert one row with `count=7`. Confirms the
     v0.8.0 `INSERT … ON DUPLICATE KEY UPDATE count = count +
     VALUES(count)` SQL path executes (not a duplicate-key error or a
@@ -2372,7 +2386,7 @@ integration test fills.
   the shared `Optimus Telemetry Event` table.
 - **`setUp` snapshots `telemetry_enabled` + `telemetry_sink_doctype`**
   from the live Settings doc, then forces both ON. `tearDown`
-  restores whatever the original values were — the bench is left in
+  restores whatever the original values were the bench is left in
   the same state it was found in.
 - **`tearDown` does `frappe.db.delete('Optimus Telemetry Event',
   {event_name: like prefix%})`** because `_write_doctype` uses direct
@@ -2384,7 +2398,7 @@ integration test fills.
 
 ### Docs
 
-- `optimus/tests_integration/README.md` — row 2 of the extraction
+- `optimus/tests_integration/README.md`: row 2 of the extraction
   roadmap ticked. 5 rows remain
   (`test_ai_privacy_exclusion_on_api.py`,
   `test_regenerate_reports_idempotent.py`,
@@ -2394,12 +2408,12 @@ integration test fills.
 
 ### Unchanged
 
-- `optimus/telemetry.py` — the function under test. The integration
-  test is exactly that — testing, not editing.
-- `Optimus Telemetry Event` DocType JSON — schema is the same v0.8.0
+- `optimus/telemetry.py`: the function under test. The integration
+  test is exactly that testing, not editing.
+- `Optimus Telemetry Event` DocType JSON schema is the same v0.8.0
   shape; the test asserts the columns that release defined.
 - All v0.8.0 unit-suite telemetry tests
-  (`optimus/tests/test_telemetry.py`) — they stay as the pure-pytest
+  (`optimus/tests/test_telemetry.py`) they stay as the pure-pytest
   backstop that runs on every PR.
 
 ### Compatibility
@@ -2410,9 +2424,9 @@ No behaviour change. Pure test addition. Integration-suite total: 13 →
 
 ---
 
-## [0.12.1] — 2026-05-25
+## [0.12.1] - 2026-05-25
 
-**Integration test — atomic Lua merge under multi-worker contention.
+**Integration test atomic Lua merge under multi-worker contention.
 First row of the v0.11.0 deferred-tests table is now ticked.**
 
 The v0.11.0 release shipped the real-bench integration harness with two
@@ -2422,30 +2436,30 @@ deferred follow-ups. This is the first of those: a real-Redis + real-Lua
 (`a356f64` → `0e4a270` → `f30f44e`) is lossless under genuine
 multi-worker contention. The unit-suite version
 (`test_session_jobs.py::TestAtomicMergeJobMetaConcurrent`) silently
-`pytest.skip`s when Redis/Lua aren't available — under pure pytest,
+`pytest.skip`s when Redis/Lua aren't available under pure pytest,
 that's every run. The integration version is the first-class CI gate.
 
 ### Added
 
 - **NEW `optimus/tests_integration/test_atomic_lua_merge_concurrent.py`**
-  — 5 tests covering the v0.7.x trilogy's invariants under real Redis
+  5 tests covering the v0.7.x trilogy's invariants under real Redis
   + Lua:
-  - `test_recording_uuid_and_status_race_is_lossless` — the canonical
+  - `test_recording_uuid_and_status_race_is_lossless`: the canonical
     regression test. 50 distinct job_ids × 2 racing threads per job
     (one writes `recording_uuid`, one writes `status`), released
     simultaneously via `threading.Barrier`. Asserts every job has
     BOTH fields after the dust settles.
-  - `test_concurrent_distinct_job_ids_dont_clobber` — 20 threads
+  - `test_concurrent_distinct_job_ids_dont_clobber`: 20 threads
     write to 20 distinct hash fields simultaneously; validates the
     per-field cjson isolation inside the Lua script.
-  - `test_setdefault_first_writer_wins` — 20 threads race
+  - `test_setdefault_first_writer_wins`: 20 threads race
     `_SETDEFAULT_JOB_META_LUA` after a known first-writer's seed; the
     first value must survive.
-  - `test_fallback_path_writes_when_lua_unavailable` — single-thread
+  - `test_fallback_path_writes_when_lua_unavailable`: single-thread
     test (`frappe.local` is main-thread only). Monkey-patches
     `frappe.cache.eval` to raise; asserts `_atomic_merge_job_meta`
     still writes via the Python read-modify-write fallback.
-  - `test_atomic_merge_does_not_raise_when_lua_unavailable` —
+  - `test_atomic_merge_does_not_raise_when_lua_unavailable`:
     defensive lock-in: the wrapper catches eval failures silently and
     the host code never sees the underlying error.
 - Workflow line in `.github/workflows/integration.yml` to run the new
@@ -2460,7 +2474,7 @@ that's every run. The integration version is the first-class CI gate.
   `test_session_jobs.py::TestAtomicMergeJobMetaConcurrent` continues
   to skip under pure pytest).
 - Each test owns a per-test fixture session_uuid + purges the jobs
-  hash in setUp/tearDown — independent of the autouse
+  hash in setUp/tearDown independent of the autouse
   `cleanup_session` fixture (which handles Optimus Session DocType
   rows but not arbitrary Redis hashes the test creates directly).
 - The 4 race-test methods pre-compute the prefixed Redis key in the
@@ -2470,7 +2484,7 @@ that's every run. The integration version is the first-class CI gate.
 ### Deferred
 
 The remaining 6 rows of the integration-test extraction roadmap stay
-deferred — `test_telemetry_flush_doctype_sink`,
+deferred `test_telemetry_flush_doctype_sink`,
 `test_ai_privacy_exclusion_on_api`,
 `test_regenerate_reports_idempotent`,
 `test_phase2_tool_orphan_recovery`,
@@ -2482,16 +2496,16 @@ Version: 0.12.0 → 0.12.1.
 
 ---
 
-## [0.12.0] — 2026-05-24
+## [0.12.0] - 2026-05-24
 
-**Redis schema versioning foundation — closes the architecture review's
+**Redis schema versioning foundation closes the architecture review's
 mid-term refactor list.**
 
 Pre-v0.12.0, every Redis key Optimus writes had been evolving across
 the v0.5 → v0.11 sweep (the v0.7.x bg-tracking trilogy added per-job
 hashes; v0.8.0 added the telemetry buffer; v0.5.1 split combined
 frontend metrics into separate XHR/vitals lists) and **nothing in the
-codebase carried a version tag** — not the key names, not the value
+codebase carried a version tag**: not the key names, not the value
 envelopes, not a startup sentinel. The HMAC envelope used for
 ``profiler:tree:*`` was bare ``sig | pickle``; a future change to the
 pyinstrument tree shape would silently corrupt reads with no detection
@@ -2505,11 +2519,11 @@ construction.
 
 ### Added
 
-- **NEW `optimus/redis_keys.py`** — single source of truth for every
+- **NEW `optimus/redis_keys.py`**: single source of truth for every
   Redis key Optimus writes. ~22 public builder functions, one per key
   pattern. ``SCHEMA_VERSION = 1`` constant + a ``KEY_PATTERNS`` tuple
   the audit test cross-references against the doc.
-- **NEW `optimus/redis_schema.py`** — versioned-value envelope helpers
+- **NEW `optimus/redis_schema.py`**: versioned-value envelope helpers
   (``wrap_value`` / ``unwrap_value``) + schema-version sentinel write/
   read (``write_schema_sentinel`` / ``read_schema_sentinel``). The
   helpers are opt-in for new code; legacy un-wrapped values continue
@@ -2517,11 +2531,11 @@ construction.
   emits a ``redis.schema_drift`` telemetry event (via the v0.8.0
   pipeline) so operators see the mismatch in
   ``Optimus Telemetry Event``.
-- **NEW `docs/REDIS-SCHEMA.md`** — full schema documentation. Every
+- **NEW `docs/REDIS-SCHEMA.md`**: full schema documentation. Every
   key pattern × value shape × encoding × TTL × lifecycle, with a
   versioning contract section + a contributor checklist. The audit
   asserts this doc stays in lock-step with ``KEY_PATTERNS``.
-- **NEW `optimus/tests/test_redis_audit.py`** — drift-protection
+- **NEW `optimus/tests/test_redis_audit.py`**: drift-protection
   canary in the v0.11.1 audit-test style. Two assertions: no inline
   f-string keys inside ``frappe.cache.*`` calls (orphans are listed
   with file:line on failure); ``redis_keys.KEY_PATTERNS`` equals the
@@ -2541,19 +2555,19 @@ now resolve through ``redis_keys.*`` builders:
 ``optimus/settings.py`` (1), ``optimus/janitor.py`` (1),
 ``optimus/session.py`` (3 ``delete_session_state`` cleanup lines),
 ``optimus/optimus/doctype/optimus_settings/optimus_settings.py`` (1).
-Behaviour-preserving — the strings the builders return are identical
+Behaviour-preserving the strings the builders return are identical
 to the f-strings they replace; no deployed Redis state shifts.
 
 ### Untouched
 
-- The HMAC ``sign_blob`` / ``unsign_blob`` envelope — adding a version
+- The HMAC ``sign_blob`` / ``unsign_blob`` envelope adding a version
   tag inside the signed envelope is a follow-up with its own
   migration story.
 - ``session.py`` / ``line_profile/capture.py``'s pre-v0.12.0 internal
-  helpers (``_active_key``, ``_meta_key``, etc.) — those callers don't
+  helpers (``_active_key``, ``_meta_key``, etc.) those callers don't
   go through ``frappe.cache.X(literal_key, ...)``; they pass the
   helper's return value, which is invisible to the audit.
-- Every existing Redis value envelope — no wrapping in this PR. The
+- Every existing Redis value envelope no wrapping in this PR. The
   ``wrap_value`` / ``unwrap_value`` helpers are reserved for the next
   schema-version bump.
 
@@ -2565,10 +2579,10 @@ to the f-strings they replace; no deployed Redis state shifts.
   with a migration path for in-flight signed blobs).
 - **Migrate the jobs hash to JSON-only encoding** to drop the dual-
   encoding hazard documented in REDIS-SCHEMA.md § 5.
-- **Janitor proactive purge on schema-version mismatch** — reactive
+- **Janitor proactive purge on schema-version mismatch**: reactive
   cleanup-on-read is sufficient for the foundation.
 - **Unify the legacy ``session._meta_key`` etc. into ``redis_keys``**
-  — could be done now but doubles the diff size; cleaner as its own
+  could be done now but doubles the diff size; cleaner as its own
   follow-up.
 
 ### Engineering
@@ -2584,13 +2598,13 @@ Version: 0.11.1 → 0.12.0.
 
 ---
 
-## [0.11.1] — 2026-05-24
+## [0.11.1] - 2026-05-24
 
-**Telemetry instrumentation sweep — closes the v0.8.0 deferral.**
+**Telemetry instrumentation sweep closes the v0.8.0 deferral.**
 
 v0.8.0 (`5529cde`) shipped opt-in failure telemetry with 15 hand-picked
 top-of-stack migration sites and an explicit deferral: *"migration of
-remaining ~65 log_error sites — picked once we see the v0.8.0 signal
+remaining ~65 log_error sites picked once we see the v0.8.0 signal
 shape."* This release closes that deferral with a sweep of **72 additional
 sites** across 8 files, plus a **drift-protection audit test** that
 forever-after fails CI if a new `frappe.log_error(...)` call lands
@@ -2599,7 +2613,7 @@ lines.
 
 ### Added
 
-- **NEW `optimus/tests/test_telemetry_audit.py`** — the forever-after
+- **NEW `optimus/tests/test_telemetry_audit.py`**: the forever-after
   drift-protection canary. Walks every `.py` file under `optimus/`,
   asserts every `frappe.log_error(` line has a `telemetry.emit_failure(`
   call within 16 lines after. Excludes `tests/`, `tests_integration/`,
@@ -2607,17 +2621,17 @@ lines.
   roadmap), and `telemetry.py` itself (its sink-failure handler can't
   recurse into emit). Lists orphans with file:line on failure so a new
   contributor knows exactly where to add the emit. The audit is the
-  v0.11.1 contract — from this PR forward, drift is mechanically caught.
+  v0.11.1 contract from this PR forward, drift is mechanically caught.
 
 ### Code
 
-- `optimus/api.py` — 16 new emit sites (`api.set_draining_window`,
+- `optimus/api.py`: 16 new emit sites (`api.set_draining_window`,
   `api.scheduler_check`, `api.inline_analyze.mark_failed`,
   `api.inline_analyze.run`, `api.frontend_metrics.{xhr,vitals}_{rpush,ltrim}`,
   `api.regenerate_reports.{fetch,ai_backfill}`, `api.suggest_fix.persist`,
   `api.humanize_steps.fetch`, `api.refill_indexes.per_table`,
   `api.phase2.{force_stop_redis_cleanup,force_stop_parent_save,scheduler_check}`).
-- `optimus/analyze.py` — 22 new emit sites
+- `optimus/analyze.py`: 22 new emit sites
   (`analyze.{custom_hook.{not_callable,load_failed},singleflight_reenqueue,
   bg_job_wait_reenqueue,auto_arm_phase2,missing_session,analyzer_failed,
   ai_auto_suggest_outer,ai_index_suggest_outer,pyi_tree.{load_failed_both_paths,
@@ -2627,29 +2641,29 @@ lines.
   identifiers (analyzer_name, recording_uuid, filename, table) go into
   `context=`, not the event_name, so the DocType-level dedup groups all
   failures of the same class under one row.
-- `optimus/janitor.py` — 14 new emit sites covering the 7 outer
+- `optimus/janitor.py`: 14 new emit sites covering the 7 outer
   sweep wrappers + the 7 inner-loop sites (per-old-session deletes,
   enqueue_failed, stopping re-enqueue, phase-2 cleanup ×2, stuck phase-2
   ×2).
-- `optimus/infra_capture.py` — 6 new emit sites
+- `optimus/infra_capture.py`: 6 new emit sites
   (`infra_capture.{process_metrics,system_metrics,loadavg,db_metrics,
   redis_metrics,rq_metrics}`).
-- `optimus/install.py` — 5 new emit sites
+- `optimus/install.py`: 5 new emit sites
   (`install.after_install.{auto_role,tracked_apps_seed}`,
   `install.on_user_role_change`, `install.before_uninstall.capture`,
   `install.uninstall.cleanup`).
-- `optimus/hooks_callbacks.py` — 5 sites missed by the v0.8.0 sweep
+- `optimus/hooks_callbacks.py`: 5 sites missed by the v0.8.0 sweep
   (`after_request.{infra_end,header_injection,pyi_dump,sidecar_dump}`,
   `after_job.infra_end`).
-- `optimus/analyzers/explain_flags.py` — 1 new emit site
+- `optimus/analyzers/explain_flags.py`: 1 new emit site
   (`analyzers.explain_flags.row_parse`).
-- `optimus/analyzers/index_suggestions.py` — 2 new emit sites
+- `optimus/analyzers/index_suggestions.py`: 2 new emit sites
   (`analyzers.index_suggestions.{optimizer_failure,dropped}`).
-- `optimus/line_profile/analyzer.py` — 1 new emit site
+- `optimus/line_profile/analyzer.py`: 1 new emit site
   (`phase2.rerender_failed`).
 
 Every migrated site keeps its existing `frappe.log_error(...)` call
-unchanged — the emit is **additive**, never a replacement. Bare
+unchanged the emit is **additive**, never a replacement. Bare
 `except Exception:` blocks were converted to `except Exception as exc:`
 to feed the exception into `emit_failure`.
 
@@ -2659,33 +2673,33 @@ to feed the exception into `emit_failure`.
   `install.`, `analyzers.`, `phase2.`, `after_request.`, `after_job.`
 - **Phase suffix** where the failure has a natural inner identity
   (e.g. `analyze.pyi_tree.deserialize`).
-- **Dynamic identity in context, not event_name** — the per-analyzer
+- **Dynamic identity in context, not event_name**: the per-analyzer
   failures all share `event_name="analyze.analyzer_failed"` with the
   analyzer name in `context["analyzer"]`. Keeps the operator-facing
   Optimus Telemetry Event list view scannable as instrumentation grows.
 
 ### Operator notes
 
-- Defaults preserve existing behavior — telemetry stays opt-in
+- Defaults preserve existing behavior telemetry stays opt-in
   (`telemetry_enabled` default OFF). This release adds instrumentation,
   not surveillance.
 - High-rate loops (frontend XHR/vitals rpush, per-finding AI auto-
   suggest, per-pyi-tree deserialize, per-analyzer, per-bg-job, per-table
   index, janitor per-old-session deletes) compress to a handful of
-  unique signatures at flush time via the v0.8.0 signature dedup — one
+  unique signatures at flush time via the v0.8.0 signature dedup one
   DocType row per `(event_name, signature)` with `count=N`. The deque's
   `maxlen=500` provides backpressure if a single 10-minute window
   somehow produces > 500 distinct signatures.
 
 ### Deferred
 
-- `optimus/renderer/_internal.py` — graceful-degradation paths inside
+- `optimus/renderer/_internal.py`: graceful-degradation paths inside
   the 60+ silent excepts. Picked up in a follow-up PR using the
   renderer-split extraction recipe in `optimus/renderer/README.md`. The
   allowlist entry in `test_telemetry_audit.py` documents the deferral.
-- Event-name standardization for the v0.8.0-migrated sites — they're
+- Event-name standardization for the v0.8.0-migrated sites they're
   shipped + stable; no reason to churn.
-- A Frappe report ranking telemetry events by recent count — operator UX,
+- A Frappe report ranking telemetry events by recent count operator UX,
   not blocked by this PR.
 
 ### Engineering
@@ -2696,14 +2710,14 @@ to feed the exception into `emit_failure`.
 
 ---
 
-## [0.11.0] — 2026-05-24
+## [0.11.0] - 2026-05-24
 
-**Real-bench integration-test foundation — CI workflow + harness + two
+**Real-bench integration-test foundation CI workflow + harness + two
 pilot tests.**
 
 The pre-v0.11.0 CI (`.github/workflows/tests.yml`) is a fast (~6 s)
 pure-pytest pipeline using the Frappe stub in `optimus/tests/conftest.py`
-— great for logic regressions, blind to the integration layer:
+great for logic regressions, blind to the integration layer:
 `before_request` / `after_request` / `before_job` / `after_job` hooks,
 `scheduler_events`, the atomic Lua merge for bg-job tracking (the v0.7.x
 trilogy's `TestAtomicMergeJobMetaConcurrent` test is explicitly skipped
@@ -2719,7 +2733,7 @@ each become a small follow-up PR using this harness.
 
 ### Added
 
-- **NEW `.github/workflows/integration.yml`** — provisions a Frappe v16
+- **NEW `.github/workflows/integration.yml`**: provisions a Frappe v16
   bench against MariaDB 10.6 + two Redis service containers; runs the
   integration suite via `bench run-tests --app optimus --module …`.
   Triggers on PRs to `main`, push to `main`, scheduled daily at 04:00
@@ -2727,58 +2741,58 @@ each become a small follow-up PR using this harness.
   ~10-15 minutes cold, ~6-8 minutes with pip + yarn caches warm). Logs
   for both the test runs + the bench's own logs are uploaded as the
   `integration-logs` artifact on failure (14-day retention). No secrets
-  required — a fork's CI runs identically.
-- **NEW `.github/helper/install.sh`** — ~50-line bash script following
+  required a fork's CI runs identically.
+- **NEW `.github/helper/install.sh`**: ~50-line bash script following
   the established Frappe / ERPNext community pattern. Runs `bench init
   --frappe-branch version-16`, points it at the runner's service
   containers, symlinks the optimus checkout as `apps/optimus`, creates
   a `test_site`, installs optimus, runs `bench migrate`. Idempotent +
   reusable locally for spinning up a clean test bench.
-- **NEW `optimus/tests_integration/`** — sibling directory to
+- **NEW `optimus/tests_integration/`**: sibling directory to
   `optimus/tests/`. Tests subclass `frappe.tests.utils.FrappeTestCase`
   and use real `frappe.db` / `frappe.cache` / `frappe.get_doc` calls.
   The pure-pytest workflow never traverses this directory; the Frappe
   test runner never traverses `optimus/tests/`. Clean separation.
-- **NEW `tests_integration/conftest.py`** — bench-aware fixtures:
-  `test_site` (current site name), `cleanup_session` (autouse —
+- **NEW `tests_integration/conftest.py`**: bench-aware fixtures:
+  `test_site` (current site name), `cleanup_session` (autouse
   hard-deletes leftover Optimus Session rows + clears the per-user
   Redis active-session pointer; defence-in-depth on top of the per-test
   transaction rollback), `seeded_session` (start → yield uuid → stop +
   wait for terminal status).
-- **NEW `test_install_smoke.py`** — 4 tests: `Optimus User` role
+- **NEW `test_install_smoke.py`**: 4 tests: `Optimus User` role
   exists, all 8 Optimus DocTypes registered, Optimus Settings Single
   doc readable, `bench migrate` idempotent (re-runs without raising +
   no schema drift).
-- **NEW `test_recording_lifecycle_e2e.py`** — 4 tests covering the
+- **NEW `test_recording_lifecycle_e2e.py`**: 4 tests covering the
   canonical capture → analyze → render pipeline: `api.start` creates
   the DocType row + Redis pointer; `api.stop` clears the pointer +
   marks the session for analyze; the full lifecycle reaches a terminal
   state within 60 s + the report file is attached; session totals are
   populated post-analyze. This is the canonical regression canary for
   the integration layer.
-- **NEW `tests_integration/README.md`** — harness documentation, the
+- **NEW `tests_integration/README.md`**: harness documentation, the
   "no flakiness" rule (quarantine in 24 h, never retry-on-failure), and
   the seven-row extraction roadmap for follow-up PRs.
 
 ### Modified
 
-- **`CONTRIBUTING.md`** — added an "Integration tests (real bench)"
+- **`CONTRIBUTING.md`**: added an "Integration tests (real bench)"
   section with the local + CI commands and a pointer at the
   tests_integration README.
 
 ### Untouched (the point of the two-track design)
 
-- `.github/workflows/tests.yml` — the pure-pytest workflow stays the
+- `.github/workflows/tests.yml`: the pure-pytest workflow stays the
   fast-feedback loop. Both workflows run in parallel on PRs; branch
   protection gates merge on both.
-- `optimus/tests/` — the 1810-test pure-pytest suite continues
+- `optimus/tests/`: the 1810-test pure-pytest suite continues
   unchanged. The Frappe stub in its `conftest.py` doesn't apply to
   `tests_integration/` (sibling directory, never imported under
   `pytest optimus/tests/`).
-- `pyproject.toml` — no new pip dependencies. `frappe-bench` is
+- `pyproject.toml`: no new pip dependencies. `frappe-bench` is
   installed inside the bench helper script, not declared as a
   project dep.
-- The renderer package, the telemetry module, the AI fix path — every
+- The renderer package, the telemetry module, the AI fix path every
   v0.7.x → v0.10.0 piece stays exactly as-is. Integration tests
   exercise them via the live bench, but the code under test doesn't
   change.
@@ -2791,27 +2805,27 @@ each become a small follow-up PR using this harness.
 
 ### Deferred (each is a follow-up PR using this harness)
 
-- `test_atomic_lua_merge_concurrent.py` — un-skip the v0.7.x trilogy's
+- `test_atomic_lua_merge_concurrent.py`: un-skip the v0.7.x trilogy's
   concurrent Redis test.
-- `test_telemetry_flush_doctype_sink.py` — emit → flush → assert
+- `test_telemetry_flush_doctype_sink.py`: emit → flush → assert
   DocType row.
-- `test_ai_privacy_exclusion_on_api.py` — live `api.suggest_fix` with
+- `test_ai_privacy_exclusion_on_api.py`: live `api.suggest_fix` with
   an excluded type.
-- `test_regenerate_reports_idempotent.py` — render → regenerate → diff.
-- `test_phase2_tool_orphan_recovery.py` — leak `sys.monitoring` tool 2
+- `test_regenerate_reports_idempotent.py`: render → regenerate → diff.
+- `test_phase2_tool_orphan_recovery.py`: leak `sys.monitoring` tool 2
   + verify the startup probe reclaims.
-- `test_safe_report_self_contained_on_real_bench.py` — the canary on a
+- `test_safe_report_self_contained_on_real_bench.py`: the canary on a
   real bench's File-served HTML.
-- `test_janitor_sweeps_actually_delete.py` — janitor cron + retention.
+- `test_janitor_sweeps_actually_delete.py`: janitor cron + retention.
 - Cross-version matrix (Frappe v15 + v16), coverage reporting from the
-  integration suite, parallel test sharding — all out of scope for the
+  integration suite, parallel test sharding all out of scope for the
   foundation.
 
 ---
 
-## [0.10.0] — 2026-05-24
+## [0.10.0] - 2026-05-24
 
-**Renderer refactor — foundation PR splitting the 4,958-line monolith
+**Renderer refactor foundation PR splitting the 4,958-line monolith
 into a package, with a structural-snapshot canary.**
 
 `optimus/renderer.py` (4,958 lines, 86 top-level defs, one 812-line
@@ -2823,7 +2837,7 @@ hazard. Touching one helper rippled through 15+ callers spread over
 This release converts the file into a package and extracts the four
 lowest-coupling clusters as a proof-of-concept of the extraction
 recipe. The remaining five clusters stay in `_internal.py` and are
-staged for follow-up PRs — see `optimus/renderer/README.md` for the
+staged for follow-up PRs see `optimus/renderer/README.md` for the
 roadmap.
 
 ### Architecture
@@ -2832,31 +2846,31 @@ roadmap.
 shim in `__init__.py` walks `dir(_internal)` and re-exports every
 non-dunder name (including underscore-prefixed internals), so every
 existing `from optimus.renderer import X` and `optimus.renderer.X` call
-site continues to work unchanged — `analyze.py`, `api.py`, the test
+site continues to work unchanged `analyze.py`, `api.py`, the test
 suite, and any third-party fork stay on the contract.
 
 ### Extracted modules (~538 LOC moved)
 
-- `optimus/renderer/syntax.py` — Pygments highlighting + diff-block
+- `optimus/renderer/syntax.py`: Pygments highlighting + diff-block
   wrapper. `_ensure_pygments`, `_highlight_python_block_cached`,
   `_highlight_python_snippet`, `_highlight_all_snippets`,
   `_highlight_diff_html`, plus the `_PRE_BLOCK_RE` / `_diff_line_class`
   / `_looks_like_diff` internals.
-- `optimus/renderer/source.py` — source-file I/O + bounded LRU cache.
+- `optimus/renderer/source.py`: source-file I/O + bounded LRU cache.
   `_BoundedFileCache`, `_path_within_bench`, `_resolve_source_path`,
   `_read_source_snippet`, `_read_source_window`,
   `_SNIPPET_TRUNCATE_CHARS`, `_FILE_CACHE_MAX_ENTRIES`.
-- `optimus/renderer/visualization.py` — donut chart + hot-frames table +
+- `optimus/renderer/visualization.py`: donut chart + hot-frames table +
   frame-name redaction. `build_donut_data`, `build_donut_svg`,
   `build_hot_frames_table`, `redact_frame_name`, plus the
   `_DONUT_COLORS` palette.
-- `optimus/renderer/time_format.py` — duration + datetime formatting.
+- `optimus/renderer/time_format.py`: duration + datetime formatting.
   `_format_duration_ms`, `_format_datetime_display`,
   `_get_server_timezone`.
 
 ### Added
 
-- **NEW `test_renderer_structure_snapshot.py`** — the structural canary.
+- **NEW `test_renderer_structure_snapshot.py`**: the structural canary.
   Pre-v0.10.0 tests asserted *content* ("the string '50× hits' appears
   in the HTML") but never *structure*. A refactor that renamed
   `<div class="finding-card">` to `<section class="finding">` would
@@ -2868,7 +2882,7 @@ suite, and any third-party fork stay on the contract.
   `REGENERATE_RENDERER_SNAPSHOT=1 pytest`. 14 tests total, including
   enumerated public-API resolution checks for the 10 named symbols that
   matter to external callers.
-- **NEW `optimus/renderer/README.md`** — the future-author roadmap: why
+- **NEW `optimus/renderer/README.md`**: the future-author roadmap: why
   the package exists, the 5-step extraction recipe, the structural
   snapshot's role, the public-API stability promise, and the 5-cluster
   follow-up table with coupling estimates.
@@ -2884,7 +2898,7 @@ suite, and any third-party fork stay on the contract.
 - Updated tests that referenced `optimus/renderer.py` as a known file
   path (5 test files, ~14 sites) to point at the new
   `optimus/renderer/_internal.py`.
-- `test_app_priority_split.py` — one `patch.object(renderer, X)` call
+- `test_app_priority_split.py`: one `patch.object(renderer, X)` call
   rewritten to `patch.object(_renderer_internal, X)` because the
   package re-export trick doesn't apply when `_internal.py`'s own call
   sites resolve names through its own globals.
@@ -2892,12 +2906,12 @@ suite, and any third-party fork stay on the contract.
 ### Deferred (follow-up PRs)
 
 - `call_tree_renderer` (~240 LOC, weak coupling).
-- `line_drilldown` (~840 LOC, internal coupling) — single biggest
+- `line_drilldown` (~840 LOC, internal coupling) single biggest
   remaining chunk.
 - `doc_event_renderer` (~300 LOC, moderate coupling).
-- `finding_enrichment` (~380 LOC, HIGH coupling) — tightly coupled to
+- `finding_enrichment` (~380 LOC, HIGH coupling) tightly coupled to
   `analyze.py`; defer until the surrounding modules are extracted.
-- `render()` orchestrator (~812 LOC, core) — keep integrated; an
+- `render()` orchestrator (~812 LOC, core) keep integrated; an
   orchestrator isn't a section.
 
 ### Engineering
@@ -2909,15 +2923,15 @@ suite, and any third-party fork stay on the contract.
 
 ---
 
-## [0.9.0] — 2026-05-24
+## [0.9.0] - 2026-05-24
 
-**AI privacy hardening — Critical Risk #2 of the architecture review.**
+**AI privacy hardening Critical Risk #2 of the architecture review.**
 
 When AI fix suggestions are enabled, Optimus sends source code, normalized
 and raw SQL (including table/column names and EXPLAIN output), and action
 labels to the configured LLM provider. The pre-v0.9.0 controls were the
 master switch (`ai_enabled`), the batch toggle (`ai_auto_suggest`), and the
-per-pathway hard-off toggles — fine-grained enough to disable AI entirely
+per-pathway hard-off toggles fine-grained enough to disable AI entirely
 but with no opt-out short of that for an operator who wanted to keep
 specific *categories* of finding off the wire.
 
@@ -2925,20 +2939,20 @@ This release adds three pieces, all additive:
 
 ### Added
 
-- **NEW `docs/AI-FIXING.md`** — definitive data-flow documentation. Per-
+- **NEW `docs/AI-FIXING.md`**: definitive data-flow documentation. Per-
   pathway inventory tables (finding-fix, humanize-steps, index-suggestion,
   connectivity probe) listing every field that crosses the wire with
   typical and maximum sizes. What does *not* leave the host. Provider
   matrix. Three local-LLM recipes (ollama, LM Studio, vLLM) with starting
   timeout recommendations and first-token latency expectations. Threat
   model + note for dev shops receiving a profile.
-- **`ai_excluded_finding_types`** — new field in `Optimus Settings → AI →
+- **`ai_excluded_finding_types`**: new field in `Optimus Settings → AI →
   Privacy & Operations`. Multi-line, `#` comments, exact-match
   case-sensitive. Listed types are skipped in both auto-suggest and
-  on-demand calls — the payload is never built and no request leaves the
+  on-demand calls the payload is never built and no request leaves the
   host. Mirrors the parsing pattern of the existing `skip_request_paths` /
   `sensitive_sql_columns` skip-lists.
-- **`ai_request_timeout_seconds`** — new field with default 60, clamped
+- **`ai_request_timeout_seconds`**: new field with default 60, clamped
   10–600. Replaces the hardcoded 60-second `_HTTP_TIMEOUT` (which was
   fatal for local-LLM cold starts: ollama / vLLM first-token latency on a
   CPU-only host or first model load routinely exceeds 60s). Hosted
@@ -2962,7 +2976,7 @@ This release adds three pieces, all additive:
 
 ### Operator notes
 
-- Defaults preserve existing behavior — every operator who isn't on the
+- Defaults preserve existing behavior every operator who isn't on the
   exclusion list path or doesn't need a longer timeout gets the same
   outcome as v0.8.0.
 - `bench migrate` applies the v0_9_0 patch automatically.
@@ -2993,9 +3007,9 @@ This release adds three pieces, all additive:
 
 ---
 
-## [0.8.0] — 2026-05-24
+## [0.8.0] - 2026-05-24
 
-**Opt-in failure telemetry — Critical Risk #4 of the architecture review.**
+**Opt-in failure telemetry Critical Risk #4 of the architecture review.**
 
 The app previously had ~79 `frappe.log_error` call sites and ~200+ silent
 `try/except` blocks but no aggregation: every failure landed in Frappe's
@@ -3004,7 +3018,7 @@ global `Error Log` as a one-off row, so an operator couldn't tell
 again"*.
 
 This release adds an opt-in counter that aggregates failures by signature
-(event name + last 5 traceback frames). Default **OFF** — per the
+(event name + last 5 traceback frames). Default **OFF**: per the
 self-hosted product thesis, telemetry never phones home. When enabled the
 default sink is a local `Optimus Telemetry Event` DocType the operator
 inspects in their own Desk; a JSONL file sink (`<bench>/logs/optimus_telemetry.jsonl`)
@@ -3014,7 +3028,7 @@ a follow-up release.
 
 ### Added
 
-- `optimus/telemetry.py` — bounded in-process buffer (`maxlen=500`) +
+- `optimus/telemetry.py`: bounded in-process buffer (`maxlen=500`) +
   lock-free `emit_failure()` hot path + scheduled `flush()` every 10 minutes.
   PII scrub: file paths under bench rewrite to `<bench>/apps/<app>/file.py:LINE`,
   frames outside `optimus/` collapse to `<user_code>:LINE`, context dicts
@@ -3025,7 +3039,7 @@ a follow-up release.
   `INSERT … ON DUPLICATE KEY UPDATE` so multi-worker flushes converge.
 - 15 high-leverage migration sites in `__init__.py`, `hooks_callbacks.py`,
   `line_profile/hooks.py`, `analyze.py`, and `ai_fix.py`. Telemetry is
-  **additive** to the existing `frappe.log_error` calls — Error Log
+  **additive** to the existing `frappe.log_error` calls Error Log
   visibility is unchanged; misconfigured telemetry cannot regress it.
 - Optimus Settings: new Telemetry tab with five additive fields
   (master toggle, DocType sink, JSONL sink, endpoint URL, retention days).
@@ -3041,9 +3055,9 @@ a follow-up release.
 - Master toggle defaults OFF; the feature is invisible until enabled.
 - When enabled, the first rows appear within one 10-minute flush window.
 - Inspect via `Desk → Optimus Telemetry Event` (System Manager only;
-  read+delete permissions, no create/write — writes happen exclusively
+  read+delete permissions, no create/write writes happen exclusively
   via the flush worker).
-- The HTTPS endpoint field accepts a URL today but does nothing — the
+- The HTTPS endpoint field accepts a URL today but does nothing the
   transport will ship in a follow-up release without requiring a schema
   change.
 
@@ -3055,7 +3069,7 @@ a follow-up release.
 
 ---
 
-## [0.7.0] — 2026-05-13
+## [0.7.0] - 2026-05-13
 
 **The rename release.** The app rebrands from `frappe_profiler` →
 `optimus`, end-to-end: the Python package, the GitHub repo, every
@@ -3072,11 +3086,11 @@ trees down to the first signal-floor leaf.
 
 ### Install
 
-**Fresh deploy only** — no upgrade path from a pre-v0.7.0
+**Fresh deploy only**: no upgrade path from a pre-v0.7.0
 `frappe_profiler` install is supported. The 0.7.0 rename moves the
 package directory, renames every DocType / Role / realtime channel /
 HTTP header / `frappe.local.profiler_*` attribute / `frappe.conf
-.get("profiler_*")` key, and changes the `tabModule Def` row name —
+.get("profiler_*")` key, and changes the `tabModule Def` row name
 an in-place upgrade would need a substantial migration patch set,
 which is intentionally out of scope for the 0.7.0 release.
 
@@ -3103,14 +3117,14 @@ bench --site <yoursite> install-app optimus
 
 ### Added (rolled in from v0.6.x development)
 
-  - Line-profile Phase 2 drilldown — pick a hot function, profile it
+  - Line-profile Phase 2 drilldown pick a hot function, profile it
     line-by-line on a second recording, render hit/per-hit timing
     next to the source.
-  - Per-finding drill-down chain — walks the pyinstrument tree from
+  - Per-finding drill-down chain walks the pyinstrument tree from
     a finding's origin frame down to the first leaf below the
     signal floor (10% of origin cumulative_ms), rendered as a chain
     of indented call-site links.
-  - AI fix suggestions — `Suggest a fix (AI)` action on every finding
+  - AI fix suggestions `Suggest a fix (AI)` action on every finding
     sends the smoking-gun source window + recorded SQL evidence to
     the configured LLM endpoint and renders the response inline.
 
@@ -3126,7 +3140,7 @@ bench --site <yoursite> install-app optimus
   - Suite isolation: per-test `sys.modules` fence in `conftest.py`
     snapshots and restores per test, so stub-installer tests don't
     pollute downstream tests in the same pytest session.
-  - `frappe.db` is a Werkzeug Local proxy — tests now replace it
+  - `frappe.db` is a Werkzeug Local proxy tests now replace it
     wholesale via `monkeypatch.setattr` instead of patching its
     attributes (which the proxy intercepts inconsistently).
 
@@ -3139,27 +3153,27 @@ bench --site <yoursite> install-app optimus
 
 ---
 
-## [0.5.1] — 2026-04-15
+## [0.5.1] - 2026-04-15
 
 The "architect review" release. After v0.5.0 landed on the branch, we
 did seven back-to-back architect-review passes over the entire diff
 looking for production bugs, false positives, and bad UX. Each pass
-found 2–3 real issues of a different class — surface bugs, tests
+found 2–3 real issues of a different class surface bugs, tests
 mirroring broken production code, end-to-end error path regressions,
 HTTP-layer integration gaps, inconsistent helper adoption, and
 schema-field typos. This release bundles all of those fixes plus the
 user-reported widget bugs that surfaced during manual smoke testing
-against a real site. Zero new features — entirely product quality
+against a real site. Zero new features entirely product quality
 and correctness work.
 
 **No DocType schema changes.** No migration needed beyond
 `bench restart` + hard browser refresh.
 
-### Fixed — security
+### Fixed: security
 
 - **Stored XSS bypass via `sanitize_html` JSON fast-path.** The
   v0.5.0 renderer called Frappe's `sanitize_html` on the `notes`
-  field before passing to the template's `|safe` filter — but
+  field before passing to the template's `|safe` filter but
   without `always_sanitize=True`, sanitize_html has a JSON fast-path
   that returns the input unchanged when it parses as valid JSON.
   An attacker could set `notes` to `'{"x":"<script>alert(1)</script>"}'`
@@ -3193,7 +3207,7 @@ and correctness work.
   in existing` check was a substring compare. If another app had
   already set `Access-Control-Expose-Headers: X-Optimus-Recording-Id-Legacy`
   (or similar), the substring match would falsely think our header
-  was already present and skip appending it — silently breaking
+  was already present and skip appending it silently breaking
   the entire frontend correlation feature because the browser would
   refuse to surface the real header to JavaScript. Fixed with a
   proper comma-split case-insensitive token comparison.
@@ -3201,7 +3215,7 @@ and correctness work.
 - **Correlation header gated on active profiler session, not just
   recorder presence.** The `after_request` hook previously injected
   `X-Optimus-Recording-Id` whenever `frappe.local._recorder` had a
-  `.uuid` — which is true any time the standalone Frappe Recorder UI
+  `.uuid`: which is true any time the standalone Frappe Recorder UI
   is running, even for users who have no profiler session. The header
   was leaking onto every recorded response site-wide, and
   `optimus_frontend.js` was buffering XHRs tagged to a recording
@@ -3209,7 +3223,7 @@ and correctness work.
   `frappe.local.optimus_session_id` which is only set by our own
   `before_request` hook.
 
-### Fixed — production bugs that tests were covering for
+### Fixed: production bugs that tests were covering for
 
 These bugs shipped with v0.5.0 because my tests mocked the same
 broken pattern the production code used, so the test suite rubber-
@@ -3229,12 +3243,12 @@ matching.
   Fixed by calling `frappe.cache.info("stats")` directly and
   passing `frappe.cache` as the RQ connection. New `Tripwire` test
   stub raises on `.redis` access and asserts `info()` is called on
-  the root object — behavioral catch instead of string matching.
+  the root object behavioral catch instead of string matching.
 
 - **Cap-exceeded failure path wrote to phantom `analyze_error`
   field.** v0.5.0's inline-analyze safety cap (default 50 recordings)
   called `frappe.db.set_value("Optimus Session", docname,
-  {"analyze_error": "..."})` — but that field does NOT exist on the
+  {"analyze_error": "..."})`: but that field does NOT exist on the
   doctype. The real field is `analyzer_warnings` (plural). On
   scheduler-disabled sites with ≥51 recordings, clicking Stop
   crashed with MariaDB `Unknown column 'analyze_error' in 'field
@@ -3248,8 +3262,8 @@ matching.
   re-raises. When analyze ran inline via `frappe.enqueue(now=True)`,
   the re-raise propagated all the way up through `_enqueue_analyze`
   → `_stop_session` → `stop()` → the client. The widget's error
-  callback fired, showed "Failed to stop profiler — try again,"
-  and reset the widget to Recording — but the session was actually
+  callback fired, showed "Failed to stop profiler try again,"
+  and reset the widget to Recording but the session was actually
   Failed server-side. User clicks again, `status()` says no active
   session, widget falls into "Analyzing…" and hangs forever. Fixed
   by catching the inline-analyze re-raise in `_enqueue_analyze` and
@@ -3261,7 +3275,7 @@ matching.
 - **`submit_frontend_metrics` had a GET-merge-SET race.** Two
   concurrent submits (stop-time `frappe.call` racing a `beforeunload`
   sendBeacon) could both read the same existing blob, both compute
-  a merged result, and both write — losing one submission's data.
+  a merged result, and both write losing one submission's data.
   v0.5.1 switched to two atomic Redis lists per session
   (`profiler:frontend:<uuid>:xhr` and `:vitals`) written via RPUSH +
   LTRIM. Each submit appends its entries atomically; LTRIM enforces
@@ -3278,7 +3292,7 @@ matching.
   `application/json`, and Frappe's request handler parses JSON
   bodies and flattens their top-level keys into `form_dict` as
   kwargs. So the server was being called with
-  `submit_frontend_metrics(session_uuid=..., xhr=..., vitals=...)` —
+  `submit_frontend_metrics(session_uuid=..., xhr=..., vitals=...)`:
   mismatching the `payload` signature and failing with `TypeError`
   deep in the request router, logged into Frappe's internal error
   log and never reaching our own. Every `beforeunload` beacon was
@@ -3287,12 +3301,12 @@ matching.
   Frappe's flattening produces `{"payload": "..."}` which matches
   the endpoint signature.
 
-### Fixed — false positives in findings
+### Fixed: false positives in findings
 
 - **Missing Index now verifies the column is actually not indexed.**
   v0.5.0 trusted `frappe.core.doctype.recorder.recorder._optimize_query`
   and emitted a finding for whatever column it suggested. But
-  `DBOptimizer` is a heuristic that analyzes WHERE clauses — it
+  `DBOptimizer` is a heuristic that analyzes WHERE clauses it
   does NOT check whether an index already exists. Every Frappe
   session would likely produce false positives for pre-indexed
   columns: primary keys (`name`), framework columns (`parent`,
@@ -3309,7 +3323,7 @@ matching.
     - Column already indexed → suppressed, warning added to report
     - Column type is JSON / geometry → suppressed (not btree-indexable)
     - Column type is TEXT / BLOB → kept, but DDL rewritten to include
-      a prefix length: `ADD INDEX \`idx_col\` (\`col\`(255))` — the
+      a prefix length: `ADD INDEX \`idx_col\` (\`col\`(255))`: the
       plain DDL fails on TEXT with "BLOB/TEXT column used in key
       specification without a key length"
     - Column doesn't exist on table → suppressed (sql_metadata parse
@@ -3330,12 +3344,12 @@ matching.
   `RedisWrapper` methods, gunicorn worker wrappers, `cached_property`,
   etc.) all collapsed into a single `wrapper` bucket. The finding's
   customer description read *"optimizing it would help every flow
-  that touches it"* — which is useless because there is no single
+  that touches it"* which is useless because there is no single
   function called `wrapper` the user can optimize; it's a name
   shared across dozens of unrelated implementations. v0.5.1 fixes
   by including the filename in the dedup key. Key format is
   `"short/path.py::function"` where `short` is the last two path
-  segments — readable without leaking absolute paths.
+  segments readable without leaking absolute paths.
 
 - **Repeated Hot Frame was also suppressing legitimate Frappe
   application-layer targets.** The first fix of the above used the
@@ -3344,7 +3358,7 @@ matching.
   `Document.run_method` runs the user's own doc-event hooks,
   `has_permission` evaluates user-defined permission rules (including
   custom Permission Query Conditions), `make_autoname` runs the user's
-  chosen naming series — all legitimate optimization targets inside
+  chosen naming series all legitimate optimization targets inside
   `frappe/*`. v0.5.1 introduces a narrower `_is_pure_helper_frame`
   filter that only skips pure plumbing (`frappe/utils/`, `frappe/handler.py`,
   `frappe/app.py`, werkzeug, gunicorn, rq, pyinstrument itself,
@@ -3355,8 +3369,8 @@ matching.
   skip is correct.
 
 - **DB Pool Saturation used the wrong ratio.** v0.5.0 computed
-  `threads_running / threads_connected` — which measures *"of the
-  currently open connections, what % are executing queries"* —
+  `threads_running / threads_connected`: which measures *"of the
+  currently open connections, what % are executing queries"*
   and fired when that ratio exceeded 0.9. On a dev box with 5
   connections and 5 of them busy, that's 1.0 → fires the finding,
   even though MariaDB has 495 pool slots unused. The correct
@@ -3367,13 +3381,13 @@ matching.
 
 - **`infra_pressure` crashed on non-dict `infra` value.** The
   guard was `infra = rec.get("infra") or {}; if not infra: continue`
-  — which handles None and empty-dict but not a truthy non-dict
+  which handles None and empty-dict but not a truthy non-dict
   (list, string) that could come from corrupt Redis data. Any
   such value would pass the falsy check and then crash on
   `infra.get(...)`, killing analyze.run for the entire session.
   Added `isinstance(infra, dict)` guard.
 
-### Fixed — user-reported widget bugs
+### Fixed: user-reported widget bugs
 
 - **Widget stuck on "Recording" after clicking Stop.** Two
   compounding causes:
@@ -3393,8 +3407,8 @@ matching.
 
   2. **Stop callback didn't handle `{stopped: false}` response.**
      When the stop API returns `{stopped: false, reason: "no active
-     session"}` — which happens on auto-stop, janitor sweep, or a
-     retried click after a network blip on the first stop — the
+     session"}`: which happens on auto-stop, janitor sweep, or a
+     retried click after a network blip on the first stop the
      callback fell into the else branch and transitioned the
      widget to "Analyzing…" despite nothing being analyzed
      server-side. No `optimus_session_ready` realtime event would
@@ -3408,7 +3422,7 @@ matching.
   unconditionally reverted the widget to Recording and restarted
   the elapsed timer. But that's wrong when the stop actually
   succeeded server-side and the client only got a network error
-  — the widget would show Recording despite the session being
+  the widget would show Recording despite the session being
   gone. v0.5.1 error handler calls `status()` to ask the server
   what actually happened: if active → revert to Recording, if
   inactive → reset to inactive with a "Session already stopped"
@@ -3417,8 +3431,8 @@ matching.
 
 - **Start dialog silently failed on server error.** The
   `openStartDialog` `frappe.call(api.start)` had no error callback.
-  Any server-side failure — permission denied, concurrent session
-  conflict, server exception — made `frappe.call` silently skip
+  Any server-side failure permission denied, concurrent session
+  conflict, server exception made `frappe.call` silently skip
   the success callback and do nothing. Dialog closed, widget
   stayed inactive, no feedback. v0.5.1 adds an error handler that
   surfaces a red toast with actionable text, and the success path
@@ -3432,7 +3446,7 @@ matching.
   devtools. Makes future "widget doesn't work" reports debuggable
   without adding ad-hoc logging after the fact.
 
-### Fixed — inconsistent helper adoption
+### Fixed: inconsistent helper adoption
 
 - **`retry_analyze` now uses `_enqueue_analyze` for the scheduler-
   aware fallback.** v0.5.0 added the scheduler fallback to
@@ -3455,7 +3469,7 @@ matching.
   `is_scheduler_disabled()` call in `_stop_session` + `_enqueue_analyze`
   into a single call path.
 
-### Fixed — miscellaneous correctness and polish
+### Fixed: miscellaneous correctness and polish
 
 - **Widget poll-callback race.** The pass-1 fix added a guard at
   the top of `refreshStatus` to skip polling during `stopping`/
@@ -3486,7 +3500,7 @@ matching.
 - **`response_size_bytes` uses TextEncoder for accurate byte
   count.** The XHR fallback path was using
   `xhr.responseText.length` which is a UTF-16 code-unit count
-  — undercounts multi-byte characters (emoji, non-ASCII).
+  undercounts multi-byte characters (emoji, non-ASCII).
   v0.5.1 uses `new TextEncoder().encode(str).length` with a Blob
   fallback and a char-count fallback for legacy browsers.
 
@@ -3510,7 +3524,7 @@ matching.
   confirm which JS is running from devtools.
 - README.md rewritten top-to-bottom. Previously stuck at v0.1.0
   status with outdated runtime flag docs (`capture_stack`,
-  `explain` — neither exists; real flags are `capture_python_tree`
+  `explain`: neither exists; real flags are `capture_python_tree`
   and `notes`). The new README covers all 18 finding types, the
   full configuration surface, scheduler-disabled operation, a
   troubleshooting section with every v0.5.1-era failure mode,
@@ -3518,7 +3532,7 @@ matching.
   Relic / Scout / Bullet.
 - Custom `_is_pure_helper_frame` helper in `call_tree.py` for
   Repeated Hot Frame aggregation. Narrower than the pre-existing
-  `_is_framework_frame`. Both helpers are live — the broad
+  `_is_framework_frame`. Both helpers are live the broad
   filter is used for SQL-to-Python reconciliation and Slow Hot
   Path findings (where it's correct), the narrow filter is used
   for hot-frame aggregation (where the broad filter was too
@@ -3529,7 +3543,7 @@ matching.
 No DocType schema changes. No patches. Running
 `bench --site <site> migrate` is a no-op for v0.5.1 specifically,
 but `bench restart` is REQUIRED so the Python workers reload
-`hooks.py` with the new `__version__` cache-buster — otherwise
+`hooks.py` with the new `__version__` cache-buster otherwise
 browsers continue serving cached JS and none of the widget /
 frontend_frontend fixes take effect.
 
@@ -3550,7 +3564,7 @@ is needed.
   middleware accepting cookie-authenticated POSTs without a
   custom `X-Frappe-CSRF-Token` header. The SameSite cookie
   strategy is expected to work, but only the `beforeunload` path
-  is affected — the stop-time `frappe.call` flush (the primary
+  is affected the stop-time `frappe.call` flush (the primary
   delivery mechanism) is unchanged.
 - Inline analyze pollutes `RECORDER_REQUEST_HASH` with an orphan
   recording containing analyze's own query activity. Operational
@@ -3563,7 +3577,7 @@ is needed.
 
 ---
 
-## [0.5.0] — 2026-04-14
+## [0.5.0] - 2026-04-14
 
 The "Is it my code or my server?" release. Closes two competitive gaps
 with other profilers: there's no way to tell *code-slow* from
@@ -3577,80 +3591,80 @@ earlier.
 
 ### Added
 
-- **Server infrastructure capture** — new `infra_capture.py` module
+- **Server infrastructure capture**: new `infra_capture.py` module
   snapshots CPU, worker RSS, system memory, swap, load average, MariaDB
   thread counts and slow-query counter, Redis ops/sec, and RQ queue
   depths at the start and end of every recorded action. Balanced tier
   (14 metrics, ~0.8ms per snapshot). Runs in-line on the request path
-  — no background sampler thread. Every source is wrapped in its own
+  no background sampler thread. Every source is wrapped in its own
   try/except so a broken source degrades to `None` rather than
   breaking recording.
-- **`infra_pressure` analyzer** — emits four new finding types:
-  - **Resource Contention** — sustained system CPU > 85% across ≥2
+- **`infra_pressure` analyzer**: emits four new finding types:
+  - **Resource Contention**: sustained system CPU > 85% across ≥2
     actions. Severity escalates to High if any sample hits 95% or if
     >50% of actions are affected. Distinguishes "your own flow is
     CPU-bound" from "something else on the box is hogging CPU."
-  - **Memory Pressure** — worker RSS grew by > 200MB during the
+  - **Memory Pressure**: worker RSS grew by > 200MB during the
     session OR swap > 100MB during any action. High severity if
     delta > 500MB or swap is active.
-  - **DB Pool Saturation** — `threads_running / threads_connected`
+  - **DB Pool Saturation**: `threads_running / threads_connected`
     > 0.9 across ≥2 actions. Points at gunicorn worker count vs.
     MariaDB `max_connections` mismatch.
-  - **Background Queue Backlog** — any RQ queue (`default`, `short`,
+  - **Background Queue Backlog**: any RQ queue (`default`, `short`,
     `long`) peaked above 50 during the session. Signals that the
     flow enqueued work that's waiting behind other jobs.
-- **Browser-side metrics shim** — new `optimus_frontend.js` wraps
+- **Browser-side metrics shim**: new `optimus_frontend.js` wraps
   `window.fetch` and `XMLHttpRequest.prototype.open/send` to capture
   per-XHR timings (URL, method, duration, status, response size)
   whenever the server returns an `X-Optimus-Recording-Id` response
   header. Uses `PerformanceObserver` with `buffered: true` to capture
   Web Vitals (FCP, LCP, CLS, navigation timing). Wraps WHATWG
   primitives instead of application-level APIs so instrumentation
-  survives future Frappe upgrades — jQuery `$.ajax` is caught via XHR
+  survives future Frappe upgrades jQuery `$.ajax` is caught via XHR
   automatically. This is the approach every production APM library
   uses (OpenTelemetry JS, Sentry Browser, Datadog RUM).
-- **`X-Optimus-Recording-Id` correlation header** — `after_request`
+- **`X-Optimus-Recording-Id` correlation header**: `after_request`
   injects the recording UUID as a custom response header AND appends
   it to `Access-Control-Expose-Headers` so browsers actually surface
   it to JavaScript. The expose header is load-bearing: without it,
   `xhr.getResponseHeader("X-Optimus-Recording-Id")` returns `null`
   even for same-origin requests.
-- **`optimus.api.submit_frontend_metrics` endpoint** —
+- **`optimus.api.submit_frontend_metrics` endpoint**:
   receives batched XHR + Web Vitals payloads from the browser shim
   at stop time (via `frappe.call`) or at `beforeunload` (via
   `navigator.sendBeacon`). Accepts a JSON string payload because
   sendBeacon sends raw `Blob`, not form-encoded. Validates session
   ownership so a cross-user write is rejected. Soft caps (1000 XHRs,
   200 vitals) with tail-preferring truncation so end-of-flow data
-  wins on overflow. Idempotent — multiple submits merge into one
+  wins on overflow. Idempotent multiple submits merge into one
   Redis blob.
-- **`frontend_timings` analyzer** — joins XHR timings to Profiler
+- **`frontend_timings` analyzer**: joins XHR timings to Profiler
   Actions by recording UUID, dedupes multi-fire LCP per page (last
   value before next navigation, matching the Web Vitals library
   convention), and emits three finding types:
-  - **Slow Frontend Render** — LCP > 2500ms → Medium, > 4000ms → High.
-  - **Network Overhead** — `xhr_duration - backend_duration > 500ms`
+  - **Slow Frontend Render**: LCP > 2500ms → Medium, > 4000ms → High.
+  - **Network Overhead**: `xhr_duration - backend_duration > 500ms`
     AND `> backend * 1.5`. The multiplier is the key insight: a 500ms
     delta is disproportionate on a 1ms backend call but proportional
     on a 5s one. Only the disproportionate case flags.
-  - **Heavy Response** — single response > 500KB (Low, informational).
-- **Server Resource panel in the report template** — renders the
+  - **Heavy Response**: single response > 500KB (Low, informational).
+- **Server Resource panel in the report template**: renders the
   `infra_timeline` + `infra_summary` aggregates from `infra_pressure`
   as stat cards (CPU avg/peak, RSS delta, load peak, swap peak) and
   a per-action timeline table (CPU, RSS, load, DB pool ratio, RQ
   queue depths).
-- **Frontend panel in the report template** — renders the
+- **Frontend panel in the report template**: renders the
   `frontend_xhr_matched`, `frontend_vitals_by_page`, `frontend_orphans`,
   and `frontend_summary` aggregates from `frontend_timings`. Per-action
   XHR table with backend/browser/network-delta/status/size columns,
   Web Vitals table by page (FCP, LCP, CLS, TTFB, DCL), and a
   collapsed orphans section for diagnostic use (hidden entirely in
   Safe mode).
-- **`_safe_url` helper in `renderer.py`** — strips docname segments
+- **`_safe_url` helper in `renderer.py`**: strips docname segments
   from `/app/<doctype>/<name>/...` paths and redacts PII query string
   keys (`source_name`, `filters`, `name`, `doctype`, `reference_name`,
   `parent`, `customer`, `supplier`) to `?`. Method URLs
-  (`/api/method/frappe.client.save`) pass through — method names are
+  (`/api/method/frappe.client.save`) pass through method names are
   code identifiers, not PII. Applied to every URL rendered in the
   Frontend panel when `mode == "safe"`. Mirrors SQL normalization:
   full text stored, redacted form emitted.
@@ -3669,27 +3683,27 @@ earlier.
   steps"); v0.5.0 upgrades it in place rather than adding a duplicate
   `steps_to_reproduce` field, avoiding DB schema bloat and data
   migration.
-- **`v5_aggregate_json` field on Optimus Session** — hidden Long
+- **`v5_aggregate_json` field on Optimus Session**: hidden Long
   Text field that serializes the v0.5.0 `infra_pressure` and
   `frontend_timings` aggregates as a single JSON dict. Persisted by
   `_persist` alongside the existing `top_queries_json` and
   `table_breakdown_json`, read by `renderer.render()`.
 - **`data-session-uuid` attribute on the floating widget DOM element**
-  — set when a session is active, cleared when it ends. Read by
+  set when a session is active, cleared when it ends. Read by
   `optimus_frontend.js` to tag its flush payloads, keeping the two
   modules loosely coupled without a shared global.
 - **Test coverage:** 65+ new tests across:
-  - `test_scheduler_inline_fallback.py` — 5 tests
-  - `test_infra_capture.py` — 6 tests (snapshot, diff, force_stop,
+  - `test_scheduler_inline_fallback.py`: 5 tests
+  - `test_infra_capture.py`: 6 tests (snapshot, diff, force_stop,
     psutil defensive behavior, getloadavg fallback, idempotency)
-  - `test_correlation_header.py` — 7 tests
-  - `test_submit_frontend_metrics.py` — 7 tests
-  - `test_infra_pressure_analyzer.py` — 10 tests
-  - `test_frontend_timings_analyzer.py` — 11 tests
-  - `test_safe_url.py` — 9 tests
-  - `test_steps_to_reproduce.py` — 5 tests
-  - `test_v5_panels_render.py` — 5 end-to-end panel render tests
-  - `test_end_to_end_metrics.py` — 2 full-chain integration tests
+  - `test_correlation_header.py`: 7 tests
+  - `test_submit_frontend_metrics.py`: 7 tests
+  - `test_infra_pressure_analyzer.py`: 10 tests
+  - `test_frontend_timings_analyzer.py`: 11 tests
+  - `test_safe_url.py`: 9 tests
+  - `test_steps_to_reproduce.py`: 5 tests
+  - `test_v5_panels_render.py`: 5 end-to-end panel render tests
+  - `test_end_to_end_metrics.py`: 2 full-chain integration tests
   - Two new fixture files (`infra_pressure_session.json`,
     `frontend_metrics_session.json`)
   - Full suite: **277 tests passing**, zero regressions against v0.4.0.
@@ -3697,20 +3711,20 @@ earlier.
 ### Changed
 
 - **Scheduler-aware `_enqueue_analyze` fallback (also fixes a latent
-  v0.4.x bug).** When `bench disable-scheduler` is in effect —
-  common on dev, demo, and Frappe Cloud trial instances — no
+  v0.4.x bug).** When `bench disable-scheduler` is in effect
+  common on dev, demo, and Frappe Cloud trial instances no
   `bench worker` process consumes the RQ queue on many deployments,
   so an enqueued analyze job would sit forever and the session would
   hang in the **"Stopping"** state. v0.5.0 detects
   `is_scheduler_disabled()` and passes `now=True` to `frappe.enqueue`
   so analyze runs synchronously inside the stop request. A new
   `optimus_inline_analyze_limit` site config (default 50) hard-caps
-  the recording count for inline analyze — sessions above the cap
+  the recording count for inline analyze sessions above the cap
   are marked Failed with an actionable error directing the user to
   `bench enable-scheduler` and the **Retry Analyze** button. Prevents
   gunicorn's 120s worker timeout from killing a 200-recording inline
   analyze mid-flight.
-- **`api.stop()` response now includes `ran_inline: bool`** — the
+- **`api.stop()` response now includes `ran_inline: bool`**: the
   floating widget reads this to decide whether to transition through
   the "Analyzing…" state or jump straight to "Ready" (when analyze
   already completed inline, the report is attached by the time stop
@@ -3721,7 +3735,7 @@ earlier.
 - **`floating_widget.js:confirmAndStop`** now calls
   `window.optimus_frontend.flush()` before firing the stop
   API so buffered browser metrics land in Redis before analyze runs.
-  Best-effort — a failed flush never blocks stop.
+  Best-effort a failed flush never blocks stop.
 - **`_stop_session` signature changed** from `(user, session_uuid) -> str | None`
   to `(user, session_uuid) -> tuple[str | None, bool]`. Callers
   that discarded the return value still work; the only other
@@ -3733,7 +3747,7 @@ earlier.
   diff it against an end snapshot in the `finally` block, writing
   the result under `profiler:infra:<recording_uuid>` with the same
   TTL as other session keys. All work happens inside the existing
-  try/except blocks — a broken snapshot logs and falls through but
+  try/except blocks a broken snapshot logs and falls through but
   never breaks the customer's request.
 - **`capture._force_stop_inflight_capture`** is now accompanied by
   `infra_capture._force_stop_inflight` in both `api.start()` and
@@ -3752,7 +3766,7 @@ earlier.
   dicts as `rec["infra"]` before the analyzer loop runs, so
   `infra_pressure` and `frontend_timings` can read them inline
   without a Redis hop inside each analyzer. Also appends the two
-  new analyzers to `_BUILTIN_ANALYZERS`. Order is irrelevant — both
+  new analyzers to `_BUILTIN_ANALYZERS`. Order is irrelevant both
   are independent of every existing analyzer.
 
 ### Fixed
@@ -3761,7 +3775,7 @@ earlier.
   `handoff-ux` branch as `e620a57`). `confirmAndStop()` set the DOM
   display to "Stopping…" but left `currentState.display` as
   `"recording"`, so the 5-second polling guard in `refreshStatus()`
-  — which checks `currentState.display` — never tripped. If polling
+  which checks `currentState.display`: never tripped. If polling
   raced the stop API and the status call returned `active=true`
   (because the server hadn't processed stop yet), the widget would
   flip back to "Recording" mid-stop. Also added an `error` callback
@@ -3781,7 +3795,7 @@ Running `bench --site <site> migrate` will:
    upgraded `notes` field (now Text Editor) and the new
    `v5_aggregate_json` Long Text field. Existing `notes` values
    carry over unchanged because plain-text content is valid Text
-   Editor input — no data migration needed, only the metadata
+   Editor input no data migration needed, only the metadata
    changes.
 
 No breaking API changes:
@@ -3817,13 +3831,13 @@ are empty.
 
 To disable the new pyinstrument + infra capture for a specific
 session, uncheck **"Capture Python call tree"** in the start
-dialog as before — the v0.3.0 flag continues to gate the heaviest
+dialog as before the v0.3.0 flag continues to gate the heaviest
 capture paths. Infra capture is unconditional because it costs
 ~0.8ms per action and runs only while the user's session is active.
 
 ---
 
-## [0.4.0] — 2026-04-14
+## [0.4.0] - 2026-04-14
 
 The "Make it usable" release. Sands down the rough edges between
 "customer installs the app" and "customer hands a useful report to
@@ -3832,7 +3846,7 @@ handoff workflow is faster and the report is more actionable.
 
 ### Added
 
-- **Session comparison / baseline pinning** — pin any Ready session as
+- **Session comparison / baseline pinning**: pin any Ready session as
   the baseline for its label. Subsequent recordings with the same label
   auto-render three comparison sections in the safe + raw reports:
   session-level delta, per-action diff, and finding-level diff
@@ -3841,17 +3855,17 @@ handoff workflow is faster and the report is more actionable.
 - **`Pin as baseline` and `Compare with...` buttons** on the Profiler
   Session form view. Pinning is per-session-label and persists in
   Redis under `profiler:baseline:<label>`.
-- **Auto-inheritance of baseline** at recording start — `api.start`
+- **Auto-inheritance of baseline** at recording start `api.start`
   checks the baseline cache for the label and pre-populates
   `compared_to_session` on the new session.
-- **`comparison.py` module** — pure-function action and finding
+- **`comparison.py` module**: pure-function action and finding
   matchers, fixture-testable, no Frappe DB access.
-- **PDF export of the safe report** — lazy-generated on first
+- **PDF export of the safe report**: lazy-generated on first
   download click via `frappe.utils.pdf.get_pdf` (wkhtmltopdf), cached
   to a private File attachment on the Optimus Session. Subsequent
   downloads serve from cache. Generation cost is kept out of the
   analyze pipeline.
-- **`pdf_export.py` module** — `get_or_generate_pdf` and
+- **`pdf_export.py` module**: `get_or_generate_pdf` and
   `clear_cached_pdf` helpers.
 - **PDF download button** on the Optimus Session form (lazy generation
   with progress alert).
@@ -3862,24 +3876,24 @@ handoff workflow is faster and the report is more actionable.
   pointing the user at the floating Profiler pill. Suppressed for
   experienced users (anyone with a Ready Optimus Session row).
   Tracked via `profiler:onboarding_seen:<user>` in Redis.
-- **Version-driven asset cache buster** — `app_include_js` and
+- **Version-driven asset cache buster**: `app_include_js` and
   `app_include_css` now read `?v={__version__}` so every release
   automatically invalidates browser caches.
-- **6 new whitelisted API endpoints** —
+- **6 new whitelisted API endpoints**:
   `check_onboarding_seen`, `mark_onboarding_seen`, `pin_baseline`,
   `unpin_baseline`, `set_comparison`, `download_pdf`.
-- **3 new fields on Optimus Session** — `compared_to_session`
+- **3 new fields on Optimus Session**: `compared_to_session`
   (Link), `is_baseline` (Check), `safe_report_pdf_file` (Attach).
-- **SVG donut fallback for PDF mode** — wkhtmltopdf doesn't handle
+- **SVG donut fallback for PDF mode**: wkhtmltopdf doesn't handle
   `conic-gradient` reliably; the renderer now produces an inline SVG
   pie chart that's hidden in HTML mode (via `@media print` CSS) and
   shown in PDF rendering.
-- **Janitor cascade** — `sweep_old_sessions` clears the baseline
+- **Janitor cascade**: `sweep_old_sessions` clears the baseline
   cache key before deleting a baseline session and cascades the
   v0.4.0 `safe_report_pdf_file` attachment.
 - **`retry_analyze` clears the cached PDF** so the next download
   regenerates from the freshly-analyzed report.
-- **Self-contained safe report regression gate** — new test
+- **Self-contained safe report regression gate**: new test
   `test_safe_report_self_contained.py` asserts the rendered HTML
   contains no external URL fetches. Catches accidental introductions
   of CDN references at CI time.
@@ -3889,7 +3903,7 @@ handoff workflow is faster and the report is more actionable.
 - **No changes to the v0.3.0 capture or analyze pipelines.**
   `capture.py`, `hooks_callbacks.py`, `analyze.py`, and the analyzer
   modules are frozen for this release.
-- **`api.start(label, ...)` accepts the same kwargs as v0.3.0** —
+- **`api.start(label, ...)` accepts the same kwargs as v0.3.0**:
   `capture_python_tree` is unchanged. The new auto-inheritance of
   `compared_to_session` is transparent to callers.
 - **Renderer adds a comparison computation block** when
@@ -3917,7 +3931,7 @@ comparison sections in their safe + raw reports.
 
 ---
 
-## [0.3.0] — 2026-04-13
+## [0.3.0] - 2026-04-13
 
 Adds a Python call tree capture and analysis layer on top of the existing
 SQL-only profiler. Customers reading a safe report now see where their
@@ -3932,25 +3946,25 @@ for the full design spec.
   at 1ms intervals (configurable via
   `site_config.json: optimus_sampler_interval_ms`). Scoped per request
   so non-recording users are unaffected.
-- **Reconciled unified call tree** — each captured SQL call is grafted
+- **Reconciled unified call tree**: each captured SQL call is grafted
   onto the deepest user-code frame in the pyinstrument tree, so the
-  customer sees "your `discounts.calculate` function spent 320ms — 280ms
+  customer sees "your `discounts.calculate` function spent 320ms 280ms
   of that in 14 SQL queries (children below)".
 - **Four new finding types:**
-  - `Slow Hot Path` — a Python subtree consumes >25% of an action AND >200ms.
-  - `Hook Bottleneck` — same shape, but the subtree is a doc-event hook
+  - `Slow Hot Path`: a Python subtree consumes >25% of an action AND >200ms.
+  - `Hook Bottleneck`: same shape, but the subtree is a doc-event hook
     (called via `Document.run_method`); the finding names the hook function.
-  - `Repeated Hot Frame` — the same frame appears in ≥3 actions and
+  - `Repeated Hot Frame`: the same frame appears in ≥3 actions and
     consumes ≥500ms total across the session.
-  - `Redundant Call` — the same `frappe.get_doc(doctype, name)` /
+  - `Redundant Call`: the same `frappe.get_doc(doctype, name)` /
     `frappe.cache.get_value(key)` / `frappe.permissions.has_permission(...)`
     fired N times from the same callsite (thresholds: 5/10/10 by default,
     all configurable).
-- **Session-wide time-attribution donut** in the safe report — at-a-glance
+- **Session-wide time-attribution donut** in the safe report at-a-glance
   "this session was 38% SQL, 22% erpnext, 18% your custom code, …".
-- **Hot frames leaderboard** in the safe report — top 20 hottest function
+- **Hot frames leaderboard** in the safe report top 20 hottest function
   paths across the whole session, sortable.
-- **`api.start(label, capture_python_tree=True)`** — new kwarg lets
+- **`api.start(label, capture_python_tree=True)`**: new kwarg lets
   customers opt out per session (falls back to v0.2.0 SQL-only capture).
   Surfaced in the floating widget's start dialog as a checkbox.
 - **Auto-promote of large per-action call trees** to private File
@@ -3968,31 +3982,31 @@ for the full design spec.
   not data).
 - **`pyinstrument >= 4.6, < 6` dependency** added to `pyproject.toml`.
   Pure-Python, MIT, no compiled extensions.
-- **Streaming `_fetch_recordings`** — converted from list-returning to
+- **Streaming `_fetch_recordings`**: converted from list-returning to
   generator so the analyze pipeline holds bounded memory across large
   sessions.
-- **Per-analyzer wall-clock budget tracker** — analyzers exceeding 60s
+- **Per-analyzer wall-clock budget tracker**: analyzers exceeding 60s
   are flagged; total analyze budgeted at 20 min (5-min headroom under
   RQ long-queue timeout). Past the cap, remaining analyzers are skipped
   with a partial-completion warning.
-- **`api.export_session()` v0.3.0 fields** — JSON output now includes
+- **`api.export_session()` v0.3.0 fields**: JSON output now includes
   `call_tree`, `hot_frames`, `session_time_breakdown`, `total_python_ms`,
   `total_sql_ms`.
 - **New site config keys:**
-  - `optimus_sampler_interval_ms` — pyinstrument sample interval (default 1).
-  - `optimus_tree_prune_threshold_pct` — drop frames below N% of action time (default 0.005).
-  - `optimus_tree_node_cap` — max nodes per persisted tree (default 500, hot path always preserved).
+  - `optimus_sampler_interval_ms`: pyinstrument sample interval (default 1).
+  - `optimus_tree_prune_threshold_pct`: drop frames below N% of action time (default 0.005).
+  - `optimus_tree_node_cap`: max nodes per persisted tree (default 500, hot path always preserved).
   - `optimus_redundant_doc_threshold` (default 5).
   - `optimus_redundant_cache_threshold` (default 10).
   - `optimus_redundant_perm_threshold` (default 10).
   - `optimus_redundant_high_multiplier` (default 5).
-  - `optimus_safe_extra_allowed_apps` — extra app prefixes whose function names are kept un-redacted in safe mode.
+  - `optimus_safe_extra_allowed_apps`: extra app prefixes whose function names are kept un-redacted in safe mode.
 
 ### Changed
 
 - **Per-flow recording overhead** climbs from "10–30% per query" to
   roughly "1.5–2× wall clock during recording" when `capture_python_tree=True`.
-  Non-recording users on the same site are still unaffected — the
+  Non-recording users on the same site are still unaffected the
   activation gate is per-user, and the wraps' hot-path check is a single
   attribute lookup with **<100ns overhead** measured against an unwrapped
   baseline.
@@ -4001,7 +4015,7 @@ for the full design spec.
 - **Renderer adds donut + hot frames sections** to both safe and raw
   reports. Old v0.2.0 sessions render with the old layout (no v0.3.0
   fields → sections skipped).
-- **R2 redaction policy** — function names in safe-mode reports collapse
+- **R2 redaction policy**: function names in safe-mode reports collapse
   custom-app frames to `<app>:<top-level-module>` (e.g.
   `my_acme_app.discounts.pricing.calc_secret` → `my_acme_app:discounts`).
   Frappe / ERPNext / payments / hrms keep full names.
@@ -4015,7 +4029,7 @@ for the full design spec.
   `capture.install_wraps` except handler crashed when test code stubs
   `frappe` with a minimal fake module that lacks `log_error`. Now
   bulletproofed with a nested try/except.
-- **Best-effort sidecar entry build** — a failure inside `_identify_args`
+- **Best-effort sidecar entry build**: a failure inside `_identify_args`
   (e.g. an arg with a broken `__str__`) used to propagate out and break
   the user's `frappe.get_doc` call. Now caught locally; the wrap skips
   the entry but always calls `orig`.
@@ -4032,7 +4046,7 @@ Running `bench --site <site> migrate` will:
 3. Add 4 new fields to `tabOptimus Session`: `total_python_ms`,
    `total_sql_ms`, `hot_frames_json`, `session_time_breakdown_json`.
 
-No breaking API changes — `start`, `stop`, `status`, `get_active_session`,
+No breaking API changes `start`, `stop`, `status`, `get_active_session`,
 `health`, `export_session`, `retry_analyze` all keep their existing
 signatures (`start` accepts a new optional kwarg with backward-compatible
 default).
@@ -4047,7 +4061,7 @@ To opt out of the new pyinstrument capture per-session, uncheck
 
 ---
 
-## [0.2.0] — 2026-04-09
+## [0.2.0] - 2026-04-09
 
 Round 2 improvements. 28 items across correctness, operations, UX,
 extensibility, and housekeeping. See
@@ -4055,125 +4069,125 @@ extensibility, and housekeeping. See
 
 ### Added
 
-- **JSON export endpoint** — `optimus.api.export_session(uuid)`
+- **JSON export endpoint**: `optimus.api.export_session(uuid)`
   returns a structured blob (session + actions + findings + top queries +
   table breakdown) for programmatic consumption by dev-shop tools.
-- **Health / metrics endpoint** — `optimus.api.health()` returns
+- **Health / metrics endpoint**: `optimus.api.health()` returns
   counts by status and analyze-pipeline performance over the last 24 hours.
   Intended for Prometheus/Grafana/Datadog scrapers.
-- **Custom analyzer hook** — third-party Frappe apps can contribute
+- **Custom analyzer hook**: third-party Frappe apps can contribute
   analyzers via `hooks.py: optimus_analyzers = ["my_app.analyzers.custom.analyze"]`.
   Hooks run after the builtins and share the same `AnalyzeContext`.
-- **Cross-session EXPLAIN cache** — EXPLAIN results are now cached in
+- **Cross-session EXPLAIN cache**: EXPLAIN results are now cached in
   Redis with a 1-hour TTL (configurable via
   `site_config.json: optimus_explain_cache_ttl_seconds`). Two consecutive
   analyze runs on a stable schema skip the DB roundtrip entirely.
-- **Notes field on Optimus Session** — customers can annotate sessions
+- **Notes field on Optimus Session**: customers can annotate sessions
   with reproduction steps, ticket refs, context. Editable even on Ready
   sessions. Rendered in the HTML report header.
-- **Progress updates during analyze** — the analyze pipeline emits
+- **Progress updates during analyze**: the analyze pipeline emits
   `frappe.publish_realtime("optimus_progress", ...)` events at each
   phase (5% fetching, 20% EXPLAIN, 50% analyzers, 80% persist, 90%
   render, 100% done). The floating widget subscribes and displays a live
   percentage instead of a bare "Analyzing…".
-- **Retention-policy cleanup** — daily janitor deletes Ready/Failed
+- **Retention-policy cleanup**: daily janitor deletes Ready/Failed
   sessions older than 90 days (configurable via
   `site_config.json: optimus_session_retention_days`).
-- **Orphan Redis cleanup** — the daily janitor also sweeps
+- **Orphan Redis cleanup**: the daily janitor also sweeps
   `profiler:session:*` Redis keys whose parent Optimus Session row no
   longer exists (e.g. failed analyzes that never retried).
-- **Sensitive-field redactor** — raw report now redacts known-sensitive
+- **Sensitive-field redactor**: raw report now redacts known-sensitive
   fields from headers and form_dict before rendering. Redacts: password,
   secret, token, api_key, authorization, cookie, csrf, otp, card_number,
   cvv, ssn, aadhar, pan_number, and similar. Defense-in-depth against
   download-and-share leaks.
-- **Session TTL refresh on activity** — long flows (45+ minutes) no
+- **Session TTL refresh on activity**: long flows (45+ minutes) no
   longer silently stop at the 10-minute TTL. Every
   `register_recording` call refreshes the user's active-session key so
   an actively-used session stays alive as long as there's traffic.
-- **Server timezone in report header** — the report now labels times
+- **Server timezone in report header**: the report now labels times
   with an explicit server timezone so distributed teams don't get
   confused about UTC vs. local.
-- **Retry Analyze button** — Failed sessions now have a "Retry Analyze"
+- **Retry Analyze button**: Failed sessions now have a "Retry Analyze"
   custom button in the form view that re-enqueues the analyze job. New
   `optimus.api.retry_analyze(session_uuid)` whitelisted endpoint.
-- **Fixture builder helpers** — `optimus.tests.fixture_builders`
+- **Fixture builder helpers**: `optimus.tests.fixture_builders`
   provides `build_call`, `build_recording`, `build_explain_row` to
   reduce boilerplate in analyzer tests.
 
 ### Fixed
 
-- **N+1 attribution blamed frappe framework code** — `_callsite()` now
+- **N+1 attribution blamed frappe framework code**: `_callsite()` now
   walks the stack skipping `frappe/` and `optimus/` prefixes so
   N+1 findings point at customer business logic (e.g.
   `erpnext/accounts/sales_invoice.py:212`) instead of framework helpers
   (`frappe/database/database.py:742`). Single most impactful fix in
   the round-1 review.
 - **`explain_flags` documented a `filtered < 10` check that wasn't
-  implemented** — the new check fires on queries where MariaDB's
+  implemented**: the new check fires on queries where MariaDB's
   `filtered` column < 10 AND rows_examined > 100, emitting a new
   `Low Filter Ratio` finding type.
-- **`before_request`/`before_job` could clobber an existing recorder** —
+- **`before_request`/`before_job` could clobber an existing recorder**:
   if the standalone Recorder UI is active globally, frappe's own hook
   creates a Recorder first; our hook now checks
   `frappe.local._recorder` and piggybacks instead of overwriting it.
-- **`api.start()` had no role check** — any authenticated user could
+- **`api.start()` had no role check**: any authenticated user could
   POST to the endpoint and start a session on themselves. Now requires
   `Optimus User` or `System Manager` role (enforced at the HTTP level,
   not just the UI).
-- **N+1 threshold of 5 was too low** — raised default to 10 with a
+- **N+1 threshold of 5 was too low**: raised default to 10 with a
   `optimus_n_plus_one_threshold` site config override. Also requires
   minimum total time (default 20ms) so 10×0.1ms queries no longer
   trigger false positives.
-- **`_enrich_recordings` had no EXPLAIN cap** — now caps at 2000
+- **`_enrich_recordings` had no EXPLAIN cap**: now caps at 2000
   queries per recording and dedupes EXPLAIN by query shape. Prevents
   the analyze job from running millions of EXPLAINs on pathological
   sessions.
-- **DB indexes missing on `status` and `started_at`** — the janitor
+- **DB indexes missing on `status` and `started_at`**: the janitor
   query was a table scan at scale. Added `search_index: 1` on both.
-- **`index_suggestions` silently swallowed errors** — now logs the
+- **`index_suggestions` silently swallowed errors**: now logs the
   first 3 per-query failures and surfaces a `"Could not analyze X queries"`
   warning in the report.
-- **Multi-line SQL rendered as single line in top-N table** — switched
+- **Multi-line SQL rendered as single line in top-N table**: switched
   from `<code>` to `<pre class="sql-inline">` with bounded height.
 - **`before_job` left `_profiler_session_id` in kwargs on malformed
-  kwargs** — defensive type check + error log.
-- **Widget polled forever in hidden tabs** — now pauses polling on
+  kwargs**: defensive type check + error log.
+- **Widget polled forever in hidden tabs**: now pauses polling on
   `visibilitychange` and resumes when the tab becomes visible again.
-- **Cap warning not surfaced in UI** — `analyzer_warnings` now renders
+- **Cap warning not surfaced in UI**: `analyzer_warnings` now renders
   as an orange `frm.set_intro` banner at the top of the form.
-- **"Top contributor" summary missed session-wide findings** — the
+- **"Top contributor" summary missed session-wide findings**: the
   two-step fallback now picks the highest-impact finding overall when
   there's no action-specific match.
-- **Session list view had no severity indicator** — new `top_severity`
+- **Session list view had no severity indicator**: new `top_severity`
   field populated by analyze, color-coded in the list view via a custom
   `listview_settings.get_indicator`.
-- **`track_changes=1` on Optimus Session caused storage bloat** —
+- **`track_changes=1` on Optimus Session caused storage bloat**:
   every analyze created 10+ tabVersion rows. Disabled track_changes;
   patch `v0_2_0.remove_version_tracking` cleans up existing rows on
   `bench migrate`.
-- **Potential recursive analyze** — `analyze.run()` now sets
+- **Potential recursive analyze**: `analyze.run()` now sets
   `frappe.local.optimus_analyzing = True` so hooks skip activation on
   the analyze pipeline's own DocType writes.
 - **`_optimize_query` errors could leak query literals in the error
-  log** — added a paranoia scrub (`'foo'` → `'?'`, long numbers → `?`)
+  log**: added a paranoia scrub (`'foo'` → `'?'`, long numbers → `?`)
   before logging.
-- **Uninstall didn't clean Redis state** — `before_uninstall` now
+- **Uninstall didn't clean Redis state**: `before_uninstall` now
   SCAN+DELETEs all `profiler:*` keys for the site.
 
 ### Changed
 
-- **Analyzer unit tests** — 50+ new tests covering per_action, top_queries,
+- **Analyzer unit tests**: 50+ new tests covering per_action, top_queries,
   n_plus_one (with callsite attribution assertions), explain_flags (all
   4 red flags including the new filtered check), index_suggestions (with
   `monkeypatch` for `_optimize_query`), table_breakdown, the enqueue
   patch (idempotency + session id injection), and frontend asset smoke
   tests (JS syntax + content assertions). All 67 tests pass in < 1s.
-- **Shared `SEVERITY_ORDER` and `walk_callsite`** — moved from
+- **Shared `SEVERITY_ORDER` and `walk_callsite`**: moved from
   per-module copies to `analyzers/base.py`.
-- **Refactored `_stop_session`** — split into `_clear_active`,
+- **Refactored `_stop_session`**: split into `_clear_active`,
   `_mark_stopping`, `_enqueue_analyze` for clarity.
-- **README overhauled** — operational caveats, hard-cap table, config
+- **README overhauled**: operational caveats, hard-cap table, config
   knobs, verification checklist.
 - **Version bumped** from 0.0.1 to 0.2.0.
 
@@ -4191,12 +4205,12 @@ Running `bench --site <site> migrate` will:
 4. Add the new `Low Filter Ratio` value to the `Optimus Finding.finding_type`
    select.
 
-No breaking API changes — existing calls to `start`, `stop`, `status`,
+No breaking API changes existing calls to `start`, `stop`, `status`,
 `get_active_session`, `retry_analyze` are unchanged.
 
 ---
 
-## [0.1.0] — 2026-04-08
+## [0.1.0] - 2026-04-08
 
 Initial feature-complete v1. All 8 phases from the design doc plus 21
 fixes from the first-review pass. See `ARCHITECTURE.md` for the design
@@ -4227,6 +4241,6 @@ rationale.
 
 ---
 
-## [0.0.1] — 2026-04-08
+## [0.0.1] - 2026-04-08
 
-Initial scaffold. Empty app with no logic — just the DocType structure.
+Initial scaffold. Empty app with no logic just the DocType structure.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,7 +39,7 @@ needed for your bench setup.
 
 The unit suite above runs in seconds against a Frappe stub. The
 integration suite at `optimus/tests_integration/` runs against a real
-bench — real MariaDB, real Redis, real RQ — and catches regressions in
+bench real MariaDB, real Redis, real RQ and catches regressions in
 the inter-component handoff the unit stubs can't reach.
 
 In CI: `.github/workflows/integration.yml` provisions a fresh Frappe
@@ -60,7 +60,7 @@ bench --site <your-site> run-tests --app optimus \
 
 Adding a new integration test: read `optimus/tests_integration/README.md`
 for the harness pattern, the deferred-test extraction roadmap, and the
-"no flakiness" rule. Integration tests must justify the bench cost —
+"no flakiness" rule. Integration tests must justify the bench cost
 prefer a unit test when feasible.
 
 ## Pre-commit

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 **A flow-aware performance profiler for Frappe and ERPNext.** Records a real business workflow (Sales Invoice save → submit → Delivery Note → submit → …), joins it with server resource state and browser-side timings, and produces two downloadable HTML reports you can actually act on: a **Safe Report** to share with a third-party dev shop without leaking customer data, and a **Raw Report** for internal debugging with full stack traces and SQL literals.
 
-> **Status:** `v0.12.26` — production-ready. MIT-licensed. 1820 unit tests + 39 integration tests in CI on every pull request and on merge to `main` (ruff + pytest on Python 3.14; bench-driven integration suite on Frappe v16). See the [CHANGELOG](./CHANGELOG.md) for the full feature history, including the v0.7.0 rename from `frappe_profiler` → `optimus`.
+> **Status:** `v0.12.26`: production-ready. MIT-licensed. 1820 unit tests + 39 integration tests in CI on every pull request and on merge to `main` (ruff + pytest on Python 3.14; bench-driven integration suite on Frappe v16). See the [CHANGELOG](./CHANGELOG.md) for the full feature history, including the v0.7.0 rename from `frappe_profiler` → `optimus`.
 
 ---
 
@@ -13,18 +13,18 @@
 - [Install](#install)
 - [60-second quickstart](#60-second-quickstart)
 - [Using Optimus](#using-optimus)
-- [The customer → partner handoff](#the-customer--partner-handoff)
+- [The customer → partner handoff](#the-customer-partner-handoff)
 - [Finding types](#finding-types)
 - [How it works](#how-it-works)
 - [Dependencies](#dependencies)
 - [Comparison with alternatives](#comparison-with-alternatives)
 - [Production safety](#production-safety)
 - [Scheduler-disabled sites](#scheduler-disabled-sites)
-- [Configuration — Optimus Settings (DocType)](#configuration--optimus-settings-doctype)
+- [Configuration: Optimus Settings (DocType)](#configuration-optimus-settings-doctype)
   - [General tab](#general-tab)
   - [Analysis tab](#analysis-tab)
   - [AI Fix Suggestions tab](#ai-fix-suggestions-tab)
-- [Configuration — site_config.json (operator knobs)](#configuration--site_configjson-operator-knobs)
+- [Configuration: site_config.json (operator knobs)](#configuration-site_configjson-operator-knobs)
 - [Runtime flags](#runtime-flags)
 - [Custom analyzers](#custom-analyzers)
 - [Verification checklist](#verification-checklist)
@@ -38,7 +38,7 @@
 ## What it is
 
 - **On-demand profiler for specific slow flows.** You press Start, run your slow flow, press Stop, and get a report. No always-on overhead. No data egress. No external service.
-- **Flow-aware.** Automatically captures the entire chain of HTTP requests **and** background jobs triggered by one business operation — e.g. a single Sales Invoice `submit` that enqueues GL posting, stock updates, and GST calculation shows up as one session, not four disconnected transactions. The only profiler that does this for Frappe.
+- **Flow-aware.** Automatically captures the entire chain of HTTP requests **and** background jobs triggered by one business operation e.g. a single Sales Invoice `submit` that enqueues GL posting, stock updates, and GST calculation shows up as one session, not four disconnected transactions. The only profiler that does this for Frappe.
 - **Customer-safe report.** Safe mode replaces SQL literals with `?`, strips docnames and filters from URLs, redacts headers and form data, and bleach-sanitizes any user-typed notes. Shareable with a third-party dev shop over email without leaking PII.
 - **ERPNext-native findings.** N+1 detection blames `erpnext/accounts/gl_entry.py:211` instead of `frappe/database/database.py:sql`. Findings know about Document hooks, permission queries, naming series, and child table patterns.
 - **Server + browser + infra in one report.** v0.5.0 adds per-action CPU/RSS/DB pool/RQ queue snapshots and per-XHR timings with Web Vitals, joined to the matching recording by correlation header. You can tell *code-slow* from *server-slow*, and *backend-slow* from *network-slow*.
@@ -47,7 +47,7 @@
 
 - **Not always-on monitoring.** If you need *"alert me when production p95 regresses,"* use New Relic / Datadog / Sentry. We're opt-in and session-scoped by design.
 - **Not distributed tracing.** We only see Frappe. A microservices architecture spanning Python + Go + Node needs OpenTelemetry.
-- **Not a replacement for `frappe.recorder`.** We *extend* it — we reuse its SQL capture and stack walker unchanged, and add session tracking, multi-request joining, resource/frontend capture, and the analyze pipeline on top.
+- **Not a replacement for `frappe.recorder`.** We *extend* it we reuse its SQL capture and stack walker unchanged, and add session tracking, multi-request joining, resource/frontend capture, and the analyze pipeline on top.
 
 ---
 
@@ -60,11 +60,11 @@ bench --site <your-site> install-app optimus
 bench restart
 ```
 
-Tested on **Frappe v16** with MariaDB and Redis. The app declares `required_apps = ["frappe"]`. Runtime dependencies (installed automatically by `bench get-app`) are listed in [`pyproject.toml`](./pyproject.toml) — currently `pyinstrument`, `line_profiler`, `requests`, `sqlparse`, and `Jinja2`, all pure-Python with no compiled extensions (`line_profiler` ships a small C extension; pre-built wheels exist for cpython 3.10–3.14).
+Tested on **Frappe v16** with MariaDB and Redis. The app declares `required_apps = ["frappe"]`. Runtime dependencies (installed automatically by `bench get-app`) are listed in [`pyproject.toml`](./pyproject.toml) currently `pyinstrument`, `line_profiler`, `requests`, `sqlparse`, and `Jinja2`, all pure-Python with no compiled extensions (`line_profiler` ships a small C extension; pre-built wheels exist for cpython 3.10–3.14).
 
 After install, an **Optimus User** role is created automatically. All existing System Managers are granted this role, and new System Managers get it automatically via a `User.validate` hook.
 
-> **After every upgrade:** run `bench restart` so the new sign / verify code loads. Sessions captured **before** the restart have null call trees on their actions — their Phase-2 picker dialog opens with a yellow "No curated functions available" callout pointing this out. Capture a fresh session after the restart for a working picker.
+> **After every upgrade:** run `bench restart` so the new sign / verify code loads. Sessions captured **before** the restart have null call trees on their actions their Phase-2 picker dialog opens with a yellow "No curated functions available" callout pointing this out. Capture a fresh session after the restart for a working picker.
 
 ---
 
@@ -73,7 +73,7 @@ After install, an **Optimus User** role is created automatically. All existing S
 1. Open Desk. A bright red **Optimus** pill appears in the bottom-right corner.
 2. Click it. A dialog asks for a label, an optional "Steps to Reproduce" note, and a `Capture Python call tree` toggle (leave on).
 3. Click **Start**. The pill turns green and shows an elapsed timer.
-4. Run your flow — save a Sales Invoice, submit it, wait for background jobs, whatever you want profiled.
+4. Run your flow save a Sales Invoice, submit it, wait for background jobs, whatever you want profiled.
 5. Click the pill again to **Stop**. The pill turns orange ("Analyzing…") while the analyze pipeline runs (typically 2–15 seconds).
 6. Click the pill once more (now blue, "Report ready") to jump to the session form.
 7. Click **Download Safe Report** or **Download Safe Report (PDF)**. Email it to whoever needs it.
@@ -103,13 +103,13 @@ Managers receive it automatically; you can grant it to other users via
 
 The Start dialog lets you set:
 
-- **Label** — what shows up in the session list. Pick something
+- **Label**: what shows up in the session list. Pick something
   searchable (`SI submit, 100 items` beats `test`).
-- **Steps to Reproduce / Notes** — a rich-text block. Rendered at the
+- **Steps to Reproduce / Notes**: a rich-text block. Rendered at the
   top of both reports. Use it to give context to whoever reads the
   report ("Customer says save takes 8s; happens on every SI ≥ 50
   items").
-- **Capture Python call tree** — leave on for actionable findings.
+- **Capture Python call tree**: leave on for actionable findings.
   Turning it off gives you the v0.2.0 SQL-only behavior (~10–30%
   overhead instead of 1.5–2×), useful only when you specifically
   want to verify a SQL-level hypothesis without Python overhead.
@@ -119,31 +119,31 @@ The Start dialog lets you set:
 Every session lands as an **Optimus Session** row. The form has three
 read-only sections:
 
-1. **Status + timing** — Recording / Analyzing / Ready / Failed; start
+1. **Status + timing**: Recording / Analyzing / Ready / Failed; start
    time; analyze wall-clock duration; counts of actions and findings.
-2. **Reports** — two file links plus action buttons:
-   - **Download Safe Report** / **Open Safe Report** — the customer-
+2. **Reports**: two file links plus action buttons:
+   - **Download Safe Report** / **Open Safe Report**: the customer-
      safe HTML. Email-shareable.
-   - **Download Raw Report** / **Open Raw Report** — the un-redacted
+   - **Download Raw Report** / **Open Raw Report**: the un-redacted
      version. Hidden from non-admins; the link itself is permission-
      gated server-side, so guessing the file name does not bypass it.
-   - **Re-analyze** — re-runs the analyze pipeline from the captured
+   - **Re-analyze**: re-runs the analyze pipeline from the captured
      recordings (which live in Redis for 10 minutes after Stop).
      Useful when a session ends `Failed` because of a transient
-     error. After 10 minutes the recordings are gone — re-analyze
+     error. After 10 minutes the recordings are gone re-analyze
      can still re-render reports from the persisted DocType data,
      but cannot recompute findings.
-   - **Regenerate Reports** — re-renders both HTML files from the
+   - **Regenerate Reports**: re-renders both HTML files from the
      persisted Action/Finding rows. Cheaper than a full re-analyze;
      useful after an Optimus upgrade that improves the renderer.
-   - **Phase 2 → Line Profile** — opens the picker dialog (see
+   - **Phase 2 → Line Profile**: opens the picker dialog (see
      below).
-   - **Pin as Baseline** / **Unpin Baseline** — see _Baseline
+   - **Pin as Baseline** / **Unpin Baseline**: see _Baseline
      comparison_ below.
-3. **Captured actions + findings** — child tables you can drill into
+3. **Captured actions + findings**: child tables you can drill into
    without opening the report.
 
-### Report modes — Safe vs Raw
+### Report modes: Safe vs Raw
 
 | Aspect | Safe Report | Raw Report |
 |---|---|---|
@@ -151,16 +151,16 @@ read-only sections:
 | SQL literals | Replaced with `?` | Preserved verbatim |
 | URLs | `/app/sales-invoice/SI-2026-00123/edit` becomes `/app/sales-invoice/<name>/edit`; filters / source_name redacted | Preserved verbatim |
 | Headers + form data | `Authorization`, `Cookie`, CSRF, anything matching `password\|secret\|token\|api[-_]?key\|...` → `[REDACTED]` | Preserved verbatim |
-| User notes | bleach-sanitized HTML (strips `<script>`, `onclick`, `javascript:` URLs) | Same — bleach runs in both modes for XSS safety |
+| User notes | bleach-sanitized HTML (strips `<script>`, `onclick`, `javascript:` URLs) | Same bleach runs in both modes for XSS safety |
 | Custom-app function names | Hashed to `<app>:<short>` | Preserved verbatim |
 | Permission gate | None (anyone with the URL can open) | System Manager or the user who recorded the session |
-| Self-contained | Yes — no CDN fonts, no external scripts, no `@import` (canary test in CI) | Yes |
+| Self-contained | Yes no CDN fonts, no external scripts, no `@import` (canary test in CI) | Yes |
 
 Both reports render from the same `templates/report.html` and the same
-persisted data — Safe mode is a renderer-time redaction pass, not a
+persisted data Safe mode is a renderer-time redaction pass, not a
 separate capture.
 
-### Phase 2 — Line profiling
+### Phase 2: Line profiling
 
 The default capture (Phase 1) tells you _which functions_ are hot. Phase
 2 tells you _which lines inside those functions_ are hot. Use it when
@@ -175,7 +175,7 @@ Workflow:
 3. **Auto-expand hot chain** (ticked by default) walks each pick down
    the call tree to instrument the full chain, not just the entry
    frame.
-4. Click **Start Phase 2** — the widget switches back to recording mode.
+4. Click **Start Phase 2**: the widget switches back to recording mode.
 5. Re-execute the same flow you profiled in Phase 1.
 6. Click Stop. Phase 2 analyze runs; the report adds a **Line-Level
    Drilldown** section with per-line hit-count and time.
@@ -190,22 +190,22 @@ hot-loop pick from freezing the UI.
 
 Optimus can call an LLM (Anthropic, OpenAI, Kimi, or any OpenAI-
 compatible endpoint including local ones like Ollama or LM Studio) to
-suggest concrete fixes for each finding. Off by default — no traffic
+suggest concrete fixes for each finding. Off by default no traffic
 leaves your bench until you enable it.
 
 Three feature toggles, all under **Optimus Settings → AI Fix
 Suggestions → Use the LLM for**:
 
-- **Fix suggestions on findings** — adds a "Suggest a fix (AI)" button
+- **Fix suggestions on findings**: adds a "Suggest a fix (AI)" button
   per finding and an auto-suggest pass during analyze (when the
   auto-suggest checkbox below is on).
-- **Index recommendations** — adds a "Suggest an index (AI)" button to
+- **Index recommendations**: adds a "Suggest an index (AI)" button to
   the per-table breakdown.
-- **Humanized "Steps to Reproduce"** — rewrites the auto-captured
+- **Humanized "Steps to Reproduce"**: rewrites the auto-captured
   action list into a friendly flow ("Open Sales Invoice list, click
   New, …").
 
-Turning any one of these off is a hard disable — the button is hidden,
+Turning any one of these off is a hard disable the button is hidden,
 the API refuses, and re-rendered reports omit the AI block. See
 [`docs/AI-FIXING.md`](./docs/AI-FIXING.md) for the per-pathway data
 inventory and local-LLM recipes.
@@ -217,15 +217,15 @@ baseline comparison gives you a side-by-side report:
 
 1. On a Ready "before" session, click **Pin as Baseline**.
 2. Capture a "after" session of the same flow (same label is
-   convenient but not required — the comparison matches actions by
+   convenient but not required the comparison matches actions by
    label, falling back to path).
 3. Open the after-session's Safe or Raw report. Three new sections
    appear at the top:
-   - **Session-level delta** — total wall time, query count, SQL/Python
+   - **Session-level delta**: total wall time, query count, SQL/Python
      ms, with old → new.
-   - **Per-action comparison** — matched actions with before/after
+   - **Per-action comparison**: matched actions with before/after
      stats.
-   - **Findings compared to baseline** — Fixed / New / Unchanged with
+   - **Findings compared to baseline**: Fixed / New / Unchanged with
      delta.
 4. The customer signs off on concrete numbers, not "it feels faster".
 
@@ -237,7 +237,7 @@ To swap the baseline, unpin the old one and pin the new one.
 
 This is the primary use case and the feature set is built around it.
 
-**Traditional workflow** — how 90% of ERPNext performance debugging happens today:
+**Traditional workflow**: how 90% of ERPNext performance debugging happens today:
 
 > Customer: *"Saving a Sales Invoice is slow."*
 > Partner: *"Can you check the slow query log?"*
@@ -255,14 +255,14 @@ This is the primary use case and the feature set is built around it.
    - URLs: `/app/sales-invoice/SI-2026-00123/edit` → `/app/sales-invoice/<name>/edit`; `?filters=[...]`, `?source_name=X` → `?filters=?, ?source_name=?`
    - User-typed notes → bleach-sanitized HTML (strips `<script>`, `onclick`, `javascript:` URLs)
    - Python function names from custom apps → `my_acme_app:discounts` (app-level, not module-level)
-   - SQL identifiers (table/column/function names) are NOT redacted — they're code, not customer data
+   - SQL identifiers (table/column/function names) are NOT redacted they're code, not customer data
 3. **Customer emails the .html or .pdf** to the partner. No VPN, no SSH, no shared credentials.
-4. **Partner opens the file on their laptop offline.** The report is fully self-contained — no CDN fonts, no external scripts, no `@import`. Tested in CI via `test_safe_report_self_contained.py`.
+4. **Partner opens the file on their laptop offline.** The report is fully self-contained no CDN fonts, no external scripts, no `@import`. Tested in CI via `test_safe_report_self_contained.py`.
 5. **Partner diagnoses and fixes.** Every finding has a plain-language `customer_description`, a technical detail with callsite + query + suggested DDL, and an estimated impact in ms.
 6. **Partner re-records** the fixed flow and pins the original slow session as a baseline. The new report auto-renders three comparison sections:
-   - **Session-level delta** — total wall time, query count, SQL/Python ms (old vs new)
-   - **Per-action comparison** — matched actions (by label, fallback to path) with before/after stats
-   - **Findings compared to baseline** — which findings were **Fixed**, which are **New** regressions, which are **Unchanged** with delta
+   - **Session-level delta**: total wall time, query count, SQL/Python ms (old vs new)
+   - **Per-action comparison**: matched actions (by label, fallback to path) with before/after stats
+   - **Findings compared to baseline**: which findings were **Fixed**, which are **New** regressions, which are **Unchanged** with delta
 7. **Customer signs off** with concrete numbers instead of "it feels faster."
 
 ---
@@ -271,7 +271,7 @@ This is the primary use case and the feature set is built around it.
 
 v0.5.1 emits 18 finding types across 10 analyzers. Every finding has a severity (High/Medium/Low) and an estimated impact in ms.
 
-### Database / SQL (6 types — from v0.2.0)
+### Database / SQL (6 types: from v0.2.0)
 
 | Type | Trigger | Actionable detail |
 |---|---|---|
@@ -283,7 +283,7 @@ v0.5.1 emits 18 finding types across 10 analyzers. Every finding has a severity 
 | **Low Filter Ratio** | `EXPLAIN.filtered < 10%` AND `rows > 100` | Query + *"WHERE clause selectivity is low"* |
 | **Missing Index** | `DBOptimizer` suggests an index AND the column exists AND is not already indexed AND is btree-compatible (v0.5.1 verifies against `information_schema` before emitting) | Table, column, verified DDL (with prefix length for TEXT/BLOB), example queries |
 
-### Python call tree (4 types — v0.3.0)
+### Python call tree (4 types: v0.3.0)
 
 | Type | Trigger | Actionable detail |
 |---|---|---|
@@ -292,7 +292,7 @@ v0.5.1 emits 18 finding types across 10 analyzers. Every finding has a severity 
 | **Repeated Hot Frame** | The same `file::function` appears in ≥3 actions and consumes ≥500 ms across the session | User-actionable: optimizing this function helps every flow that touches it. v0.5.1 filter skips plumbing (werkzeug, frappe.handler, frappe.utils) but keeps `Document.run_method`, `has_permission`, `make_autoname`, etc. |
 | **Redundant Call** | The same `frappe.get_doc(doctype, name)` / `frappe.cache.get_value(key)` / `has_permission(...)` fired N times from the same callsite (thresholds 5/10/10, configurable) | Callsite + arg hash + *"cache or hoist this call"* |
 
-### Infrastructure (4 types — v0.5.0)
+### Infrastructure (4 types: v0.5.0)
 
 | Type | Trigger | Actionable detail |
 |---|---|---|
@@ -301,7 +301,7 @@ v0.5.1 emits 18 finding types across 10 analyzers. Every finding has a severity 
 | **DB Pool Saturation** | `threads_connected / max_connections > 0.9` across ≥2 actions (v0.5.1 uses the correct ratio after an earlier version used the wrong one) | *"raise `max_connections` or reduce gunicorn workers to match"* |
 | **Background Queue Backlog** | Any RQ queue (`default`/`short`/`long`) peaked > 50 during the session | *"your worker count is too low for the load; check if your flow enqueues work"* |
 
-### Frontend (3 types — v0.5.0)
+### Frontend (3 types: v0.5.0)
 
 | Type | Trigger | Actionable detail |
 |---|---|---|
@@ -318,7 +318,7 @@ Five sentences:
 1. **Don't fork the recorder.** We reuse `frappe.recorder.Recorder`, `record(force=True)`, and `dump()` for SQL capture. Our app adds session tracking, per-user activation, background-job inheritance, resource/frontend capture, and the analyze pipeline on top.
 2. **Per-user activation via hook ordering.** Frappe's `before_request` runs `frappe.recorder.record()` first (no-op without a global flag); our `before_request` runs second and calls `record(force=True)` only if the current user has an active session in our Redis pointer.
 3. **Background-job session inheritance via a `frappe.enqueue` patch.** We wrap the canonical `enqueue` to inject `_profiler_session_id` into job kwargs whenever the calling user has an active session; the worker's `before_job` hook pops the marker (so the user's method never sees it) and activates recording for the job.
-4. **Frontend capture wraps WHATWG primitives, not Frappe APIs.** `optimus_frontend.js` hooks `window.fetch` and `XMLHttpRequest.prototype.open/send` directly — the same approach every production APM library uses. Survives future Frappe upgrades because `fetch` and `XHR` are stable web platform standards, while jQuery `ajaxComplete` hooks would break when Frappe drops jQuery.
+4. **Frontend capture wraps WHATWG primitives, not Frappe APIs.** `optimus_frontend.js` hooks `window.fetch` and `XMLHttpRequest.prototype.open/send` directly the same approach every production APM library uses. Survives future Frappe upgrades because `fetch` and `XHR` are stable web platform standards, while jQuery `ajaxComplete` hooks would break when Frappe drops jQuery.
 5. **Ten analyzers, all pure functions.** Per-action breakdown, top-N slow queries, N+1 (by callsite), EXPLAIN flags, index suggestions (verified against schema), per-table breakdown, Python call tree (v0.3.0), redundant calls (v0.3.0), infra pressure (v0.5.0), frontend timings (v0.5.0). Each is independently testable from JSON fixtures with no Frappe DB access.
 
 For the full architecture (data-flow diagrams, hook order, edge cases, extension points), read the inline docstrings in [`optimus/analyze.py`](./optimus/analyze.py) and [`optimus/renderer.py`](./optimus/renderer.py).
@@ -333,7 +333,7 @@ Deliberately minimal. **Only one non-Frappe dependency is declared** in `pyproje
 
 | Package | Version | What it powers |
 |---|---|---|
-| **[`pyinstrument`](https://pypi.org/project/pyinstrument/)** | `>=4.6,<6` | Statistical Python call-tree sampler. Produces the per-recording call tree that drives the **Hot Frames** leaderboard, **Slow Hot Path** findings, **Hook Bottleneck** detection, the **Time Breakdown** donut, and the self-referential hot-path phrasing. Without this, the profiler would only see SQL — no Python context. |
+| **[`pyinstrument`](https://pypi.org/project/pyinstrument/)** | `>=4.6,<6` | Statistical Python call-tree sampler. Produces the per-recording call tree that drives the **Hot Frames** leaderboard, **Slow Hot Path** findings, **Hook Bottleneck** detection, the **Time Breakdown** donut, and the self-referential hot-path phrasing. Without this, the profiler would only see SQL no Python context. |
 
 ### Inherited from Frappe (no extra install)
 
@@ -341,11 +341,11 @@ Deliberately minimal. **Only one non-Frappe dependency is declared** in `pyproje
 |---|---|
 | **`frappe.recorder`** | Frappe's built-in SQL recorder. Captures every query + Python stack during a request. We reuse it unchanged for SQL capture; session tracking and analyze pipeline live on top. |
 | **[`sqlparse`](https://pypi.org/project/sqlparse/)** | SQL tokenizer / pretty-printer. Formats queries in the Raw report and normalizes whitespace for the **Top Queries** leaderboard. |
-| **[`sql_metadata`](https://pypi.org/project/sql-metadata/)** | SQL parser used only by `index_suggestions.py` to extract WHERE/JOIN columns for the **Missing Index** finding's suggested DDL. Parser limitations are caught and downgraded to Analyzer Notes warnings — never a hard failure. |
+| **[`sql_metadata`](https://pypi.org/project/sql-metadata/)** | SQL parser used only by `index_suggestions.py` to extract WHERE/JOIN columns for the **Missing Index** finding's suggested DDL. Parser limitations are caught and downgraded to Analyzer Notes warnings never a hard failure. |
 | **[`psutil`](https://pypi.org/project/psutil/)** | CPU %, worker RSS, load average, swap. Powers the **Server Resource** panel + **Memory Pressure** / **Resource Contention** findings. |
-| **[`rq`](https://pypi.org/project/rq/)** | Redis Queue — reads queue depth (default/short/long) for the **Background Queue Backlog** finding. |
+| **[`rq`](https://pypi.org/project/rq/)** | Redis Queue reads queue depth (default/short/long) for the **Background Queue Backlog** finding. |
 | **`redis`** (via `frappe.cache`) | Storage of recordings, sidecar argument logs, pyinstrument session pickles. |
-| **[`Jinja2`](https://pypi.org/project/Jinja2/)** | Report template (`templates/report.html`) — the single source of truth for both Safe and Raw modes. |
+| **[`Jinja2`](https://pypi.org/project/Jinja2/)** | Report template (`templates/report.html`) the single source of truth for both Safe and Raw modes. |
 
 ### Standard-library workhorses (no install, always present)
 
@@ -361,17 +361,17 @@ Deliberately minimal. **Only one non-Frappe dependency is declared** in `pyproje
 | Package | Role |
 |---|---|
 | **`pytest`** | Test runner. 472+ tests in the suite. |
-| **[`hypothesis`](https://pypi.org/project/hypothesis/)** | Property-based testing for the call-tree pruner — fuzzes its invariants (hot-path preservation, soft-cap floor, SQL-leaf preservation). |
+| **[`hypothesis`](https://pypi.org/project/hypothesis/)** | Property-based testing for the call-tree pruner fuzzes its invariants (hot-path preservation, soft-cap floor, SQL-leaf preservation). |
 
 ### Written in-house (no library)
 
 These do real analytical work without pulling a dependency:
 
-- **EXPLAIN-based findings** — Full Table Scan / Filesort / Temporary Table / Low Filter Ratio are derived from MariaDB's own EXPLAIN output dict (no SQL-planning library).
-- **N+1 detection** — groups the recorder's captured stacks by `(filename, lineno)` and collapses multi-variant loops (v0.5.2 callsite dedup).
-- **Framework classifier** — pure path-boundary matching against the `FRAMEWORK_APPS` frozenset (frappe, erpnext, hrms, lms, helpdesk, insights, crm, builder, wiki, drive, payments) + third-party lib heuristics.
-- **Post-fix timing projections** — per-finding-type speedup factors (20× for full-scan, 3× for filesort, 2× for temp-table, `filtered_pct/100` for low filter, 2× avg for N+1 batching). See `analyzers/base.project_post_fix_ms`.
-- **Per-app bucketing, executive summary, analyzer notes, collapsible sections** — pure Python in the renderer + Jinja macros.
+- **EXPLAIN-based findings**: Full Table Scan / Filesort / Temporary Table / Low Filter Ratio are derived from MariaDB's own EXPLAIN output dict (no SQL-planning library).
+- **N+1 detection**: groups the recorder's captured stacks by `(filename, lineno)` and collapses multi-variant loops (v0.5.2 callsite dedup).
+- **Framework classifier**: pure path-boundary matching against the `FRAMEWORK_APPS` frozenset (frappe, erpnext, hrms, lms, helpdesk, insights, crm, builder, wiki, drive, payments) + third-party lib heuristics.
+- **Post-fix timing projections**: per-finding-type speedup factors (20× for full-scan, 3× for filesort, 2× for temp-table, `filtered_pct/100` for low filter, 2× avg for N+1 batching). See `analyzers/base.project_post_fix_ms`.
+- **Per-app bucketing, executive summary, analyzer notes, collapsible sections**: pure Python in the renderer + Jinja macros.
 
 ---
 
@@ -395,7 +395,7 @@ These do real analytical work without pulling a dependency:
 
 **Positioning:** commercial APMs are always-on monitoring for *"something regressed, find it."* optimus is on-demand debugging for *"this specific customer flow is slow, what should my dev shop fix."* They're complementary, not competitive. Most ERPNext shops run only optimus because Datadog is expensive and leaks customer data off-site.
 
-For the specific job of *"debug a slow ERPNext workflow and hand the report to a partner shop,"* optimus produces a better report than any commercial APM — because of callsite-grouped N+1, framework-native findings, flow-aware session, and customer-safe export. None of those exist anywhere else at any price.
+For the specific job of *"debug a slow ERPNext workflow and hand the report to a partner shop,"* optimus produces a better report than any commercial APM because of callsite-grouped N+1, framework-native findings, flow-aware session, and customer-safe export. None of those exist anywhere else at any price.
 
 ---
 
@@ -412,7 +412,7 @@ This app is **designed** to run on production because the whole point is to meas
 | Infra snapshot (v0.5.0) | ~0.8 ms per action boundary |
 | Frontend capture (v0.5.0) | ~5 µs per XHR (one fetch wrap + one XHR prototype wrap) |
 
-**When not recording**, cost is a single Redis `GET` per request to check the active-session flag — sub-millisecond on local Redis. Users who are not recording pay essentially nothing.
+**When not recording**, cost is a single Redis `GET` per request to check the active-session flag sub-millisecond on local Redis. Users who are not recording pay essentially nothing.
 
 **Reports should be read as relative, not absolute.** *"This step took 5× longer than that step"* is accurate. *"This step took exactly 4.2 seconds"* is inflated by the recording overhead.
 
@@ -425,7 +425,7 @@ Only the user who clicked Start gets recorded. Other users on the same site at t
 
 ### Background job inheritance
 
-Background jobs spawned by the recording user's actions are automatically captured under the same session. ERPNext's submission path enqueues several jobs (GL postings, stock updates) — without this, the report would miss huge chunks of work.
+Background jobs spawned by the recording user's actions are automatically captured under the same session. ERPNext's submission path enqueues several jobs (GL postings, stock updates) without this, the report would miss huge chunks of work.
 
 ### Hard caps
 
@@ -449,8 +449,8 @@ When a session moves to `Ready`, the source recordings in Redis (`RECORDER_REQUE
 
 ### Two report modes
 
-- **`safe_report_file`** — Normalized SQL, redacted URLs/headers/form data, sanitized notes, redacted custom-app function names. Safe to email to a third-party.
-- **`raw_report_file`** — Full data: raw SQL with literals, request headers, form data, complete stack traces. **Gated at two layers:**
+- **`safe_report_file`**: Normalized SQL, redacted URLs/headers/form data, sanitized notes, redacted custom-app function names. Safe to email to a third-party.
+- **`raw_report_file`**: Full data: raw SQL with literals, request headers, form data, complete stack traces. **Gated at two layers:**
   1. The "Download Raw Report" button is hidden in the form UI unless the user has `System Manager` role or recorded the session themselves.
   2. A `File.has_permission` hook (`optimus.permissions.file_has_permission`) blocks direct URL access even if the user guesses the file name.
 
@@ -458,23 +458,23 @@ When a session moves to `Ready`, the source recordings in Redis (`RECORDER_REQUE
 
 ## Scheduler-disabled sites
 
-On sites where `bench disable-scheduler` is in effect — common on dev, demo, and Frappe Cloud trial instances — the analyze RQ queue has no worker consuming it. v0.5.0+ detects this via `frappe.utils.scheduler.is_scheduler_disabled()` and falls back to `frappe.enqueue(now=True)`, which runs analyze **synchronously inside the stop request**.
+On sites where `bench disable-scheduler` is in effect common on dev, demo, and Frappe Cloud trial instances the analyze RQ queue has no worker consuming it. v0.5.0+ detects this via `frappe.utils.scheduler.is_scheduler_disabled()` and falls back to `frappe.enqueue(now=True)`, which runs analyze **synchronously inside the stop request**.
 
 Consequences:
 
-- **The stop API blocks for the analyze duration** (typically 2–20 seconds). The widget transitions from "Stopping…" directly to "Report ready" or "Analyze failed" — skipping the intermediate "Analyzing…" state — because the session is already finalized by the time the stop response arrives.
+- **The stop API blocks for the analyze duration** (typically 2–20 seconds). The widget transitions from "Stopping…" directly to "Report ready" or "Analyze failed" skipping the intermediate "Analyzing…" state because the session is already finalized by the time the stop response arrives.
 - **A safety cap (`optimus_inline_analyze_limit`, default 50) refuses inline analyze on huge sessions** to avoid gunicorn's 120-second request timeout. When a session exceeds the cap, it's marked `Failed` with an actionable error pointing the user to `bench enable-scheduler` and the **Retry Analyze** button.
-- **`retry_analyze` and the janitor's auto-stop path also use the scheduler-aware enqueue** — you can't accidentally get stuck with a Failed session that won't retry.
+- **`retry_analyze` and the janitor's auto-stop path also use the scheduler-aware enqueue**: you can't accidentally get stuck with a Failed session that won't retry.
 
 ---
 
-## Configuration — Optimus Settings (DocType)
+## Configuration: Optimus Settings (DocType)
 
 Almost every knob a regular admin needs lives in the **Optimus Settings**
 Single doc (go to **Desk → search "Optimus Settings"**, or
 `/app/optimus-settings`). Three tabs: **General**, **Analysis**, **AI Fix
 Suggestions**. The two ops-only knobs not in the UI (memory caps, lock
-behaviour, etc.) live in `site_config.json` — see the next section.
+behaviour, etc.) live in `site_config.json`: see the next section.
 
 Resolution order for any field with both a DocType row and a
 site_config fallback (n+1, redundant-call, sampler-interval): **DocType
@@ -488,7 +488,7 @@ populated.
 | Field | Default | Purpose |
 |---|---|---|
 | **Profiler Enabled** | ✓ on | Master kill-switch. When off, no requests or background jobs are profiled even when users have active sessions. Use it to pause site-wide instrumentation without touching individual widgets. |
-| **Session Retention (days)** | `30` | Optimus Session rows older than this — only in `Ready` or `Failed` state — are deleted by the daily housekeeping job, along with their attached HTML reports and `File` rows. `0` = keep forever. _Reference: Strict 90 · Recommended 30 · Relaxed 7._ |
+| **Session Retention (days)** | `30` | Optimus Session rows older than this only in `Ready` or `Failed` state are deleted by the daily housekeeping job, along with their attached HTML reports and `File` rows. `0` = keep forever. _Reference: Strict 90 · Recommended 30 · Relaxed 7._ |
 
 #### Apps section
 
@@ -497,26 +497,26 @@ Two child tables that control which Frappe apps Optimus treats as
 
 | Field | Purpose |
 |---|---|
-| **Tracked Apps** | Allowlist. When populated, **only** these apps' findings are actionable; everything else routes to the report's _Framework-level observations_ block. Leave it empty to keep the built-in defaults (`frappe`, `erpnext`, `hrms`, `lms`, `helpdesk`, `insights`, `crm`, `builder`, `wiki`, `drive`, `payments` + pip libs are framework code). **Do NOT add `frappe` or `erpnext` here** — that flips them to "user code" and floods actionable findings with framework noise. |
-| **Ignored Apps** | Exclusion list. Findings whose blame-app is in this list are **dropped entirely** (both Findings and Observations sections). Use it for apps you can't or won't patch — typically `frappe`, `optimus`, sometimes `erpnext`. The "Issues found" stat card surfaces a "N findings hidden" note so the total stays honest. |
+| **Tracked Apps** | Allowlist. When populated, **only** these apps' findings are actionable; everything else routes to the report's _Framework-level observations_ block. Leave it empty to keep the built-in defaults (`frappe`, `erpnext`, `hrms`, `lms`, `helpdesk`, `insights`, `crm`, `builder`, `wiki`, `drive`, `payments` + pip libs are framework code). **Do NOT add `frappe` or `erpnext` here**: that flips them to "user code" and floods actionable findings with framework noise. |
+| **Ignored Apps** | Exclusion list. Findings whose blame-app is in this list are **dropped entirely** (both Findings and Observations sections). Use it for apps you can't or won't patch typically `frappe`, `optimus`, sometimes `erpnext`. The "Issues found" stat card surfaces a "N findings hidden" note so the total stays honest. |
 
 #### Skip Rules section
 
 Patterns and users to exclude from instrumentation entirely (no
-recording captured in the first place — cheaper than dropping at
+recording captured in the first place cheaper than dropping at
 analyze time).
 
 | Field | Format | Purpose |
 |---|---|---|
-| **Skip Request Paths** | One URL prefix per line. `#` starts a comment. | Requests starting with any of these prefixes are not profiled even with an active session. Useful for healthcheck endpoints, polling APIs. The profiler's own admin endpoints are always skipped — these extend the built-in list. |
+| **Skip Request Paths** | One URL prefix per line. `#` starts a comment. | Requests starting with any of these prefixes are not profiled even with an active session. Useful for healthcheck endpoints, polling APIs. The profiler's own admin endpoints are always skipped these extend the built-in list. |
 | **Skip Users** | One user email per line. `#` comments. | Requests / jobs running as one of these users are not profiled. Useful for system bot users (scheduler, health-checks). |
 
 #### Redaction section
 
-Optimus redacts sensitive values **at capture time** — passwords, API
+Optimus redacts sensitive values **at capture time**: passwords, API
 keys, tokens, CSRF, cookies, authorization headers never reach Redis or
 the persisted report. Defaults cover 12 canonical patterns. The fields
-below extend the defaults — they are **never removed**. Substring match,
+below extend the defaults they are **never removed**. Substring match,
 case-insensitive.
 
 | Field | Format | Purpose |
@@ -528,14 +528,14 @@ case-insensitive.
 
 | Field | Default | Purpose |
 |---|---|---|
-| **Max Queries per Recording** | `2000` | Per-recording cap on queries enriched (`sqlparse` + `EXPLAIN` + normalization) by analyze. Anything beyond is truncated with a banner at the top of the report. Each query costs one `EXPLAIN` round-trip — raising the cap scales analyze time roughly linearly. Raise to `5000` / `10000` for legitimately heavy flows (e.g. Manufacturing Plan Submit creating 100+ child orders). _Reference: Strict 5000 · Recommended 2000 · Relaxed 1000._ |
+| **Max Queries per Recording** | `2000` | Per-recording cap on queries enriched (`sqlparse` + `EXPLAIN` + normalization) by analyze. Anything beyond is truncated with a banner at the top of the report. Each query costs one `EXPLAIN` round-trip raising the cap scales analyze time roughly linearly. Raise to `5000` / `10000` for legitimately heavy flows (e.g. Manufacturing Plan Submit creating 100+ child orders). _Reference: Strict 5000 · Recommended 2000 · Relaxed 1000._ |
 | **Sampler Interval (ms)** | `1.0` | pyinstrument statistical-sampler interval. Lower = finer call-tree resolution but higher overhead. `1ms` is recommended; raise to `5–10ms` for prod-like profiling. Floor: `0.1`. _Reference: Strict 0.5 · Recommended 1.0 · Relaxed 5.0._ |
-| **Hide framework / internal database tables** | ✓ on | When on, the "Time spent per database table" section drops Frappe schema/meta tables (`tabDocType`, `tabSingles`, `tabPatch Log`, etc.), framework-internal tables, and `information_schema.*`. Touched by every request via framework machinery — not user-actionable. Other sections (top-queries leaderboard, per-action drill-down, recordings) are unaffected. Uncheck to see them all. |
-| **Wait for Background Jobs (seconds)** | `300` | How long the analyze job watches the bg jobs the profiled flow enqueued, waiting for each to reach a terminal state (Completed / Failed / Timeout). Hard-capped at `300`. `0` = don't wait. On a single-worker bench the analyze job yields the worker between checks so those jobs can run; if the scheduler is disabled, the wait is skipped. Jobs still running at the ceiling appear as `Running` in the report — click _Retry Analyze_ once they finish to capture their data. _Reference: Strict 300 · Recommended 300 · Relaxed 60._ |
+| **Hide framework / internal database tables** | ✓ on | When on, the "Time spent per database table" section drops Frappe schema/meta tables (`tabDocType`, `tabSingles`, `tabPatch Log`, etc.), framework-internal tables, and `information_schema.*`. Touched by every request via framework machinery not user-actionable. Other sections (top-queries leaderboard, per-action drill-down, recordings) are unaffected. Uncheck to see them all. |
+| **Wait for Background Jobs (seconds)** | `300` | How long the analyze job watches the bg jobs the profiled flow enqueued, waiting for each to reach a terminal state (Completed / Failed / Timeout). Hard-capped at `300`. `0` = don't wait. On a single-worker bench the analyze job yields the worker between checks so those jobs can run; if the scheduler is disabled, the wait is skipped. Jobs still running at the ceiling appear as `Running` in the report click _Retry Analyze_ once they finish to capture their data. _Reference: Strict 300 · Recommended 300 · Relaxed 60._ |
 
 #### Display Filters section
 
-These shape how reports **render** — they don't change what's captured
+These shape how reports **render**: they don't change what's captured
 or analyzed.
 
 | Field | Default | Purpose |
@@ -551,7 +551,7 @@ or analyzed.
 
 | Field | Default | Purpose |
 |---|---|---|
-| **Sensitivity Profile** | `Recommended` | One-knob preset for the 9 detection thresholds below. **Strict** catches more (lower thresholds, more findings, more noise). **Relaxed** catches less. **Recommended** is the shipped default and automatically tracks future tuning across upgrades. **Custom** lets you hand-tune the individual fields — they stay locked under the named presets. Display filters, Phase-2, capture, retention, and AI settings are **not** affected by the profile. |
+| **Sensitivity Profile** | `Recommended` | One-knob preset for the 9 detection thresholds below. **Strict** catches more (lower thresholds, more findings, more noise). **Relaxed** catches less. **Recommended** is the shipped default and automatically tracks future tuning across upgrades. **Custom** lets you hand-tune the individual fields they stay locked under the named presets. Display filters, Phase-2, capture, retention, and AI settings are **not** affected by the profile. |
 
 #### Analyzer Thresholds section
 
@@ -595,22 +595,22 @@ user override these per run.
 
 ### AI Fix Suggestions tab
 
-Off by default — no traffic leaves your bench until you turn it on.
+Off by default no traffic leaves your bench until you turn it on.
 
 #### AI Fix Suggestions section (provider wiring)
 
 | Field | Default | Purpose |
 |---|---|---|
 | **Enable AI Fix Suggestions** | ✗ off | Master switch for the entire AI feature. When off, every AI button on the Session form is hidden and the API refuses. |
-| **Provider** | `Anthropic` | Wire format. `Anthropic`, `OpenAI`, `Kimi`, and `OpenAI-compatible` (which requires Base URL + Model — covers Ollama, LM Studio, vLLM, OpenRouter, Together, Groq). |
-| **Base URL** | _empty_ | Leave blank to use the hosted default. Required for `OpenAI-compatible` — e.g. `http://localhost:11434/v1` (Ollama), `http://localhost:1234/v1` (LM Studio). |
+| **Provider** | `Anthropic` | Wire format. `Anthropic`, `OpenAI`, `Kimi`, and `OpenAI-compatible` (which requires Base URL + Model covers Ollama, LM Studio, vLLM, OpenRouter, Together, Groq). |
+| **Base URL** | _empty_ | Leave blank to use the hosted default. Required for `OpenAI-compatible`: e.g. `http://localhost:11434/v1` (Ollama), `http://localhost:1234/v1` (LM Studio). |
 | **Model** | _empty_ | Leave blank for the provider default. Examples: `claude-sonnet-4-6` (Anthropic), `gpt-4.1-mini` (OpenAI), `kimi-k2-0905-preview` (Kimi), or your local model name. |
 | **API Key** | _empty_ | Per-site, stored encrypted (Frappe `Password` field). Most local OpenAI-compatible endpoints don't need one; hosted ones do. |
 
 #### Use the LLM for (section toggles)
 
 Three independent on/off switches. Turning any one off is a **hard
-disable** — the section is never auto-generated, the matching button is
+disable**: the section is never auto-generated, the matching button is
 hidden, the API refuses, and re-rendered reports omit the block.
 
 | Field | Default | Purpose |
@@ -623,27 +623,27 @@ hidden, the API refuses, and re-rendered reports omit the block.
 
 | Field | Default | Purpose |
 |---|---|---|
-| **Suggest AI fixes in the report by default** | ✗ off | When on, the analyze pipeline auto-generates a fix for each eligible finding so suggestions are already in the report — no need to click per finding. Costs LLM tokens (and a little analyze time) on every session. Keep off unless you want suggestions baked in. |
-| **Max auto-suggested findings per session** | `5` | Cap on how many findings get an automatic suggestion — highest-severity, highest-impact first. `0` = every eligible finding (can be slow + costly on big sessions). _Strict 10 · Recommended 5 · Relaxed 3._ |
+| **Suggest AI fixes in the report by default** | ✗ off | When on, the analyze pipeline auto-generates a fix for each eligible finding so suggestions are already in the report no need to click per finding. Costs LLM tokens (and a little analyze time) on every session. Keep off unless you want suggestions baked in. |
+| **Max auto-suggested findings per session** | `5` | Cap on how many findings get an automatic suggestion highest-severity, highest-impact first. `0` = every eligible finding (can be slow + costly on big sessions). _Strict 10 · Recommended 5 · Relaxed 3._ |
 
 #### Privacy & Operations section
 
 | Field | Default | Purpose |
 |---|---|---|
-| **Excluded finding types** | _empty_ | One finding type per line. Those types are skipped in both auto-suggest and on-demand — the payload is never built (no data ever sent for them). Exact-match, case-sensitive. `#` comments. Canonical names: `Filesort`, `Framework N+1`, `Full Table Scan`, `Hot Line`, `Low Filter Ratio`, `Missing Index`, `N+1 Query`, `Redundant Call`, `Slow Query`, `Temporary Table`. |
-| **Request timeout (seconds)** | `60` | HTTP timeout for outbound LLM calls. `60s` fits hosted providers (Anthropic / OpenAI reply in 2–10s typically). For local LLMs (Ollama / LM Studio / vLLM) first-token cold-start can exceed 60s — start at `180` and tune once warm-call P99 is known. Clamped to `10–600`. |
+| **Excluded finding types** | _empty_ | One finding type per line. Those types are skipped in both auto-suggest and on-demand the payload is never built (no data ever sent for them). Exact-match, case-sensitive. `#` comments. Canonical names: `Filesort`, `Framework N+1`, `Full Table Scan`, `Hot Line`, `Low Filter Ratio`, `Missing Index`, `N+1 Query`, `Redundant Call`, `Slow Query`, `Temporary Table`. |
+| **Request timeout (seconds)** | `60` | HTTP timeout for outbound LLM calls. `60s` fits hosted providers (Anthropic / OpenAI reply in 2–10s typically). For local LLMs (Ollama / LM Studio / vLLM) first-token cold-start can exceed 60s start at `180` and tune once warm-call P99 is known. Clamped to `10–600`. |
 
 ---
 
-## Configuration — site_config.json (operator knobs)
+## Configuration: site_config.json (operator knobs)
 
-Knobs that don't have a UI yet — usually because they're emergency
+Knobs that don't have a UI yet usually because they're emergency
 levers, performance trade-offs, or security hardening that an admin
 should not be flipping casually. All live in
 `sites/<your-site>/site_config.json`; all are optional; defaults are
 inert.
 
-A handful of them (the threshold ones — `optimus_redundant_*_threshold`,
+A handful of them (the threshold ones `optimus_redundant_*_threshold`,
 `optimus_n_plus_one_threshold`, `optimus_sampler_interval_ms`) also work
 as pre-DocType fallbacks. The DocType row wins if both are set.
 
@@ -660,7 +660,7 @@ as pre-DocType fallbacks. The DocType row wins if both are set.
 |---|---|---|
 | `optimus_explain_cache_ttl_seconds` | `3600` | How long `EXPLAIN` results are cached in Redis across analyze runs. `0` disables the cross-session cache. |
 | `optimus_analyze_gc_collect` | `True` | After analyze frees the pyinstrument session blob, call `gc.collect()` to return RAM to the OS. Safe-on default. Set `False` only if you've measured and the collect pause matters. |
-| `optimus_analyze_nice` | `5` | `os.nice` increment for the async analyze worker — lower CPU priority so it doesn't fight live requests. `0` disables. Linux only; ignored on macOS. |
+| `optimus_analyze_nice` | `5` | `os.nice` increment for the async analyze worker lower CPU priority so it doesn't fight live requests. `0` disables. Linux only; ignored on macOS. |
 | `optimus_singleflight_max_wait_seconds` | `600` | When two re-analyzes race for the same session, the second waits up to this long (with polite re-enqueue) for the first to finish. `0` disables single-flight. |
 | `optimus_enrich_throttle_every` | `0` | Sleep every N enriched queries during analyze (for EXPLAIN). `0` = no throttle (default). Raise to e.g. `200` on shared MariaDB instances where back-to-back EXPLAINs cause noisy-neighbor issues. |
 | `optimus_enrich_throttle_sleep_ms` | `5` | Sleep length when the throttle above fires. |
@@ -692,18 +692,18 @@ as pre-DocType fallbacks. The DocType row wins if both are set.
 
 ### N+1 / redundancy fallbacks (DocType wins if set)
 
-These are pre-DocType compatibility — the DocType field with the same
+These are pre-DocType compatibility the DocType field with the same
 purpose is the recommended surface. Listed here for sites still tuned
 through site_config.
 
 | Key | Default | Maps to DocType field |
 |---|---|---|
 | `optimus_n_plus_one_threshold` | `10` | N+1 Minimum Occurrences |
-| `optimus_n_plus_one_min_total_ms` | `20` | _(no DocType equivalent — min cumulative ms for an N+1 group)_ |
+| `optimus_n_plus_one_min_total_ms` | `20` | _(no DocType equivalent min cumulative ms for an N+1 group)_ |
 | `optimus_redundant_doc_threshold` | `5` | Redundant `get_doc` Threshold |
 | `optimus_redundant_cache_threshold` | `50` | Redundant Cache Lookup Threshold |
 | `optimus_redundant_perm_threshold` | `10` | Redundant Permission Check Threshold |
-| `optimus_redundant_high_multiplier` | `5` | _(no DocType equivalent — multiplier above which severity escalates to High)_ |
+| `optimus_redundant_high_multiplier` | `5` | _(no DocType equivalent multiplier above which severity escalates to High)_ |
 | `optimus_sampler_interval_ms` | `1` | Sampler Interval (ms) |
 
 ### Retention (DocType wins)
@@ -720,9 +720,9 @@ Set per session via the widget's start dialog or `api.start(...)`:
 
 | Flag | Default | Purpose |
 |---|---|---|
-| `label` (str, required) | — | Human-readable session label. |
+| `label` (str, required) | | Human-readable session label. |
 | `capture_python_tree` (bool) | `True` | Capture pyinstrument call tree + sidecar wraps for redundant-call detection. Disable to get v0.2.0 SQL-only behavior with ~10–30% overhead instead of 1.5–2×. |
-| `notes` (str) | `""` | Free-form "Steps to Reproduce / Notes" Text Editor content. Rendered at the top of both Safe and Raw reports. Bleach-sanitized before render — safe to include rich formatting but `<script>` tags are stripped. |
+| `notes` (str) | `""` | Free-form "Steps to Reproduce / Notes" Text Editor content. Rendered at the top of both Safe and Raw reports. Bleach-sanitized before render safe to include rich formatting but `<script>` tags are stripped. |
 
 Example Python call:
 
@@ -762,12 +762,12 @@ def analyze(
 ```
 
 Contract:
-- **No Frappe DB access** inside the function — analyzers are pure transformations over the recording data. This makes them unit-testable from JSON fixtures with no running site.
+- **No Frappe DB access** inside the function analyzers are pure transformations over the recording data. This makes them unit-testable from JSON fixtures with no running site.
 - Exceptions are caught by `analyze.run` and logged; a failing custom analyzer never halts the pipeline, but any findings it would have emitted are lost for that session.
 - Custom analyzers can read earlier analyzers' output from `context.actions`, `context.findings`, and `context.aggregate`.
 - A 60-second soft cap per analyzer logs a warning; the 20-minute total budget aborts remaining analyzers with a partial-completion warning.
 
-See [`optimus/analyzers/base.py`](./optimus/analyzers/base.py) for the full type contract and the analyzers under [`optimus/analyzers/`](./optimus/analyzers/) for working examples (each is a self-contained module — `n_plus_one.py`, `call_tree.py`, `redundant_calls.py`, and `infra_pressure.py` are good starting points).
+See [`optimus/analyzers/base.py`](./optimus/analyzers/base.py) for the full type contract and the analyzers under [`optimus/analyzers/`](./optimus/analyzers/) for working examples (each is a self-contained module `n_plus_one.py`, `call_tree.py`, `redundant_calls.py`, and `infra_pressure.py` are good starting points).
 
 ---
 
@@ -796,11 +796,11 @@ After `bench migrate`, verify in this order:
    >>> optimus.__version__
    '0.12.26'
    ```
-   If this returns an older version, `bench restart` didn't land — workers are stale.
+   If this returns an older version, `bench restart` didn't land workers are stale.
 
-4. **Floating widget appears in Desk:** log in as a System Manager, open any Desk page, look bottom-right for the red **Optimus** pill. Hover it — the tooltip should show the current build ID. Open devtools → Console — you should see `[optimus] floating_widget.js LOADED build=... at ...`.
+4. **Floating widget appears in Desk:** log in as a System Manager, open any Desk page, look bottom-right for the red **Optimus** pill. Hover it the tooltip should show the current build ID. Open devtools → Console you should see `[optimus] floating_widget.js LOADED build=... at ...`.
 
-5. **Correlation header is set:** start a session, open devtools → Network, click any link in Desk, inspect the response headers. You should see `X-Optimus-Recording-Id` AND `Access-Control-Expose-Headers: X-Optimus-Recording-Id` (without the second header, browsers hide the custom header from JavaScript — this is the single most common frontend instrumentation failure mode).
+5. **Correlation header is set:** start a session, open devtools → Network, click any link in Desk, inspect the response headers. You should see `X-Optimus-Recording-Id` AND `Access-Control-Expose-Headers: X-Optimus-Recording-Id` (without the second header, browsers hide the custom header from JavaScript this is the single most common frontend instrumentation failure mode).
 
 6. **Full end-to-end smoke test:**
    ```python
@@ -815,7 +815,7 @@ After `bench migrate`, verify in this order:
    >>> len(doc.actions), len(doc.findings)
    ```
 
-7. **Safe Report is self-contained:** open `doc.safe_report_file` in a browser with network disabled. It must render fully — no missing fonts, no broken layout. Tested in CI via `test_safe_report_self_contained.py`.
+7. **Safe Report is self-contained:** open `doc.safe_report_file` in a browser with network disabled. It must render fully no missing fonts, no broken layout. Tested in CI via `test_safe_report_self_contained.py`.
 
 8. **Scheduler-disabled fallback:** `bench --site <site> disable-scheduler`, reload Desk, run a session, click Stop. The widget should transition straight from "Stopping…" to "Report ready" (no intermediate "Analyzing…"). Re-enable: `bench --site <site> enable-scheduler`.
 
@@ -833,14 +833,14 @@ After `bench migrate`, verify in this order:
 
 **Fix (in order):**
 
-1. `bench restart` — reloads the Python workers so they see the updated `__version__`.
+1. `bench restart`: reloads the Python workers so they see the updated `__version__`.
 2. Hard-refresh Desk in the browser: `Cmd+Shift+R` (Mac) / `Ctrl+Shift+R` (Windows/Linux).
-3. Verify in devtools → Console: you should see `[optimus] floating_widget.js LOADED build=<current build> at ...`. Hover the widget pill — the tooltip should show the same build ID.
+3. Verify in devtools → Console: you should see `[optimus] floating_widget.js LOADED build=<current build> at ...`. Hover the widget pill the tooltip should show the same build ID.
 4. If the build ID matches and the bug still reproduces, open devtools → Console, click Stop, and check the `[optimus] stop callback: {...}` log. Paste it with a bug report.
 
 ### Stop button is silently doing nothing
 
-**Most likely cause:** `api.start` or `api.stop` is returning a server error and `frappe.call` is not invoking the success callback. The widget has explicit error handlers for this case (added in v0.5.1) — they show a red toast in the top-right corner. Look there first. Also check Frappe's error log:
+**Most likely cause:** `api.start` or `api.stop` is returning a server error and `frappe.call` is not invoking the success callback. The widget has explicit error handlers for this case (added in v0.5.1) they show a red toast in the top-right corner. Look there first. Also check Frappe's error log:
 
 ```bash
 bench --site <site> mariadb -e "SELECT method, error FROM \`tabError Log\` WHERE method LIKE 'optimus%' ORDER BY creation DESC LIMIT 5;"
@@ -848,23 +848,23 @@ bench --site <site> mariadb -e "SELECT method, error FROM \`tabError Log\` WHERE
 
 ### "No active session" after clicking Stop
 
-The session was already cleared server-side — usually because the auto-stop TTL expired (10 minutes of inactivity) or the janitor swept it. v0.5.1 handles this cleanly: the widget resets to inactive with a gray toast *"Session already stopped."* If you see the widget stuck on "Analyzing…" after this, you're on pre-v0.5.1 JS (see cache troubleshooting above).
+The session was already cleared server-side usually because the auto-stop TTL expired (10 minutes of inactivity) or the janitor swept it. v0.5.1 handles this cleanly: the widget resets to inactive with a gray toast *"Session already stopped."* If you see the widget stuck on "Analyzing…" after this, you're on pre-v0.5.1 JS (see cache troubleshooting above).
 
 ### Missing Index finding suggests a column that's already indexed
 
-**Shouldn't happen** in v0.5.1 — the analyzer verifies against `information_schema` before emitting. If you do see this, check the session's `analyzer_warnings`: suppressed suggestions are reported there with their reason. If a genuinely false-positive finding is still reaching the report, please file a bug with the full `technical_detail_json` attached.
+**Shouldn't happen** in v0.5.1 the analyzer verifies against `information_schema` before emitting. If you do see this, check the session's `analyzer_warnings`: suppressed suggestions are reported there with their reason. If a genuinely false-positive finding is still reaching the report, please file a bug with the full `technical_detail_json` attached.
 
 ### Repeated Hot Frame shows generic names like `wrapper` or `handle`
 
-**Shouldn't happen** in v0.5.1 — the aggregator now groups by `file::function` instead of the bare function name, and skips pure plumbing (werkzeug, `frappe.handler`, `frappe.utils`). If you still see this, verify the widget build ID is `2026-04-15-stop-fix-v3` or later.
+**Shouldn't happen** in v0.5.1 the aggregator now groups by `file::function` instead of the bare function name, and skips pure plumbing (werkzeug, `frappe.handler`, `frappe.utils`). If you still see this, verify the widget build ID is `2026-04-15-stop-fix-v3` or later.
 
 ### Scheduler is disabled and stop is taking forever
 
-On scheduler-disabled sites, analyze runs inline inside the stop request. A session with many recordings can take 10–30 seconds; the widget shows "Stopping…" the whole time. If it exceeds ~60 seconds, gunicorn's request timeout is at risk — lower `optimus_inline_analyze_limit` in site_config or re-enable the scheduler.
+On scheduler-disabled sites, analyze runs inline inside the stop request. A session with many recordings can take 10–30 seconds; the widget shows "Stopping…" the whole time. If it exceeds ~60 seconds, gunicorn's request timeout is at risk lower `optimus_inline_analyze_limit` in site_config or re-enable the scheduler.
 
 ### Call tree is huge and slows down the Optimus Session form load
 
-v0.5.0 caps `v5_aggregate_json` at 200 timeline entries + 500 XHR matches + 100 orphans with tail-preferring truncation. If you're still seeing slow form loads, check `analyzer_warnings` for the truncation count and the per-action `call_tree_json` field — trees larger than 200 KB overflow to a private File attachment rather than inlining.
+v0.5.0 caps `v5_aggregate_json` at 200 timeline entries + 500 XHR matches + 100 orphans with tail-preferring truncation. If you're still seeing slow form loads, check `analyzer_warnings` for the truncation count and the per-action `call_tree_json` field trees larger than 200 KB overflow to a private File attachment rather than inlining.
 
 ---
 
@@ -877,17 +877,17 @@ cd ~/frappe-bench/apps/optimus
 python -m pytest optimus/tests/ -v
 ```
 
-1820+ unit tests run in ~7 seconds on a laptop. The suite is **decoupled from Frappe** — most tests use JSON fixtures and mocked `frappe.cache` / `frappe.db`, so you can run them without a site. Tests that do need Frappe import guards are gated via `pytest.importorskip` or stubbed at module level.
+1820+ unit tests run in ~7 seconds on a laptop. The suite is **decoupled from Frappe**: most tests use JSON fixtures and mocked `frappe.cache` / `frappe.db`, so you can run them without a site. Tests that do need Frappe import guards are gated via `pytest.importorskip` or stubbed at module level.
 
 A second tier of 39 **integration tests** under `optimus/tests_integration/` exercises a real Frappe v16 bench provisioned by `.github/helper/install.sh` and runs via `bench --site <site> run-tests --app optimus`. These cover install-time invariants, scheduler/cron paths, the atomic Lua merge under multi-worker load, and other behaviors that can't be proven from pure-pytest stubs. See `optimus/tests_integration/README.md` for the local-run recipe.
 
 ### Test organization
 
-- `tests/test_<analyzer>_*.py` — per-analyzer unit tests with JSON fixtures
-- `tests/fixtures/*.json` — recording blobs (sanitized) used across analyzer tests
-- `tests/test_frontend_assets.py` — JS syntax + widget structure regression guards (uses `node --check`)
-- `tests/test_*_v5_*.py` — v0.5.0 integration tests (infra + frontend end-to-end)
-- `tests/test_analyze_run_*_wiring.py` — source-inspection regression guards for orchestration changes
+- `tests/test_<analyzer>_*.py`: per-analyzer unit tests with JSON fixtures
+- `tests/fixtures/*.json`: recording blobs (sanitized) used across analyzer tests
+- `tests/test_frontend_assets.py`: JS syntax + widget structure regression guards (uses `node --check`)
+- `tests/test_*_v5_*.py`: v0.5.0 integration tests (infra + frontend end-to-end)
+- `tests/test_analyze_run_*_wiring.py`: source-inspection regression guards for orchestration changes
 
 ### Adding an analyzer
 
@@ -906,7 +906,7 @@ MIT-licensed Frappe app. Contributions welcome via PR.
 
 **Before submitting:**
 
-- Run `pytest optimus/tests/ -v` — all 1820+ unit tests must pass.
+- Run `pytest optimus/tests/ -v`: all 1820+ unit tests must pass.
 - Run `node --check` on any JS changes.
 - Bump `__version__` in `optimus/__init__.py` for any user-visible change so the asset cache-buster rotates.
 - Add a CHANGELOG entry under the current unreleased section.
@@ -923,4 +923,4 @@ MIT-licensed Frappe app. Contributions welcome via PR.
 
 ## License
 
-MIT — see [`license.txt`](./license.txt).
+MIT see [`license.txt`](./license.txt).

--- a/docs/AI-FIXING.md
+++ b/docs/AI-FIXING.md
@@ -1,4 +1,4 @@
-# AI Fix Suggestions — data flow & privacy
+# AI Fix Suggestions: data flow & privacy
 
 This document inventories **exactly** what data leaves your host when Optimus's AI fix suggestion feature is enabled, where it goes, and how to keep everything on-box with a local LLM. It's written for operators making the consent decision and for reviewers (compliance / security / a dev shop receiving a profile) who need to audit the wire.
 
@@ -6,7 +6,7 @@ If you're picking up Optimus for the first time: every AI feature here is **off 
 
 ---
 
-## 1. TL;DR — default OFF
+## 1. TL;DR: default OFF
 
 Optimus ships with `ai_enabled = 0` and `ai_auto_suggest = 0` in `Optimus Settings`. No request leaves your host until a System Manager flips the master toggle AND configures a provider (or points at a local LLM). With AI off:
 
@@ -20,7 +20,7 @@ When AI is enabled, three knobs gate every outbound call:
 |---|---|---|
 | `ai_enabled` | OFF | Master gate. OFF → zero LLM calls ever. |
 | `ai_auto_suggest` | OFF | Batch mode. OFF → AI runs only when the operator clicks **Suggest a fix (AI)** on one finding. ON → analyze.run sends the top-N eligible findings during the background analyze pass. |
-| `ai_excluded_finding_types` | empty | One finding type per line (v0.9.0+). Listed types are skipped in **both** auto-suggest and on-demand — the request body is never built and never sent. |
+| `ai_excluded_finding_types` | empty | One finding type per line (v0.9.0+). Listed types are skipped in **both** auto-suggest and on-demand the request body is never built and never sent. |
 
 The combination of `ai_enabled=OFF`, on-demand-only (`ai_auto_suggest=OFF`), and the exclusion list gives the operator three independent axes of consent: feature-level (the master), event-level (the click), and type-level (the exclusion).
 
@@ -49,17 +49,17 @@ Triggered by **Suggest a fix (AI)** (on-demand) or auto-suggest at analyze time.
 | `callsite.filename` | technical_detail_json | 40–80 chars | Relative path under your bench, e.g. `apps/myapp/myapp/forms/invoice.py`. |
 | `callsite.lineno` | technical_detail_json | 3–5 chars | Line number. |
 | `callsite.function` | technical_detail_json | 20–60 chars | Function name from your code. |
-| **`source_window`** | `renderer._read_source_window` | **1–2 KB typical** | Up to 80 lines of your source: 24 before / 24 after the callsite, capped at `_MAX_SOURCE_WINDOW_LINES`. Verbatim — including comments, strings, variable names. **This is the largest field in a typical request.** |
+| **`source_window`** | `renderer._read_source_window` | **1–2 KB typical** | Up to 80 lines of your source: 24 before / 24 after the callsite, capped at `_MAX_SOURCE_WINDOW_LINES`. Verbatim including comments, strings, variable names. **This is the largest field in a typical request.** |
 | `phase2_hotline` | Phase 2 line-profile | 100–400 chars | When available, the hottest single line from line-profiling (line number, content, total ms, hit count). |
 | `technical_detail.function` | technical_detail_json | 30–80 chars | Hot function name (for Slow-Hot-Path-type findings). |
 | `technical_detail.cumulative_ms` | technical_detail_json | ~5 chars | Time in that function. |
 | `technical_detail.action_wall_time_ms` | technical_detail_json | ~5 chars | Action's total wall time. |
-| `technical_detail.normalized_query` | technical_detail_json | 100–2400 chars | **Capped 2400.** Normalized SQL — table names, column names, WHERE clause structure preserved; literals replaced by `?` (then redacted again by `optimus.redaction` if they match sensitive column names). |
+| `technical_detail.normalized_query` | technical_detail_json | 100–2400 chars | **Capped 2400.** Normalized SQL table names, column names, WHERE clause structure preserved; literals replaced by `?` (then redacted again by `optimus.redaction` if they match sensitive column names). |
 | `technical_detail.suggested_ddl` | technical_detail_json | 50–300 chars | Profiler's heuristic DDL pick, e.g. `ALTER TABLE tabBOMItem ADD INDEX ...`. |
-| `technical_detail.explain_row` | technical_detail_json | 100–800 chars | `EXPLAIN` output, capped — type / rows / key / Extra etc. |
+| `technical_detail.explain_row` | technical_detail_json | 100–800 chars | `EXPLAIN` output, capped type / rows / key / Extra etc. |
 | `technical_detail.fix_hint` | technical_detail_json | 50–200 chars | Profiler's deterministic suggestion. |
 | `technical_detail.validation_note` | technical_detail_json | 0–300 chars | Caveats. |
-| **`technical_detail.example_queries`** | live recording (Redis) | **0–4800 chars** | Up to 2 of the slowest **raw** SQL queries from this action's recording, each capped at 2400 chars. These are real production queries — table names, column names, WHERE values are preserved (after `password = '…'`-style literal redaction at capture time, see `optimus.redaction`). |
+| **`technical_detail.example_queries`** | live recording (Redis) | **0–4800 chars** | Up to 2 of the slowest **raw** SQL queries from this action's recording, each capped at 2400 chars. These are real production queries table names, column names, WHERE values are preserved (after `password = '…'`-style literal redaction at capture time, see `optimus.redaction`). |
 
 Total user content is truncated to `_MAX_USER_CONTENT_CHARS = 18000` characters before sending (`ai_fix._truncate`).
 
@@ -113,7 +113,7 @@ Smallest payload (`ai_fix.test_connection`). System: ~80 chars. User content: ~4
 These items are **never** sent in any AI request body:
 
 - **Sensitive SQL literals.** `password = '...'`, `api_key = '...'`, `token = '...'`, and the 12 other patterns in `optimus.redaction.DEFAULT_SENSITIVE_SQL_COLUMNS` are replaced with `<REDACTED>` at capture time, so even the `example_queries` field sees the redacted form. Operators can extend this list via `sensitive_sql_columns` in Optimus Settings.
-- **HTTP form bodies.** `form_dict` keys matching `password` / `api_key` / `token` / etc. are redacted at capture (`optimus.redaction.DEFAULT_SENSITIVE_KEYS`), and form bodies themselves are never included in AI payloads — only summary fields like `cmd` / `doctype` reach the humanize-steps path.
+- **HTTP form bodies.** `form_dict` keys matching `password` / `api_key` / `token` / etc. are redacted at capture (`optimus.redaction.DEFAULT_SENSITIVE_KEYS`), and form bodies themselves are never included in AI payloads only summary fields like `cmd` / `doctype` reach the humanize-steps path.
 - **Your API keys.** The provider API key is read from a Password field decrypted on demand (`frappe.utils.password.get_decrypted_password`). It is sent **only** in HTTP headers (`x-api-key` or `Authorization: Bearer …`), never echoed in the prompt, never logged, never returned to the client. The OpenAI-compatible provider with `needs_key=False` (local endpoints) omits the header entirely.
 - **Recording UUIDs.** Internal Redis keys.
 - **Your full DB schema.** Only tables observed in this profile's recordings are mentioned by name.
@@ -131,18 +131,18 @@ These items are **never** sent in any AI request body:
 | `Anthropic` | Messages | `https://api.anthropic.com` | Yes | Default model: `claude-sonnet-4-6`. |
 | `OpenAI` | Chat completions | `https://api.openai.com/v1` | Yes | Default model: `gpt-4.1-mini`. |
 | `Kimi (Moonshot)` | Chat completions | `https://api.moonshot.ai/v1` | Yes | Default model: `kimi-k2-0905-preview`. |
-| `Aerele` | Chat completions | `https://api.aerele.in/optimus/v1` | Yes | Managed service — buy a fixed token pack up front. See § 10. |
+| `Aerele` | Chat completions | `https://api.aerele.in/optimus/v1` | Yes | Managed service buy a fixed token pack up front. See § 10. |
 | `OpenAI-compatible` | Chat completions | (you set it) | No (configurable) | Use this for local LLMs and any other OpenAI-shaped server. |
 
 `ai_base_url`, `ai_model`, and `ai_api_key` (Password) all override the provider defaults. The HTTP timeout is `ai_request_timeout_seconds` (v0.9.0+, default 60s, clamped 10–600s).
 
-For an explicit data-residency choice, use `OpenAI-compatible` pointed at a process you run yourself — see § 6.
+For an explicit data-residency choice, use `OpenAI-compatible` pointed at a process you run yourself see § 6.
 
 ---
 
 ## 5. Eligible finding types
 
-These ten finding types are the only ones for which Optimus builds an AI payload. All other types (Slow Hot Path, Hook Bottleneck, Repeated Hot Frame, infra / frontend findings, etc.) are skipped — they don't carry enough code/SQL context for the LLM to add value over the profiler's own deterministic suggestions.
+These ten finding types are the only ones for which Optimus builds an AI payload. All other types (Slow Hot Path, Hook Bottleneck, Repeated Hot Frame, infra / frontend findings, etc.) are skipped they don't carry enough code/SQL context for the LLM to add value over the profiler's own deterministic suggestions.
 
 - Filesort
 - Framework N+1
@@ -159,18 +159,18 @@ The exact set lives in `optimus/ai_fix.py::AI_ELIGIBLE_FINDING_TYPES`. A test (`
 
 ### 5.1 Per-type opt-out (`ai_excluded_finding_types`)
 
-`Optimus Settings → AI → Privacy & Operations → Excluded finding types` is a multi-line list. Each line names one of the ten types above (exact match, case-sensitive). Lines starting with `#` are comments. Listed types are skipped in **both** auto-suggest and on-demand calls — no payload is built, no request is sent, the on-demand button surfaces a clear "excluded by Optimus Settings" message.
+`Optimus Settings → AI → Privacy & Operations → Excluded finding types` is a multi-line list. Each line names one of the ten types above (exact match, case-sensitive). Lines starting with `#` are comments. Listed types are skipped in **both** auto-suggest and on-demand calls no payload is built, no request is sent, the on-demand button surfaces a clear "excluded by Optimus Settings" message.
 
 Use this when the SQL or source for a particular finding category embeds business logic you don't want flowing to a hosted provider:
 
 ```text
 # We're fine sending N+1 patterns to Anthropic, but our pricing-rule SQL
-# embeds margin formulas — skip Slow Query and Full Table Scan.
+# embeds margin formulas: skip Slow Query and Full Table Scan.
 Slow Query
 Full Table Scan
 ```
 
-The list is empty by default. The exclusion list is **additive** — types not listed continue to flow normally.
+The list is empty by default. The exclusion list is **additive**: types not listed continue to flow normally.
 
 ---
 
@@ -242,7 +242,7 @@ Default `ai_request_timeout_seconds = 60` is fine for hosted providers (Anthropi
 
 What this design protects against:
 
-- **Accidental egress.** With `ai_enabled = OFF` (default) no request body is ever built — there's no code path that exfiltrates finding data.
+- **Accidental egress.** With `ai_enabled = OFF` (default) no request body is ever built there's no code path that exfiltrates finding data.
 - **Click-to-send.** With `ai_auto_suggest = OFF` (default) the LLM only sees a finding when the operator explicitly clicks the per-finding button. Every send is a deliberate, attributable action.
 - **Category-level opt-out.** `ai_excluded_finding_types` lets you keep specific categories (e.g. Slow Query, where raw SQL flows verbatim) out of the wire entirely.
 - **Network-residency.** The OpenAI-compatible provider + a local LLM keeps everything on your host. You can verify with `tcpdump` / `lsof` / `netstat` that no outbound socket opens during an AI call.
@@ -252,7 +252,7 @@ What this design does **not** protect against:
 - **A compromised LLM provider.** If you're using Anthropic / OpenAI / a third-party, your finding context is at the mercy of their logging, retention, and abuse-monitoring policies. Read each provider's data-use policy.
 - **On-disk caching by the LLM client.** Local servers (Ollama, LM Studio, vLLM) may log requests to disk depending on their flags. Check their docs and configure logging off if you're paranoid.
 - **Backups and audit logs.** The AI suggestion (the response text) is persisted to `Optimus Finding.llm_fix_json`. Your DB backups include it. If a fix suggestion contains a paraphrase of sensitive code/SQL, it'll be in those backups.
-- **The Optimus Telemetry Event DocType** (v0.8.0+). When telemetry is enabled, Optimus's own failures (including AI HTTP errors) are recorded with the provider name + endpoint label + status code — but never with the prompt or the payload. See `optimus/telemetry.py`.
+- **The Optimus Telemetry Event DocType** (v0.8.0+). When telemetry is enabled, Optimus's own failures (including AI HTTP errors) are recorded with the provider name + endpoint label + status code but never with the prompt or the payload. See `optimus/telemetry.py`.
 
 ---
 
@@ -260,11 +260,11 @@ What this design does **not** protect against:
 
 The "safe report" HTML file Optimus produces (the dev-shop interchange format) **does not** call any LLM at render or open time. When the operator sends you a profile:
 
-- The report is fully self-contained — no CDN, no remote fetch on open.
+- The report is fully self-contained no CDN, no remote fetch on open.
 - AI fix suggestions, if any, are **baked into the report** at analyze time. The HTML embeds the suggestion text as static markup; opening the report locally never triggers an AI call.
-- The dev shop doesn't need an API key / provider configured to read the report — they need it only if they want to **regenerate** suggestions on their own bench.
+- The dev shop doesn't need an API key / provider configured to read the report they need it only if they want to **regenerate** suggestions on their own bench.
 
-This means: if you're worried about a profile shared with a third party leaking your code to their LLM provider, the answer is "the profile itself doesn't." But it also means: AI suggestions baked into the report carry the same content the LLM produced — review those before sharing if they paraphrase sensitive logic.
+This means: if you're worried about a profile shared with a third party leaking your code to their LLM provider, the answer is "the profile itself doesn't." But it also means: AI suggestions baked into the report carry the same content the LLM produced review those before sharing if they paraphrase sensitive logic.
 
 ---
 
@@ -285,9 +285,9 @@ This means: if you're worried about a profile shared with a third party leaking 
 
 ## 10. Aerele Managed Provider (v0.14.x+)
 
-`Aerele` is a hosted option for customers who don't want to bring their own Anthropic / OpenAI key. The customer purchases a **fixed token pack** (e.g. "10,000 tokens for ₹X") up front; AI fix calls draw from that pack until it's exhausted, at which point the customer buys another pack. There is no subscription, no monthly reset, and no overage — when the pack runs out, calls are refused until a new pack is purchased.
+`Aerele` is a hosted option for customers who don't want to bring their own Anthropic / OpenAI key. The customer purchases a **fixed token pack** (e.g. "10,000 tokens for ₹X") up front; AI fix calls draw from that pack until it's exhausted, at which point the customer buys another pack. There is no subscription, no monthly reset, and no overage when the pack runs out, calls are refused until a new pack is purchased.
 
-**Architecturally the Optimus side is identical to the Anthropic / OpenAI / Kimi entries:** the operator picks `Aerele` as the provider, pastes the key Aerele issued into **API Key**, and every call hits Aerele's URL. There is no Optimus-side bookkeeping — no balance cache, no pre-call gate, no Refresh button, no daily sync. **All token accounting and pack validation happens on Aerele's separate Frappe site** (the URL in the provider matrix above). The bench is a dumb client.
+**Architecturally the Optimus side is identical to the Anthropic / OpenAI / Kimi entries:** the operator picks `Aerele` as the provider, pastes the key Aerele issued into **API Key**, and every call hits Aerele's URL. There is no Optimus-side bookkeeping no balance cache, no pre-call gate, no Refresh button, no daily sync. **All token accounting and pack validation happens on Aerele's separate Frappe site** (the URL in the provider matrix above). The bench is a dumb client.
 
 ### 10.1 Onboarding
 
@@ -301,9 +301,9 @@ That is the entire integration. `ai_base_url` and `ai_model` use Aerele's defaul
 
 ### 10.2 Where the token pack lives
 
-The customer manages their pack entirely on `aerele.in` — sign-ups, purchases, remaining-balance display, usage history. Optimus never sees, displays, or caches the remaining balance. Each AI call is validated server-side on every request by Aerele's Frappe site; pack-exhausted and rate-limit refusals surface through `_http_post`'s existing 4xx handling with the response body's error text.
+The customer manages their pack entirely on `aerele.in`: sign-ups, purchases, remaining-balance display, usage history. Optimus never sees, displays, or caches the remaining balance. Each AI call is validated server-side on every request by Aerele's Frappe site; pack-exhausted and rate-limit refusals surface through `_http_post`'s existing 4xx handling with the response body's error text.
 
-When a pack runs out, the next AI fix attempt from Optimus surfaces Aerele's "pack exhausted — purchase a new one" message as an inline `AiFixError` alert. The operator then visits aerele.in, buys another pack, and the existing API key automatically draws from the new pack — no Optimus re-configuration needed.
+When a pack runs out, the next AI fix attempt from Optimus surfaces Aerele's "pack exhausted purchase a new one" message as an inline `AiFixError` alert. The operator then visits aerele.in, buys another pack, and the existing API key automatically draws from the new pack no Optimus re-configuration needed.
 
 ### 10.3 What additionally leaves the host
 

--- a/docs/HMAC-ENVELOPE.md
+++ b/docs/HMAC-ENVELOPE.md
@@ -1,4 +1,4 @@
-# `sign_blob` / `unsign_blob` — HMAC envelope versioning
+# `sign_blob` / `unsign_blob`: HMAC envelope versioning
 
 `optimus.session.sign_blob` / `unsign_blob` wrap every opaque payload
 (currently pickled pyinstrument trees, but the API is bytes-in,
@@ -59,7 +59,7 @@ Pickle (the only producer of payloads for `sign_blob` today) never uses
 So a legacy pre-v0.12.14 pickle payload's first byte can never
 accidentally trigger the v1 strip branch in `unsign_blob`. Future
 producers (msgpack, JSON, raw binary) need to avoid `\x01` as a leading
-byte — see the producer compatibility table below.
+byte see the producer compatibility table below.
 
 ### Producer compatibility table
 
@@ -67,7 +67,7 @@ byte — see the producer compatibility table below.
 |---|---|---|
 | Pickle protocol 0 | Printable ASCII opcodes | Yes |
 | Pickle protocol 2-5 | `\x80` | Yes |
-| msgpack (positive fixint) | `\x00`-`\x7f` — **collides with `\x01`** | NO (write through v1 path) |
+| msgpack (positive fixint) | `\x00`-`\x7f`: **collides with `\x01`** | NO (write through v1 path) |
 | msgpack (map fixmap) | `\x80`-`\x8f` | Yes |
 | JSON (top-level dict) | `{` (`\x7b`) | Yes |
 | JSON (top-level list) | `[` (`\x5b`) | Yes |
@@ -79,7 +79,7 @@ that's just pickle, which never collides.
 
 ## Future schemes (extension points)
 
-### Scheme v2 — HMAC-SHA512 (hypothetical)
+### Scheme v2: HMAC-SHA512 (hypothetical)
 
 **When to bump**: a credible cryptanalytic finding against SHA-256 in
 the HMAC-style construction, OR a customer regulatory requirement
@@ -131,7 +131,7 @@ malicious_payload` as a v0 blob. (The v0 branch's HMAC over `body` ≠
 the v0 HMAC over an attacker-crafted v0 payload, but defence-in-depth
 matters.)
 
-### Scheme v3 — AES-SIV authenticated encryption (hypothetical)
+### Scheme v3: AES-SIV authenticated encryption (hypothetical)
 
 **When to bump**: when the operator wants to encrypt the payload at
 rest in Redis (not just authenticate it). AES-SIV is the
@@ -149,7 +149,7 @@ HMAC. The reader's verify step is the SIV `decrypt-and-verify` API
 which returns `None`/raises on tag mismatch. Same backward-compat
 strategy: try v1 first, then v3 (the marker bytes differ).
 
-### Scheme v4+ — key rotation
+### Scheme v4+: key rotation
 
 For key rotation (e.g., the operator rotates `encryption_key` and wants
 to migrate without re-signing everything inline), the marker can carry
@@ -161,29 +161,29 @@ a key-id bit:
 
 Reader inspects the marker's low bits to pick which secret to verify
 with. This is the operator-driven extension and requires explicit
-support in `_hmac_secret` (return per-key-id secret) — out of scope
+support in `_hmac_secret` (return per-key-id secret) out of scope
 for the v0.12.14 baseline.
 
 ## Canary tests
 
 `optimus/tests/test_hmac_envelope_versioning.py` (v0.12.14):
 
-* `TestSignUnsignRoundTrip` (3 tests) — v1 round-trip happy path,
+* `TestSignUnsignRoundTrip` (3 tests) v1 round-trip happy path,
   empty payload, pickle-shaped payload.
-* `TestLegacyShapeBackwardCompat` (2 tests) — pre-v0.12.14 v0
+* `TestLegacyShapeBackwardCompat` (2 tests) pre-v0.12.14 v0
   blobs still verify, including pickle-shaped legacy blobs (their
   `\x80` first byte is NOT the v1 marker, so they go through the v0
   branch correctly).
-* `TestNewShapeByteLayout` (1 test) — locks the byte layout
+* `TestNewShapeByteLayout` (1 test) locks the byte layout
   (`32 + 1 + len(payload)`).
-* `TestTamperingDetection` (3 tests) — tampered sig / version-byte /
+* `TestTamperingDetection` (3 tests) tampered sig / version-byte /
   payload all return None.
-* `TestEdgeCases` (4 tests) — too-short, non-bytes, sign rejects
+* `TestEdgeCases` (4 tests) too-short, non-bytes, sign rejects
   non-bytes, no-secret pass-through.
 
 A future scheme v2 PR would add `TestSchemeV2RoundTrip` +
 `TestV0V1V2Coexistence` + `TestV1ReaderRejectsV2Blob` (the v1 reader
-must NOT verify a v2 blob's SHA-256 of `body64` — it would fail
+must NOT verify a v2 blob's SHA-256 of `body64`: it would fail
 trivially because the lengths differ). The existing 13 tests stay
 green throughout (v0/v1 compat is forever).
 
@@ -227,15 +227,15 @@ PR should ship the janitor wiring alongside the scheme code.
 ## Out of scope
 
 * **Nonce-based authenticated encryption** (AES-GCM, ChaCha20-Poly1305)
-  — the deterministic-retrieval pattern of these blobs doesn't fit a
+  the deterministic-retrieval pattern of these blobs doesn't fit a
   nonce-per-blob design without extra state (a per-key counter, a
   per-payload random nonce written alongside, etc.). AES-SIV (scheme
   v3) is the natural fit.
-* **Per-payload-shape versioning** — that's the v0.12.0 `wrap_value`
+* **Per-payload-shape versioning**: that's the v0.12.0 `wrap_value`
   envelope's job (see `docs/REDIS-SCHEMA.md`). The HMAC scheme version
   is about the SIGNING scheme; the payload version is about the
   PAYLOAD shape. Both can evolve independently.
-* **Asymmetric signatures** (Ed25519, etc.) — the cross-process
+* **Asymmetric signatures** (Ed25519, etc.) the cross-process
   shared-secret model fits HMAC's symmetric design; introducing
   asymmetric keys would mean two separate workflows (signing-key
   process, verifying-key process), which is overkill for the
@@ -243,9 +243,9 @@ PR should ship the janitor wiring alongside the scheme code.
 
 ## See also
 
-* `optimus/session.py:sign_blob` / `unsign_blob` — the implementation.
-* `optimus/tests/test_hmac_envelope_versioning.py` — the canary
+* `optimus/session.py:sign_blob` / `unsign_blob`: the implementation.
+* `optimus/tests/test_hmac_envelope_versioning.py`: the canary
   test suite.
-* `docs/REDIS-SCHEMA.md` — the value-shape envelope (different
+* `docs/REDIS-SCHEMA.md`: the value-shape envelope (different
   concern; lives one layer up).
-* CHANGELOG.md v0.12.14 — the rollout entry.
+* CHANGELOG.md v0.12.14 the rollout entry.

--- a/docs/REDIS-SCHEMA.md
+++ b/docs/REDIS-SCHEMA.md
@@ -1,7 +1,7 @@
 # Optimus Redis schema
 
-This doc inventories every Redis key Optimus writes — the key pattern,
-the value's shape and encoding, the TTL, the lifecycle — and the
+This doc inventories every Redis key Optimus writes the key pattern,
+the value's shape and encoding, the TTL, the lifecycle and the
 versioning contract that lets value shapes evolve safely across
 releases.
 
@@ -21,7 +21,7 @@ backlog counter). The Frappe-managed MariaDB DocTypes
 Redis is the working memory.
 
 Every key Optimus writes comes from a builder in
-`optimus/redis_keys.py` — a single source of truth. The audit test
+`optimus/redis_keys.py`: a single source of truth. The audit test
 `optimus/tests/test_redis_audit.py` enforces this: a `frappe.cache.*`
 call site whose key isn't a `redis_keys.*` call fails CI.
 
@@ -35,7 +35,7 @@ Schema versions are tracked by **two** mechanisms working together:
 
 A versioned-value envelope (`optimus.redis_schema.wrap_value` /
 `unwrap_value`) is the opt-in contract for **new** value-shape
-changes. Today (v0.12.0) NO existing value is wrapped — the helpers
+changes. Today (v0.12.0) NO existing value is wrapped the helpers
 are reserved for the next time a shape changes.
 
 ---
@@ -90,7 +90,7 @@ when you add a new key; the audit test asserts this table matches
 | `profiler:onboarding_seen:<user>` | **enveloped** string (v0.12.13+) | Frappe pickle around `{"_v": 1, "data": "1"}` | 1 year (`ONBOARDING_CACHE_TTL_SECONDS`) | Dismissed-toast marker. Migrated to the v0.12.0 envelope in v0.12.13. The reader (`check_onboarding_seen`) uses `unwrap_value` so legacy bare-string writes from pre-v0.12.13 still resolve. |
 | `profiler:explain:<cache_key>` | **enveloped** list[dict] (v0.12.17+) | Frappe pickle around `{"_v": 1, "data": [<row>, ...]}` | TTL via `optimus_explain_cache_ttl_seconds` site_config (default 3600s) | EXPLAIN result hash; persists across sessions. Migrated to the v0.12.0 envelope in v0.12.17. Reads accept legacy bare-list shape for backward compat with pre-v0.12.17 writers. |
 | `optimus:analyze:inflight` | string (heartbeat token) | raw | 300s (`_SINGLEFLIGHT_TTL_SECONDS`) | Single-flight guard; heartbeated by the live analyze; auto-clears on worker death. |
-| `optimus:retention_backlog` | **enveloped** integer (v0.12.13+) | Frappe pickle around `{"_v": 1, "data": <int>}` | 3600s | Janitor backlog counter when daily sweep hits its per-run cap. Migrated to the v0.12.0 envelope in v0.12.13. Write-only inside the app — operator dashboards reading directly from Redis see the envelope shape. |
+| `optimus:retention_backlog` | **enveloped** integer (v0.12.13+) | Frappe pickle around `{"_v": 1, "data": <int>}` | 3600s | Janitor backlog counter when daily sweep hits its per-run cap. Migrated to the v0.12.0 envelope in v0.12.13. Write-only inside the app operator dashboards reading directly from Redis see the envelope shape. |
 | `optimus_settings_cached` | **enveloped** dataclass dict (v0.12.11+) | Frappe pickle around `{"_v": 1, "data": {...}}` | none (invalidated by DocType `on_update`) | Pre-prefix legacy name; kept as-is to avoid a one-shot cache miss on upgrade. **First value migrated to the v0.12.0 versioned envelope (v0.12.11).** Reads still accept legacy bare-dict shape for backward compat with pre-v0.12.11 writers. |
 | `optimus:schema_version` | integer | raw | none | v0.12.0+ sentinel. Written at app import. See § 4. |
 
@@ -104,7 +104,7 @@ of every value Optimus writes. v0.12.0 baseline is `1`.
 ### When to bump
 
 Bump `SCHEMA_VERSION` (in both `optimus/redis_keys.py` and
-`optimus/redis_schema.py` — they must stay in lock-step) when ANY of:
+`optimus/redis_schema.py`: they must stay in lock-step) when ANY of:
 
 * A field is added or removed from a persisted dict (e.g. you add a
   `capture_phase2_too` flag to `session_meta`).
@@ -115,7 +115,7 @@ Bump `SCHEMA_VERSION` (in both `optimus/redis_keys.py` and
 
 Renaming a key, adding a NEW key, or changing only the helper's
 build logic without changing the resulting string does NOT bump
-`SCHEMA_VERSION` — those are non-breaking organisational changes.
+`SCHEMA_VERSION`: those are non-breaking organisational changes.
 
 ### How to wrap a new value shape
 
@@ -142,7 +142,7 @@ On the read side, use `unwrap_value`:
 raw = frappe.cache.get_value(redis_keys.session_meta(uuid))
 payload, observed_version = redis_schema.unwrap_value(raw, default={})
 if observed_version is None:
-    # Legacy un-wrapped value — payload is the bare dict (or whatever
+    # Legacy un-wrapped value payload is the bare dict (or whatever
     # the previous shape was). Code should still work on the old shape
     # OR have a migration path.
     ...
@@ -158,7 +158,7 @@ else:
 
 ### What the unwrap helper does NOT do
 
-* It doesn't migrate the value inline — each value's shape has its
+* It doesn't migrate the value inline each value's shape has its
   own migration rules, and coupling that into one helper would create
   a god-function. The contract is: when drift is detected, the helper
   emits telemetry + returns the default. Future code can read the
@@ -195,10 +195,10 @@ migrators.
 
 Most keys carry an explicit TTL via `frappe.cache.set_value(..., expires_in_sec=N)` or `expire_key()`. The exceptions:
 
-* `profiler:session:<uuid>:meta` / `:recordings` / `:pending_jobs` / `:jobs` — explicit delete by `delete_session_state` on analyze completion. If analyze crashes before that runs, the janitor's `sweep_orphan_redis_state` daily cron picks up the orphans.
-* `profiler:lp:<uuid>:picks` / `:source` / `:samples` — explicit delete by `cleanup_run`. If a worker dies mid-run, the janitor's `sweep_stale_phase2_runs` 5-minute cron picks up the orphans.
-* `profiler:explain:<cache_key>` — persistent read-through cache. Small per-entry; not worth a TTL.
-* `optimus_settings_cached` — invalidated by the Optimus Settings DocType's `on_update` (Frappe's standard cache invalidation pattern, not a TTL).
+* `profiler:session:<uuid>:meta` / `:recordings` / `:pending_jobs` / `:jobs`: explicit delete by `delete_session_state` on analyze completion. If analyze crashes before that runs, the janitor's `sweep_orphan_redis_state` daily cron picks up the orphans.
+* `profiler:lp:<uuid>:picks` / `:source` / `:samples`: explicit delete by `cleanup_run`. If a worker dies mid-run, the janitor's `sweep_stale_phase2_runs` 5-minute cron picks up the orphans.
+* `profiler:explain:<cache_key>`: persistent read-through cache. Small per-entry; not worth a TTL.
+* `optimus_settings_cached`: invalidated by the Optimus Settings DocType's `on_update` (Frappe's standard cache invalidation pattern, not a TTL).
 
 The `profiler:onboarding_seen:<user>` 1-year TTL is the policy lever; bump or shorten via `ONBOARDING_CACHE_TTL_SECONDS` in `api.py` if the user-research story changes.
 
@@ -206,7 +206,7 @@ The `profiler:onboarding_seen:<user>` 1-year TTL is the policy lever; bump or sh
 
 ## 6. The dual-encoding hazard
 
-`profiler:session:<uuid>:jobs` is the one hash where the encoding is **deliberately raw JSON**, not Frappe's pickle wrapping. The v0.7.x trilogy (`a356f64` → `0e4a270` → `f30f44e`) shipped an atomic Lua script `_MERGE_JOB_META_LUA` that does HGET → cjson.decode → merge → cjson.encode → HSET in a single server-side step. Lua can't replicate Python's pickle, so the values are JSON bytes — and they're read/written through `_raw_redis()` in `session.py`, which bypasses Frappe's pickle wrapper.
+`profiler:session:<uuid>:jobs` is the one hash where the encoding is **deliberately raw JSON**, not Frappe's pickle wrapping. The v0.7.x trilogy (`a356f64` → `0e4a270` → `f30f44e`) shipped an atomic Lua script `_MERGE_JOB_META_LUA` that does HGET → cjson.decode → merge → cjson.encode → HSET in a single server-side step. Lua can't replicate Python's pickle, so the values are JSON bytes and they're read/written through `_raw_redis()` in `session.py`, which bypasses Frappe's pickle wrapper.
 
 **The hazard**: if any future code does `frappe.cache.hset(jobs_key, job_id, …)` directly, Frappe's `RedisWrapper.hset` pickles the value. The hash becomes heterogeneous (some JSON-encoded, some pickled), and `hgetall` returns garbage on the next read.
 
@@ -251,6 +251,6 @@ Adding a Redis-backed feature? Four steps:
    - Cross-session caches: an explicit `expires_in_sec` or a manual invalidation hook.
    - If neither applies, document the policy here.
 
-4. **If the value SHAPE is version-controlled**, wrap it via `optimus.redis_schema.wrap_value` on write and unwrap via `unwrap_value` on read. Most new keys don't need this — they're either simple strings, hash-of-IDs, or write-once lists. Only wrap when the shape might evolve.
+4. **If the value SHAPE is version-controlled**, wrap it via `optimus.redis_schema.wrap_value` on write and unwrap via `unwrap_value` on read. Most new keys don't need this they're either simple strings, hash-of-IDs, or write-once lists. Only wrap when the shape might evolve.
 
-The audit test, the schema sentinel, the version-bump rule together form the safety net — but the discipline of routing keys through `redis_keys.py` is what makes them all work.
+The audit test, the schema sentinel, the version-bump rule together form the safety net but the discipline of routing keys through `redis_keys.py` is what makes them all work.

--- a/docs/optimus_raw_report_eb7d4af777c13a4e821529.html
+++ b/docs/optimus_raw_report_eb7d4af777c13a4e821529.html
@@ -624,7 +624,7 @@
   .kpi-value.danger { color: var(--accent); }
   .kpi-unit { font-size: 14px; color: var(--ink-mute); font-weight: 400; margin-left: 2px; }
   .kpi-sub { font-size: 12px; color: var(--ink-soft); margin-top: 6px; line-height: 1.45; }
-  /* C.UT2: tiny caveat line under a KPI's sub-text — explains a known
+  /* C.UT2: tiny caveat line under a KPI's sub-text explains a known
      limitation of the metric (e.g. sampler interval for Total time). */
   .kpi-caveat {
     font-size: 11px;
@@ -641,7 +641,7 @@
      -----
      Terminology decision (U1, intentional split):
      - Data-layer field names use ``cumulative_ms`` (pyinstrument's
-       term — sum of self_time + descendant time).
+       term sum of self_time + descendant time).
      - UI text uses ``consolidated`` (the user-facing word, picked
        by the project owner for the scope-tag vocabulary).
      This split is intentional. Keep cumulative_ms in fixtures /
@@ -909,7 +909,7 @@
   .code-block .added { color: #6A9955; }
   .code-block .removed { color: #F48771; text-decoration: line-through; opacity: 0.85; }
 
-  /* VS Code Dark Modern token palette — smoking-gun .code-block
+  /* VS Code Dark Modern token palette smoking-gun .code-block
      snippet only. The hot-line amber wrapper sits OUTSIDE these
      per-token spans so the highlight composes correctly. */
   .code-block .tok-k, .code-block .tok-kn        { color: #C586C0; }
@@ -932,7 +932,7 @@
   .code-block .tok-cm                            { color: #6A9955; font-style: italic; }
   .code-block .tok-o, .code-block .tok-p         { color: #D4D4D4; }
 
-  /* VS Code Light Modern token palette — Line-Level Drilldown
+  /* VS Code Light Modern token palette Line-Level Drilldown
      .line-prof table only (light to match the editorial report
      page). */
   .line-prof .tok-k, .line-prof .tok-kn, .line-prof .tok-kc,
@@ -1732,7 +1732,7 @@
       <p class="small muted" style="font-style: italic;">
         Note: finding impacts may overlap when several findings cover the
         same code path (e.g. a Slow Hot Path and an N+1 inside the same
-        function) &mdash; don't sum <em>estimated_impact_ms</em> across findings.
+        function) don't sum <em>estimated_impact_ms</em> across findings.
       </p>
 
             <div class="finding severity-high">
@@ -1888,15 +1888,15 @@
         <span>Suggested fix</span>
         <span class="ai-tag">AI &middot; qwen3-coder:30b</span>
       </div>
-      <div class="fix-body"><p><strong>Diagnosis</strong> — <code>frappe.get_doc("User", frappe.session.user)</code> on line 20 is called 50 times in a loop — that's 50 redundant round-trips to fetch the same User document.</p>
+      <div class="fix-body"><p><strong>Diagnosis</strong> <code>frappe.get_doc("User", frappe.session.user)</code> on line 20 is called 50 times in a loop that's 50 redundant round-trips to fetch the same User document.</p>
 
 <p><strong>Fix</strong></p>
 
 <pre class="dh"><code class="diff language-diff"><span class="dh-line dh-ctx"> def _check_user_exists(doc):</span><span class="dh-line dh-del">-    for i in range(50):</span><span class="dh-line dh-del">-        user = frappe.get_doc("User", frappe.session.user)</span><span class="dh-line dh-del">-        if user.enabled:</span><span class="dh-line dh-del">-            _maybe_log_user(user, i)</span><span class="dh-line dh-add">+    user = frappe.get_doc("User", frappe.session.user)</span><span class="dh-line dh-add">+    if user.enabled:</span><span class="dh-line dh-add">+        for i in range(50):</span><span class="dh-line dh-add">+            _maybe_log_user(user, i)</span></code></pre>
 
-<p><strong>Why it works</strong> — hoisting the <code>frappe.get_doc</code> call out of the loop eliminates 49 redundant database queries for the same user, while preserving the same logic flow.</p>
+<p><strong>Why it works</strong> hoisting the <code>frappe.get_doc</code> call out of the loop eliminates 49 redundant database queries for the same user, while preserving the same logic flow.</p>
 
-<p><strong>Verify</strong> — re-profile the <code>looped_validate</code> function and confirm the <code>tabUser</code> query count dropped from 50 to 1 for this action.</p>
+<p><strong>Verify</strong> re-profile the <code>looped_validate</code> function and confirm the <code>tabUser</code> query count dropped from 50 to 1 for this action.</p>
 </div>
       <div class="fix-foot">Machine-generated &middot; 19-05-2026 13:31:27 - review before applying.</div>
     </div>
@@ -2198,12 +2198,12 @@ Also affects 1 other action.</p>
             <td class="num"><strong><span class="time-high">1.34s</span></strong></td>
             <td class="num"><strong>140</strong></td>
             <td class="num"><strong>69ms</strong></td>
-            <td class="num muted" title="Per-row maxes are not additive — column total intentionally suppressed">&mdash;</td>
+            <td class="num muted" title="Per-row maxes are not additive, so the column total is intentionally suppressed"></td>
           </tr>
         </tfoot>
       </table>
       <p class="small muted" style="font-style: italic; margin-top: 6px;">
-        Note: <em>Slowest query</em> values are per-row maxes &mdash; don't sum them.
+        Note: <em>Slowest query</em> values are per-row maxes don't sum them.
         Use the <em>DB time</em> column when you want a column total.
       </p>
       <section class="subsection">
@@ -2602,7 +2602,7 @@ Also affects 1 other action.</p>
     <p class="small muted" style="font-style: italic;">
       Note: the consolidated total sums each job's wall time. If your
       bench runs multiple RQ workers in parallel, the actual elapsed
-      pool time may be less than this sum &mdash; the per-job Duration
+      pool time may be less than this sum the per-job Duration
       column shows each job's true wall.
     </p>
     <p class="small muted">
@@ -2789,12 +2789,12 @@ Also affects 1 other action.</p>
           <td class="num"><strong><span class="time-high">1.34s</span></strong></td>
           <td class="num"><strong>140</strong></td>
           <td class="num"><strong>69ms</strong></td>
-          <td class="num muted" title="Per-row maxes are not additive — column total intentionally suppressed">&mdash;</td>
+          <td class="num muted" title="Per-row maxes are not additive, so the column total is intentionally suppressed"></td>
 <td class="num"><strong>2</strong></td>        </tr>
       </tfoot>
     </table>
     <p class="small muted" style="font-style: italic; margin-top: 6px;">
-      Note: <em>Slowest query</em> values are per-row maxes &mdash; don't sum them.
+      Note: <em>Slowest query</em> values are per-row maxes don't sum them.
       Use the <em>DB time</em> column when you want a column total.
     </p>
   </section>
@@ -3256,11 +3256,11 @@ looped_validate            </span>
         </tr>
         <tr>
           <td><code>/desk/sales-invoice/ACC-SINV-2026-00060</code></td>
-          <td class="num"><span class="vital-none">—</span></td>
-          <td class="num"><span class="vital-none">—</span></td>
+          <td class="num"><span class="vital-none"> </span></td>
+          <td class="num"><span class="vital-none"> </span></td>
           <td class="num"><span class="vital-meh">0.135</span></td>
-          <td class="num"><span class="vital-none">—</span></td>
-          <td class="num"><span class="vital-none">—</span></td>
+          <td class="num"><span class="vital-none"> </span></td>
+          <td class="num"><span class="vital-none"> </span></td>
         </tr>
       </tbody>
     </table>
@@ -3277,7 +3277,7 @@ looped_validate            </span>
           <tr>
             <th>Function</th>
             <th class="num">Total time <small class="scope-tag">consolidated</small></th>
-            <th class="num" title="Sampler hits — proportional to call count but not exact. Use Line-Level Drilldown for a true call count.">Samples</th>
+            <th class="num" title="Sampler hits proportional to call count but not exact. Use Line-Level Drilldown for a true call count.">Samples</th>
             <th class="num">Distinct actions</th>
           </tr>
         </thead>
@@ -3431,7 +3431,7 @@ looped_validate            </span>
     <a id="queries"></a>    <h2>Slowest queries - your app</h2>
       <div class="empty-state">
         <div class="empty-icon">&check; Clear</div>
-        <p>No queries cleared the 10ms display floor this session &mdash; sub-10ms queries are hidden by default to avoid noise. The per-action breakdown below lists every query, fast and framework ones included.</p>
+        <p>No queries cleared the 10ms display floor this session sub-10ms queries are hidden by default to avoid noise. The per-action breakdown below lists every query, fast and framework ones included.</p>
       </div>
   </section>
 
@@ -3564,18 +3564,18 @@ looped_validate            </span>
                   <span>Index advice</span>
                   <span class="ai-tag">AI &middot; qwen3-coder:30b</span>
                 </div>
-                <div class="fix-body"><p><strong>Recommendation</strong> — <code>(communication_type, reference_doctype, reference_name, communication_date)</code> on <code>tabCommunication</code></p>
+                <div class="fix-body"><p><strong>Recommendation</strong> <code>(communication_type, reference_doctype, reference_name, communication_date)</code> on <code>tabCommunication</code></p>
 
-<p><strong>Why</strong> — This composite index covers the most frequent filter pattern <code>(communication_type, reference_doctype, reference_name)</code> and the <code>ORDER BY communication_date</code> clause. It's optimal for the query's WHERE and ORDER BY usage, and the leftmost columns are highly selective.</p>
+<p><strong>Why</strong> This composite index covers the most frequent filter pattern <code>(communication_type, reference_doctype, reference_name)</code> and the <code>ORDER BY communication_date</code> clause. It's optimal for the query's WHERE and ORDER BY usage, and the leftmost columns are highly selective.</p>
 
-<p><strong>How to add</strong> — <code>frappe.db.add_index("Communication", ["communication_type", "reference_doctype", "reference_name", "communication_date"])</code></p>
+<p><strong>How to add</strong> <code>frappe.db.add_index("Communication", ["communication_type", "reference_doctype", "reference_name", "communication_date"])</code></p>
 
-<p><strong>Skip</strong> — 
-- <code>reference_owner</code> — already covered by the new index as a leftmost prefix.
-- <code>creation</code> — Frappe metadata column, not indexed.
-- <code>status_communication_type_index</code> — does not cover the required filter pattern.
-- <code>message_id_index</code> — not used in the queries.
-- <code>comm_ref_type_date_idx</code> — already covers <code>reference_doctype</code>, <code>reference_name</code>, <code>communication_date</code>, but not in the right order for <code>communication_type</code> to be first. The new index improves performance by placing <code>communication_type</code> first.</p>
+<p><strong>Skip</strong>
+- <code>reference_owner</code> already covered by the new index as a leftmost prefix.
+- <code>creation</code> Frappe metadata column, not indexed.
+- <code>status_communication_type_index</code> does not cover the required filter pattern.
+- <code>message_id_index</code> not used in the queries.
+- <code>comm_ref_type_date_idx</code> already covers <code>reference_doctype</code>, <code>reference_name</code>, <code>communication_date</code>, but not in the right order for <code>communication_type</code> to be first. The new index improves performance by placing <code>communication_type</code> first.</p>
 </div>
                 <div class="fix-foot">Machine-generated &middot; 19-05-2026 13:30:43 - verify against <code>SHOW INDEX</code> before applying.</div>
               </div>
@@ -3600,14 +3600,14 @@ looped_validate            </span>
                   <span>Index advice</span>
                   <span class="ai-tag">AI &middot; qwen3-coder:30b</span>
                 </div>
-                <div class="fix-body"><p><strong>Recommendation</strong> — nothing — the existing indexes already cover these read patterns.</p>
+                <div class="fix-body"><p><strong>Recommendation</strong> nothing the existing indexes already cover these read patterns.</p>
 
-<p><strong>Why</strong> — The query filters on <code>(link_doctype, link_name)</code> and orders by <code>communication_date</code>, which is already covered by the existing index <code>link_doctype_link_name_communication_date_parent_index</code>. This index's leftmost columns match the filter pattern and includes <code>communication_date</code> for ordering, making it fully suitable.</p>
+<p><strong>Why</strong> The query filters on <code>(link_doctype, link_name)</code> and orders by <code>communication_date</code>, which is already covered by the existing index <code>link_doctype_link_name_communication_date_parent_index</code>. This index's leftmost columns match the filter pattern and includes <code>communication_date</code> for ordering, making it fully suitable.</p>
 
-<p><strong>Skip</strong> — 
-- <code>link_doctype_link_name_index</code> — already covered by the more comprehensive index <code>link_doctype_link_name_communication_date_parent_index</code>.
-- <code>parent</code> — a Frappe metadata column, not indexed.
-- <code>communication_date</code> — part of the existing composite index, no need for a separate index.</p>
+<p><strong>Skip</strong>
+- <code>link_doctype_link_name_index</code> already covered by the more comprehensive index <code>link_doctype_link_name_communication_date_parent_index</code>.
+- <code>parent</code> a Frappe metadata column, not indexed.
+- <code>communication_date</code> part of the existing composite index, no need for a separate index.</p>
 </div>
                 <div class="fix-foot">Machine-generated &middot; 19-05-2026 13:30:46 - verify against <code>SHOW INDEX</code> before applying.</div>
               </div>
@@ -3631,18 +3631,18 @@ looped_validate            </span>
                   <span>Index advice</span>
                   <span class="ai-tag">AI &middot; qwen3-coder:30b</span>
                 </div>
-                <div class="fix-body"><p><strong>Recommendation</strong> — <code>(company, posting_date)</code> on <code>tabSales Invoice</code></p>
+                <div class="fix-body"><p><strong>Recommendation</strong> <code>(company, posting_date)</code> on <code>tabSales Invoice</code></p>
 
-<p><strong>Why</strong> — This composite index covers the most frequent filter pattern <code>(company, posting_date)</code> seen in the profiler, which appeared together in 1 of 20 reads. It will significantly speed up queries filtering on both columns, especially when <code>company</code> is selective and <code>posting_date</code> is used for range scans.</p>
+<p><strong>Why</strong> This composite index covers the most frequent filter pattern <code>(company, posting_date)</code> seen in the profiler, which appeared together in 1 of 20 reads. It will significantly speed up queries filtering on both columns, especially when <code>company</code> is selective and <code>posting_date</code> is used for range scans.</p>
 
-<p><strong>How to add</strong> — <code>frappe.db.add_index('Sales Invoice', ['company', 'posting_date'])</code></p>
+<p><strong>How to add</strong> <code>frappe.db.add_index('Sales Invoice', ['company', 'posting_date'])</code></p>
 
-<p><strong>Skip</strong> — 
-- <code>customer</code> — already indexed, not part of the profiler's top filter combo
-- <code>posting_date</code> — already indexed, but not in the most selective leftmost position for this pattern
-- <code>creation</code> — Frappe metadata column, not worth indexing
-- <code>docstatus</code> — Frappe metadata column, not worth indexing
-- <code>name</code> — already indexed as PRIMARY key, not part of the profiler's top filter combo</p>
+<p><strong>Skip</strong>
+- <code>customer</code> already indexed, not part of the profiler's top filter combo
+- <code>posting_date</code> already indexed, but not in the most selective leftmost position for this pattern
+- <code>creation</code> Frappe metadata column, not worth indexing
+- <code>docstatus</code> Frappe metadata column, not worth indexing
+- <code>name</code> already indexed as PRIMARY key, not part of the profiler's top filter combo</p>
 </div>
                 <div class="fix-foot">Machine-generated &middot; 19-05-2026 13:30:56 - verify against <code>SHOW INDEX</code> before applying.</div>
               </div>
@@ -3722,9 +3722,9 @@ looped_validate            </span>
       <li>The server-resource and frontend panels show CPU / memory / queue pressure and browser timings - only when captured.</li>
       <li>The full-recordings and queries-per-action sections hold the raw SQL, headers, form data and stack traces - for deep dives.</li>
       <li>Hover any <code>file.py:123</code> callsite to open it in VS&nbsp;Code. Anything starting with <code>tab</code> is a database table; the DocType is the part after <code>tab</code>.</li>
-      <li>Every duration carries a small grey scope tag: <strong>per hit</strong> (one occurrence — a single request, one query execution) or <strong>consolidated</strong> (sum across all hits in this session — total time in a table, full impact of a finding's pattern, etc.).</li>
-      <li>Call-tree and Hot-frame timings come from a wall-clock sampler at ≈1.0ms intervals. Functions whose execution is shorter than the interval can be under-sampled or invisible — for exact per-line timings, use the <strong>Line-Level Drilldown</strong>.</li>
-      <li><strong>Self-time</strong> is wall-clock self-time (the sampler measures elapsed time, not CPU). A function that blocks on I/O — <code>requests.get</code>, sync DB calls outside the recorder, <code>time.sleep</code> — counts that wait as self-time. Check the call tree for hidden I/O before optimising compute.</li>
+      <li>Every duration carries a small grey scope tag: <strong>per hit</strong> (one occurrence a single request, one query execution) or <strong>consolidated</strong> (sum across all hits in this session total time in a table, full impact of a finding's pattern, etc.).</li>
+      <li>Call-tree and Hot-frame timings come from a wall-clock sampler at ≈1.0ms intervals. Functions whose execution is shorter than the interval can be under-sampled or invisible for exact per-line timings, use the <strong>Line-Level Drilldown</strong>.</li>
+      <li><strong>Self-time</strong> is wall-clock self-time (the sampler measures elapsed time, not CPU). A function that blocks on I/O <code>requests.get</code>, sync DB calls outside the recorder, <code>time.sleep</code> counts that wait as self-time. Check the call tree for hidden I/O before optimising compute.</li>
     </ul>
   </section>
 

--- a/optimus/__init__.py
+++ b/optimus/__init__.py
@@ -1,21 +1,21 @@
-__version__ = "0.12.41"
+__version__ = "0.12.42"
 
 
 def safe_commit() -> None:
 	"""Commit pending changes with an explicit rollback-on-error guard.
 
 	Frappe's ``frappe.db.commit()`` does NOT auto-rollback when the SQL
-	COMMIT itself fails (rare but possible — replica lag, write timeout,
+	COMMIT itself fails (rare but possible replica lag, write timeout,
 	deadlock retry exhausted). Without an explicit rollback, the
 	connection is left in a tainted state that breaks the next statement
 	with a confusing error far from the original cause. This helper is
-	the Frappe-idiomatic guard the Lens audit recommends — wraps the
+	the Frappe-idiomatic guard the Lens audit recommends wraps the
 	commit, rolls back on exception, re-raises so the caller sees the
 	failure.
 
 	For best-effort callers (the janitor sweeps, etc.) the outer
 	exception handler in the entry function absorbs the re-raise and
-	moves on — no behavioural change. For must-succeed callers (analyze
+	moves on no behavioural change. For must-succeed callers (analyze
 	pipeline, install hook, PDF attachment), the exception now properly
 	surfaces and the connection stays clean.
 	"""
@@ -27,7 +27,7 @@ def safe_commit() -> None:
 			frappe.db.rollback()
 		except Exception:
 			# Rollback failing on top of commit failing is exceptionally
-			# rare — typically the connection is already gone. Swallow
+			# rare typically the connection is already gone. Swallow
 			# the rollback exception so the original (more informative)
 			# commit exception is what bubbles up.
 			pass
@@ -45,7 +45,7 @@ def safe_commit() -> None:
 # for the job.
 #
 # This is the only way to make background-job profiling work without forking
-# frappe — the worker process is a fresh interpreter that has no idea who
+# frappe the worker process is a fresh interpreter that has no idea who
 # enqueued the job, but RQ preserves kwargs verbatim across the queue boundary.
 #
 # Patched at app-import time. Idempotent via the `_profiler_patched` marker
@@ -55,13 +55,13 @@ def safe_commit() -> None:
 
 def _patch_enqueue():
 	"""Install the enqueue wrapper. Safe to call in environments without
-	frappe installed — will silently no-op (useful for running analyzer
+	frappe installed will silently no-op (useful for running analyzer
 	unit tests from a plain Python interpreter)."""
 	try:
 		import frappe
 		import frappe.utils.background_jobs as _bg
 	except ImportError:
-		# Frappe isn't available — we're probably running unit tests
+		# Frappe isn't available we're probably running unit tests
 		# or a standalone script. Nothing to patch.
 		return
 
@@ -96,7 +96,7 @@ def _patch_enqueue():
 					if lp_active:
 						kwargs["_lp_session_id"] = lp_active
 				except Exception:
-					# line_profiler not installed, or any other failure —
+					# line_profiler not installed, or any other failure
 					# phase 2 stays off for this job; phase 1 (if active)
 					# still rides along.
 					pass
@@ -107,7 +107,7 @@ def _patch_enqueue():
 		job = _original_enqueue(method, *args, **kwargs)
 
 		# v0.6.0: register the RQ job id with the session so analyze waits
-		# for it to finish before gathering recordings — so jobs that get
+		# for it to finish before gathering recordings so jobs that get
 		# picked up by a worker shortly after Stop aren't lost. `job` is
 		# None for `now=True` inline jobs (nothing async to wait for). Never
 		# track our own analyze job (it would deadlock the wait on itself).
@@ -147,7 +147,7 @@ _patch_enqueue()
 
 
 # ---------------------------------------------------------------------------
-# frappe.recorder monkey-patch — capture-time redaction (v0.7.x+)
+# frappe.recorder monkey-patch capture-time redaction (v0.7.x+)
 # ---------------------------------------------------------------------------
 # The Frappe recorder snapshots ``frappe.local.form_dict`` + ``request.headers``
 # at ``Recorder.__init__`` and stores each ``frappe.db.sql`` call's
@@ -161,19 +161,19 @@ _patch_enqueue()
 # at render time as a last line of defense. That left a window where raw
 # values existed in Redis + on disk. The architecture review (Critical Risk
 # #1) called this out; this patch closes it by redacting at the earliest
-# point we control — when the Recorder captures.
+# point we control when the Recorder captures.
 #
 # Patch surface:
-#   - ``Recorder.__init__`` — after the original sets ``self.form_dict`` /
+#   - ``Recorder.__init__``: after the original sets ``self.form_dict`` /
 #     ``self.headers``, walk them via ``redaction.redact_sensitive`` so the
 #     values reach ``dump()`` already scrubbed.
-#   - ``Recorder.register(data)`` — before ``_original_register(data)``,
+#   - ``Recorder.register(data)``: before ``_original_register(data)``,
 #     replace ``data["query"]`` with its redacted form so the SQL string
 #     stored in ``self.calls`` never carried the original literal.
 #
 # Idempotent via the ``_profiler_patched`` marker (same pattern as
 # ``_patch_enqueue``). Wrapped in ``try/except`` at every layer so a patch
-# failure never breaks a customer's request — degrades gracefully back to
+# failure never breaks a customer's request degrades gracefully back to
 # the renderer's defense-in-depth redaction.
 
 
@@ -190,7 +190,7 @@ def _patch_recorder():
 	try:
 		import frappe.recorder as _rec
 	except ImportError:
-		# Frappe isn't available — running unit tests in a plain Python
+		# Frappe isn't available running unit tests in a plain Python
 		# interpreter. Match _patch_enqueue's silent no-op.
 		return
 
@@ -208,7 +208,7 @@ def _patch_recorder():
 	_original_register = Recorder.register
 
 	def _read_extras():
-		"""Read the live sensitive-list settings. Best-effort — falls back
+		"""Read the live sensitive-list settings. Best-effort falls back
 		to empty extras (defaults still apply) if settings can't be loaded
 		(early-boot, no DB connection, etc.)."""
 		try:
@@ -262,12 +262,12 @@ _patch_recorder()
 
 
 # ---------------------------------------------------------------------------
-# sys.monitoring tool-2 startup probe (v0.7.x+) — Critical Risk #3
+# sys.monitoring tool-2 startup probe (v0.7.x+) Critical Risk #3
 # ---------------------------------------------------------------------------
 # On Python 3.12+ line_profiler claims sys.monitoring.PROFILER_ID (tool 2).
 # If a worker died mid-Phase-2 without running its after_request finally
 # (or hit the pre-6f66a43 teardown bug), tool 2 stays owned by
-# "line_profiler" process-globally — and the next request to that worker
+# "line_profiler" process-globally and the next request to that worker
 # inherits the orphan AND gets line-traced. The pre-arm self-heal in
 # optimus/line_profile/hooks.py covers Phase 2 paths but only fires when
 # the NEXT Phase 2 request runs; every interim request between worker
@@ -276,8 +276,8 @@ _patch_recorder()
 # This probe runs ONCE at app-import (between _patch_recorder and
 # _try_install_capture_wraps) and:
 #
-#   * Auto-reclaims tool 2 when it's owned by "line_profiler" — the
-#     worker-respawn-after-crash case — and LOGS the recovery so the
+#   * Auto-reclaims tool 2 when it's owned by "line_profiler" the
+#     worker-respawn-after-crash case and LOGS the recovery so the
 #     event is visible in journalctl + Error Log.
 #   * Logs LOUDLY when tool 2 is owned by an unknown component (third-
 #     party profiler / debugger / future Python change), but does NOT
@@ -285,7 +285,7 @@ _patch_recorder()
 #   * Silent (and a no-op) on Python < 3.12 (no sys.monitoring) or when
 #     nobody owns tool 2.
 #
-# Best-effort everywhere — never raises out of the import path.
+# Best-effort everywhere never raises out of the import path.
 
 
 def _startup_probe_tool2() -> None:
@@ -297,7 +297,7 @@ def _startup_probe_tool2() -> None:
 
 		mon = getattr(sys, "monitoring", None)
 		if mon is None:
-			return  # Python < 3.12 — nothing to probe
+			return  # Python < 3.12 nothing to probe
 		pid = mon.PROFILER_ID
 		owner = mon.get_tool(pid)
 		if owner is None:
@@ -344,7 +344,7 @@ _startup_probe_tool2()
 
 
 # v0.3.0: install sidecar wraps for redundant-call detection.
-# Idempotent — safe to call multiple times. Wraps are activation-gated
+# Idempotent safe to call multiple times. Wraps are activation-gated
 # at call time so they're no-ops for non-recording users.
 #
 # Both layers are wrapped in try/except: the install itself, AND the
@@ -352,14 +352,14 @@ _startup_probe_tool2()
 # fake module (e.g. test_enqueue_patch.py), `install_wraps()` may raise
 # because `frappe.permissions` / `frappe.utils.redis_wrapper` aren't
 # present, AND `frappe.log_error` may not exist either. Both failures
-# are silent — the v0.2.0 enqueue patch above uses the same defensive
+# are silent the v0.2.0 enqueue patch above uses the same defensive
 # pattern (`pass` on any exception) for the same reason.
 #
 # v0.5.3: we ONLY install at module-import if frappe is already
-# fully loaded (i.e. `frappe._` — the translation function — is
+# fully loaded (i.e. `frappe._`: the translation function is
 # available). Otherwise the install is deferred. This guards against
 # the bench test runner importing optimus during its own
-# bootstrap, while `frappe/__init__.py` is still executing — in that
+# bootstrap, while `frappe/__init__.py` is still executing in that
 # state a later call to `frappe.get_doc(...)` through our wrap hits
 # `frappe.utils.nestedset` which does `from frappe import _` at
 # module-top and blows up with
@@ -371,7 +371,7 @@ _startup_probe_tool2()
 
 def _try_install_capture_wraps() -> bool:
 	"""Attempt to install the sidecar wraps. Returns True if actually
-	installed, False if deferred or errored. Idempotent — the
+	installed, False if deferred or errored. Idempotent the
 	capture module itself guards against double-wrap.
 	"""
 	try:
@@ -381,7 +381,7 @@ def _try_install_capture_wraps() -> bool:
 		return False
 
 	# Frappe bootstrap in progress? The `_` translator is the last
-	# thing frappe/__init__.py defines that nestedset imports —
+	# thing frappe/__init__.py defines that nestedset imports
 	# if it's missing, wrap-install could cascade into a partial-
 	# init ImportError. Defer until hooks fire.
 	if not hasattr(frappe, "_"):
@@ -410,7 +410,7 @@ _try_install_capture_wraps()
 # v0.12.0: Redis schema-version sentinel
 # ---------------------------------------------------------------------------
 # Write the current SCHEMA_VERSION to ``optimus:schema_version`` at app
-# import so future migration paths can detect upgrades. Idempotent —
+# import so future migration paths can detect upgrades. Idempotent
 # overwrites the sentinel on every boot. Best-effort: a Redis hiccup
 # must never break app load, same discipline as ``_startup_probe_tool2``
 # and ``_try_install_capture_wraps`` above. See

--- a/optimus/ai_fix.py
+++ b/optimus/ai_fix.py
@@ -7,20 +7,20 @@ The profiler already pins each finding to a callsite, a source snippet, and
 (for query findings) normalized SQL + EXPLAIN. This module turns that
 context into a concrete fix by asking a configured LLM. It is invoked only
 from the ``optimus.api.suggest_fix`` whitelisted endpoint (request
-context) — never from an analyzer or from ``analyze.py``, so the
+context) never from an analyzer or from ``analyze.py``, so the
 pure-analyzer / frozen-capture invariants are untouched.
 
-Provider-agnostic by design (self-hosted thesis): two wire formats —
+Provider-agnostic by design (self-hosted thesis): two wire formats
 Anthropic Messages (``/v1/messages``) and OpenAI Chat Completions
-(``/chat/completions``) — with a ``ai_provider`` Select that picks the
+(``/chat/completions``) with a ``ai_provider`` Select that picks the
 protocol plus a sensible default endpoint/model. ``ai_base_url`` /
 ``ai_model`` / ``ai_api_key`` are all overridable in Optimus Settings, so a
 local model (Ollama / LM Studio / vLLM) can be used and nothing has to leave
 the box.
 
 ``frappe`` is imported lazily inside each function (mirrors ``settings.py``)
-so the pure helpers — ``_build_messages`` and the ``_call_*`` /
-``_http_post`` HTTP layer with ``requests`` mocked — are unit-testable
+so the pure helpers ``_build_messages`` and the ``_call_*`` /
+``_http_post`` HTTP layer with ``requests`` mocked are unit-testable
 without a bench. ``requests`` is bundled by Frappe; it's declared explicitly
 in ``pyproject.toml`` since this module imports it directly.
 """
@@ -42,14 +42,14 @@ class AiFixError(Exception):
 
 # Findings that carry enough code / SQL context for the LLM to reason about
 # a concrete fix. Infra / frontend / "function not invoked" findings are
-# excluded — the LLM would only get a title + a couple of numbers.
+# excluded the LLM would only get a title + a couple of numbers.
 #
 # v0.7.x: Slow Hot Path / Hook Bottleneck / Repeated Hot Frame removed.
 # Their AI suggestions are structurally generic (the LLM only sees a
 # function name + percentage + line range) and the actionable insight
 # already lives on the embedded N+1 / Hot Line / Redundant Call that
 # shares the same chain leaf. Skipping these types saves tokens without
-# losing diagnostic signal — the broader hot-path findings still appear
+# losing diagnostic signal the broader hot-path findings still appear
 # in the Findings section with their smoking-gun + drill-down; they
 # just no longer carry an LLM-rendered "Suggested fix" block.
 AI_ELIGIBLE_FINDING_TYPES: frozenset[str] = frozenset({
@@ -95,7 +95,7 @@ _PROVIDER_DEFAULTS: dict[str, dict[str, Any]] = {
 		"needs_key": False,
 	},
 	# v0.14.x: Aerele-managed AI provider. Architecturally identical to
-	# the Anthropic / OpenAI entries — just a hosted endpoint + an API
+	# the Anthropic / OpenAI entries just a hosted endpoint + an API
 	# key the customer pastes into ``ai_api_key``. The token balance,
 	# pre-call validation, and metering all live on Aerele's separate
 	# Frappe site (the URL below); Optimus is a dumb client. Aerele's
@@ -127,7 +127,7 @@ _SOURCE_LINES_AFTER = 24
 _MAX_SOURCE_WINDOW_LINES = 80
 _MAX_QUERY_CHARS = 2400
 _MAX_USER_CONTENT_CHARS = 18000
-# Low temperature — we want the model to stick to the code it was shown, not
+# Low temperature we want the model to stick to the code it was shown, not
 # get "creative". OpenAI's o-series reasoning models reject a non-default
 # temperature, so it's omitted for those (see `_is_reasoning_model`).
 _TEMPERATURE = 0.1
@@ -138,19 +138,19 @@ _ANTHROPIC_VERSION = "2023-06-01"
 # line, injected into the user message. Keeps the system prompt general and
 # gives the model a strong, type-specific starting point.
 _FINDING_TYPE_HINTS = {
-	"N+1 Query": "A query repeats once per row of an outer loop. Fix: lift it out of the loop and batch — one `frappe.get_all(<DocType>, filters={'name': ('in', names)}, fields=[...])` (or `frappe.db.get_values`) then build a dict keyed by the join column.",
-	"Framework N+1": "Same N+1 pattern, but the loop is inside framework code (frappe/erpnext). Fix: change YOUR calling pattern so the framework isn't invoked per-row — e.g. pass a list of names where the API accepts one, fetch needed fields up front, or avoid `get_doc` in a loop.",
+	"N+1 Query": "A query repeats once per row of an outer loop. Fix: lift it out of the loop and batch one `frappe.get_all(<DocType>, filters={'name': ('in', names)}, fields=[...])` (or `frappe.db.get_values`) then build a dict keyed by the join column.",
+	"Framework N+1": "Same N+1 pattern, but the loop is inside framework code (frappe/erpnext). Fix: change YOUR calling pattern so the framework isn't invoked per-row e.g. pass a list of names where the API accepts one, fetch needed fields up front, or avoid `get_doc` in a loop.",
 	"Slow Query": "A single SQL statement is slow. Fix: add the right index (Frappe way: Customize Form → the field → tick 'Search Index'; raw `ALTER TABLE … ADD INDEX` only if you can't customize), or restructure the WHERE/ORDER BY so an existing index is usable, or reduce the rows touched (tighter filters, fewer columns).",
-	"Missing Index": "A WHERE/JOIN/ORDER BY column has no usable index. Fix: add a Search Index (Customize Form → field → 'Search Index') — prefer a composite index when several columns are filtered together; only fall back to `ALTER TABLE … ADD INDEX (...)` if customization isn't an option.",
-	"Full Table Scan": "EXPLAIN shows `type=ALL` — the whole table is read. Fix: index the filtering column (Search Index), or make the WHERE sargable (no functions on the column, no leading-wildcard LIKE).",
-	"Filesort": "EXPLAIN shows `Using filesort` — MariaDB sorts the result set in memory/on disk. Fix: a composite index ending in the ORDER BY column(s) so the read returns rows already ordered; or, if the sort isn't needed, drop the ORDER BY.",
-	"Temporary Table": "EXPLAIN shows `Using temporary` — usually a GROUP BY / DISTINCT that can't use an index. Fix: a covering composite index on the grouped columns, or pre-aggregate, or drop an unnecessary DISTINCT.",
-	"Low Filter Ratio": "EXPLAIN's `filtered` is low — the index (if any) isn't selective; most examined rows are thrown away. Fix: index a more selective column, add a composite index matching the WHERE, or tighten the filter.",
-	"Redundant Call": "The same `get_doc` / cache lookup / `has_permission` runs many times for the same arguments from one callsite. Fix: hoist it out of the loop, or memoize for the request — stash on `frappe.local` (request-scoped) or `frappe.cache().get_value(key)` / `set_value(key, val, expires_in_sec=…)` for cross-request.",
-	"Slow Hot Path": "A subtree of the call tree dominates the action's wall time. Fix: look at what that function does — fetching data it doesn't need, doing per-row work that could be batched, recomputing something cacheable — and remove/defer/batch it. `frappe.enqueue(...)` if it's work that doesn't need to block the response.",
-	"Hook Bottleneck": "A `doc_events` / `before_*` / `after_*` hook is expensive and runs on every save/submit. Fix: make the hook do less (skip when nothing relevant changed — check `doc.has_value_changed(...)`), or move heavy work to `frappe.enqueue(...)` so it doesn't block the save.",
-	"Repeated Hot Frame": "The same function shows up many times in the sampled stacks — it's called a lot. Fix: reduce call count (batch / cache) or make each call cheaper.",
-	"Hot Line": "A single source line is the dominant time sink inside its function. Fix: optimize that line specifically — hoist invariant work out of a loop, replace an O(n²) pattern, avoid a per-iteration DB/cache hit, or use a set/dict for membership tests.",
+	"Missing Index": "A WHERE/JOIN/ORDER BY column has no usable index. Fix: add a Search Index (Customize Form → field → 'Search Index') prefer a composite index when several columns are filtered together; only fall back to `ALTER TABLE … ADD INDEX (...)` if customization isn't an option.",
+	"Full Table Scan": "EXPLAIN shows `type=ALL`: the whole table is read. Fix: index the filtering column (Search Index), or make the WHERE sargable (no functions on the column, no leading-wildcard LIKE).",
+	"Filesort": "EXPLAIN shows `Using filesort`: MariaDB sorts the result set in memory/on disk. Fix: a composite index ending in the ORDER BY column(s) so the read returns rows already ordered; or, if the sort isn't needed, drop the ORDER BY.",
+	"Temporary Table": "EXPLAIN shows `Using temporary`: usually a GROUP BY / DISTINCT that can't use an index. Fix: a covering composite index on the grouped columns, or pre-aggregate, or drop an unnecessary DISTINCT.",
+	"Low Filter Ratio": "EXPLAIN's `filtered` is low the index (if any) isn't selective; most examined rows are thrown away. Fix: index a more selective column, add a composite index matching the WHERE, or tighten the filter.",
+	"Redundant Call": "The same `get_doc` / cache lookup / `has_permission` runs many times for the same arguments from one callsite. Fix: hoist it out of the loop, or memoize for the request stash on `frappe.local` (request-scoped) or `frappe.cache().get_value(key)` / `set_value(key, val, expires_in_sec=…)` for cross-request.",
+	"Slow Hot Path": "A subtree of the call tree dominates the action's wall time. Fix: look at what that function does fetching data it doesn't need, doing per-row work that could be batched, recomputing something cacheable and remove/defer/batch it. `frappe.enqueue(...)` if it's work that doesn't need to block the response.",
+	"Hook Bottleneck": "A `doc_events` / `before_*` / `after_*` hook is expensive and runs on every save/submit. Fix: make the hook do less (skip when nothing relevant changed check `doc.has_value_changed(...)`), or move heavy work to `frappe.enqueue(...)` so it doesn't block the save.",
+	"Repeated Hot Frame": "The same function shows up many times in the sampled stacks it's called a lot. Fix: reduce call count (batch / cache) or make each call cheaper.",
+	"Hot Line": "A single source line is the dominant time sink inside its function. Fix: optimize that line specifically hoist invariant work out of a loop, replace an O(n²) pattern, avoid a per-iteration DB/cache hit, or use a set/dict for membership tests.",
 }
 
 # Postgres phrasings for the four EXPLAIN-based hints. The rest of
@@ -159,10 +159,10 @@ _FINDING_TYPE_HINTS = {
 # for plan-node wording (Seq Scan / Sort node / HashAggregate). The fix advice
 # is identical.
 _POSTGRES_EXPLAIN_HINTS = {
-	"Full Table Scan": "EXPLAIN shows a `Seq Scan` — the whole table is read. Fix: index the filtering column (Search Index), or make the WHERE sargable (no functions on the column, no leading-wildcard LIKE).",
-	"Filesort": "EXPLAIN shows a `Sort` node — no index provides the required order, so Postgres sorts in memory/on disk. Fix: a composite index ending in the ORDER BY column(s) so the read returns rows already ordered; or, if the sort isn't needed, drop the ORDER BY.",
-	"Temporary Table": "EXPLAIN shows a `HashAggregate` / `Materialize` — usually a GROUP BY / DISTINCT that can't use an index. Fix: a covering composite index on the grouped columns, or pre-aggregate, or drop an unnecessary DISTINCT.",
-	"Low Filter Ratio": "EXPLAIN's row-count estimate shows low selectivity — most examined rows are thrown away. Fix: index a more selective column, add a composite index matching the WHERE, or tighten the filter.",
+	"Full Table Scan": "EXPLAIN shows a `Seq Scan`: the whole table is read. Fix: index the filtering column (Search Index), or make the WHERE sargable (no functions on the column, no leading-wildcard LIKE).",
+	"Filesort": "EXPLAIN shows a `Sort` node no index provides the required order, so Postgres sorts in memory/on disk. Fix: a composite index ending in the ORDER BY column(s) so the read returns rows already ordered; or, if the sort isn't needed, drop the ORDER BY.",
+	"Temporary Table": "EXPLAIN shows a `HashAggregate` / `Materialize`: usually a GROUP BY / DISTINCT that can't use an index. Fix: a covering composite index on the grouped columns, or pre-aggregate, or drop an unnecessary DISTINCT.",
+	"Low Filter Ratio": "EXPLAIN's row-count estimate shows low selectivity most examined rows are thrown away. Fix: index a more selective column, add a composite index matching the WHERE, or tighten the filter.",
 }
 
 
@@ -183,25 +183,25 @@ def _finding_type_hint(ftype):
 _SYSTEM_PROMPT = (
 	"You are a senior Frappe Framework / ERPNext engineer doing a precise code "
 	"review of one finding from a performance profiler. Propose the smallest "
-	"concrete, Frappe-idiomatic change that fixes the ROOT CAUSE — not generic "
+	"concrete, Frappe-idiomatic change that fixes the ROOT CAUSE not generic "
 	"advice, not a rewrite.\n\n"
 
 	"WRITE IDIOMATIC FRAPPE. Use `frappe.get_all` / `frappe.get_list` / "
 	"`frappe.db.get_value` / `frappe.db.get_values` / `frappe.qb` (the query "
-	"builder) — never hand-built SQL strings and never an ORM call inside a "
+	"builder) never hand-built SQL strings and never an ORM call inside a "
 	"loop. Per-request memoization goes on `frappe.local`; cross-request "
 	"caching goes through `frappe.cache().get_value(key)` / "
 	"`set_value(key, value, expires_in_sec=...)`. Background work that needn't "
 	"block the response goes through `frappe.enqueue(...)`. Adding an index "
 	"means: Customize Form → the field → tick **Search Index** (which `bench "
-	"migrate` then creates) — only fall back to a raw `ALTER TABLE ... ADD "
+	"migrate` then creates) only fall back to a raw `ALTER TABLE ... ADD "
 	"INDEX (...)` when customization genuinely isn't an option, and prefer a "
 	"single composite index over several single-column ones when the same "
 	"columns are filtered together.\n\n"
 
 	"NO RAW SQL IN YOUR PROPOSED FIX. `frappe.db.sql(\"SELECT ...\")` / "
 	"`\"INSERT ...\"` / `\"UPDATE ...\"` / `\"DELETE ...\"` / `\"REPLACE ...\"` "
-	"is forbidden in your `+` lines (proposed code) — even when the `before` "
+	"is forbidden in your `+` lines (proposed code) even when the `before` "
 	"code being REPLACED was raw SQL. The replacement MUST use one of the "
 	"framework APIs above: `frappe.get_all` for typical reads / lists; "
 	"`frappe.qb` for joins, aggregations, dynamic conditions or anything the "
@@ -210,48 +210,48 @@ _SYSTEM_PROMPT = (
 	"to a framework call without breaking semantics, say so plainly in "
 	"**Diagnosis** and leave the SQL in place (recommend caching / hoisting / "
 	"adding an index / changing the query shape instead). Narrow exception: "
-	"DDL via raw SQL — `ALTER TABLE ... ADD INDEX ...` / `CREATE INDEX ...` "
-	"— is acceptable when an index recommendation truly can't go through "
+	"DDL via raw SQL `ALTER TABLE ... ADD INDEX ...` / `CREATE INDEX ...` "
+	" is acceptable when an index recommendation truly can't go through "
 	"Customize Form's Search Index toggle.\n\n"
 
-	"GROUND EVERYTHING IN THE CODE YOU WERE SHOWN — DO NOT INVENT CODE. The "
+	"GROUND EVERYTHING IN THE CODE YOU WERE SHOWN DO NOT INVENT CODE. The "
 	"only source you have is what appears under \"Source around the callsite\" "
 	"in the user message (if anything appears there at all). Treat every other "
 	"line of code as unknown to you. Hard rules:\n"
-	"  • If your **Fix** shows a \"before\" snippet — or `-` lines in a "
-	"```diff``` block — every one of those lines MUST be copied VERBATIM from "
+	"  • If your **Fix** shows a \"before\" snippet or `-` lines in a "
+	"```diff``` block every one of those lines MUST be copied VERBATIM from "
 	"the shown source: identical text, and keep its line number. Do NOT "
 	"reconstruct, paraphrase, summarise, or imagine what the code \"probably\" "
 	"looks like. A `for … in …:` loop, a `frappe.get_doc(...)` call, a "
-	"variable name — if you weren't shown it, you don't get to write it as if "
+	"variable name if you weren't shown it, you don't get to write it as if "
 	"you were.\n"
 	"  • If the loop / call / WHERE / line this finding is actually about is "
 	"NOT visible in the shown source (or no source was shown at all), then you "
 	"do NOT have the offending code. In that case: in **Diagnosis** say so "
-	"plainly (\"the offending code isn't in the window I was shown — it's "
+	"plainly (\"the offending code isn't in the window I was shown it's "
 	"likely in `<name>`\"), and in **Fix** give ONLY a short directional "
 	"recommendation, explicitly framed as \"without seeing the code, the likely "
 	"fix is …\". NO before/after snippet, NO diff, NO fabricated code block.\n"
 	"  • Never present a guess as a verified fix. If you're not certain a "
-	"symbol exists, don't use it — or mark it clearly as an assumption.\n"
+	"symbol exists, don't use it or mark it clearly as an assumption.\n"
 	"  • SQL substitution discipline: if your **Fix** replaces a raw SQL "
 	"string with `frappe.get_all` / `frappe.get_list` / `frappe.db.get_value` "
 	"/ `frappe.db.get_values` / `frappe.qb`, the new call MUST be "
-	"semantically equivalent to the SQL it replaces — same table(s), same "
+	"semantically equivalent to the SQL it replaces same table(s), same "
 	"WHERE / JOIN / GROUP BY / ORDER BY / LIMIT, same field list. If the SQL "
 	"had no WHERE clause, the replacement gets no `filters=`. If the SQL had "
 	"`LIMIT N`, the replacement gets `limit=N`. Do NOT invent filters by "
 	"copying a variable that appears elsewhere in the function "
 	"(e.g. `frappe.session.user`), and NEVER synthesise list shapes like "
-	"`[some_var] * N` to fit an `('in', ...)` filter — that is hallucination, "
+	"`[some_var] * N` to fit an `('in', ...)` filter that is hallucination, "
 	"not refactoring. If you cannot preserve semantics, say so plainly in "
 	"**Diagnosis** and leave the SQL as-is (recommend caching / hoisting / "
 	"adding an index instead).\n\n"
 
-	"NEVER suggest indexing Frappe's standard metadata columns — `name`, "
+	"NEVER suggest indexing Frappe's standard metadata columns `name`, "
 	"`idx`, `parent`, `parentfield`, `parenttype`, `creation`, `modified`, "
 	"`modified_by`, `owner`, `docstatus`, `doctype`, `_user_tags`, "
-	"`_comments`, `_assign`, `_liked_by`, `_seen` — nor any of Frappe's "
+	"`_comments`, `_assign`, `_liked_by`, `_seen`: nor any of Frappe's "
 	"framework meta tables (`tabDocType`, `tabDocField`, `tabCustom Field`, "
 	"`tabProperty Setter`, `tabSingles`, `tabSeries`, `tab__global_search`, "
 	"workspace/dashboard config tables, …). Frappe writes the former on every "
@@ -259,34 +259,34 @@ _SYSTEM_PROMPT = (
 	"schema. If the only index you can think of targets one of those, say "
 	"there's no good index-side fix and propose a query-shape change instead.\n\n"
 
-	"OUTPUT — Markdown, exactly these four headings, nothing before or after:\n"
-	"**Diagnosis** — 1-2 sentences: the actual cause, referring to the shown "
+	"OUTPUT Markdown, exactly these four headings, nothing before or after:\n"
+	"**Diagnosis**: 1-2 sentences: the actual cause, referring to the shown "
 	"source by line number when you can (e.g. \"the `frappe.get_doc(...)` on "
-	"line 14 runs once per item — N round-trips\"). If the offending code "
+	"line 14 runs once per item N round-trips\"). If the offending code "
 	"wasn't shown to you, say that here.\n"
-	"**Fix** — the concrete change, using real Frappe APIs. Only if the "
+	"**Fix**: the concrete change, using real Frappe APIs. Only if the "
 	"offending code is in the source you were shown: present it as a unified "
-	"diff in a ```diff fenced block (preferred — it renders with before/after "
+	"diff in a ```diff fenced block (preferred it renders with before/after "
 	"highlighting; `-` lines = the existing code copied verbatim from the "
-	"source above, `+` lines = the replacement). Otherwise: NO snippet/diff — "
+	"source above, `+` lines = the replacement). Otherwise: NO snippet/diff "
 	"just the directional recommendation (\"without seeing the code, the likely "
 	"fix is …\"). For an index, give the Customize Form path AND (only as a "
-	"fallback) the `ALTER TABLE` DDL — that's a config change, not invented "
+	"fallback) the `ALTER TABLE` DDL that's a config change, not invented "
 	"code, so it's fine without a source window.\n"
-	"**Why it works** — 1-2 sentences tying the change to the cause.\n"
-	"**Verify** — 1 line: how to confirm it worked (re-profile the same flow "
-	"and check the relevant number dropped — query count / wall time / EXPLAIN).\n\n"
+	"**Why it works**: 1-2 sentences tying the change to the cause.\n"
+	"**Verify**: 1 line: how to confirm it worked (re-profile the same flow "
+	"and check the relevant number dropped query count / wall time / EXPLAIN).\n\n"
 
-	"Keep the whole answer focused — roughly 150-350 words. Do not restate the "
+	"Keep the whole answer focused roughly 150-350 words. Do not restate the "
 	"finding's title or numbers back at the reader.\n\n"
 
-	"EXAMPLE — this is ONLY to show the heading shape and the verbatim-before "
+	"EXAMPLE this is ONLY to show the heading shape and the verbatim-before "
 	"discipline. It happens to be an N+1; that does NOT mean your finding is an "
-	"N+1 — most aren't. Match YOUR finding type and YOUR shown code, and if "
+	"N+1 most aren't. Match YOUR finding type and YOUR shown code, and if "
 	"your source window doesn't contain a loop like this one, do NOT produce a "
 	"diff like this one:\n"
-	"**Diagnosis** — `frappe.db.get_value('Item', d.item_code, 'stock_uom')` "
-	"on line 12 runs once per row of `self.items` — that's the N+1.\n"
+	"**Diagnosis**: `frappe.db.get_value('Item', d.item_code, 'stock_uom')` "
+	"on line 12 runs once per row of `self.items`: that's the N+1.\n"
 	"**Fix**\n"
 	"```diff\n"
 	"-for d in self.items:\n"
@@ -299,32 +299,32 @@ _SYSTEM_PROMPT = (
 	"+    uom = uoms.get(d.item_code)\n"
 	"+    ...\n"
 	"```\n"
-	"**Why it works** — one batched `frappe.get_all` replaces N per-row "
+	"**Why it works**: one batched `frappe.get_all` replaces N per-row "
 	"queries; the dict lookup is in-memory.\n"
-	"**Verify** — re-record the same Save and confirm the `tabItem` query "
+	"**Verify**: re-record the same Save and confirm the `tabItem` query "
 	"count for this action dropped from ~N to 1.\n\n"
 
-	"SECOND EXAMPLE — same heading shape, this time showing the "
+	"SECOND EXAMPLE same heading shape, this time showing the "
 	"SQL-equivalence rule: a raw SQL with NO WHERE clause maps to a "
 	"`frappe.get_all` with NO `filters=`. Notice the replacement preserves "
-	"exactly the original table, fields, and LIMIT — nothing is invented:\n"
-	"**Diagnosis** — line 207 runs a raw `SELECT name, email FROM `tabUser` "
+	"exactly the original table, fields, and LIMIT nothing is invented:\n"
+	"**Diagnosis**: line 207 runs a raw `SELECT name, email FROM `tabUser` "
 	"LIMIT 50` which can be replaced with the framework-idiomatic call.\n"
 	"**Fix**\n"
 	"```diff\n"
 	"-users = frappe.db.sql(\"SELECT name, email FROM `tabUser` LIMIT 50\", as_dict=True)\n"
 	"+users = frappe.get_all('User', fields=['name', 'email'], limit=50)\n"
 	"```\n"
-	"**Why it works** — `frappe.get_all` is the framework-idiomatic shape; "
+	"**Why it works**: `frappe.get_all` is the framework-idiomatic shape; "
 	"same table, same fields, same LIMIT, so the result set is identical.\n"
-	"**Verify** — diff the row count returned by the new call vs. the old "
+	"**Verify**: diff the row count returned by the new call vs. the old "
 	"`frappe.db.sql` and confirm they match.\n"
 )
 
 
 _STEPS_SYSTEM_PROMPT = (
 	"You are a senior ERPNext / Frappe Framework functional + technical expert "
-	"— you know every standard ERPNext document flow cold and you know exactly "
+	" you know every standard ERPNext document flow cold and you know exactly "
 	"which Desk UI gesture produces which HTTP call. Your job: write the "
 	"\"Steps to Reproduce\" section of a performance report. You're given the "
 	"ordered list of HTTP actions a user performed during a profiling session "
@@ -334,25 +334,25 @@ _STEPS_SYSTEM_PROMPT = (
 	"same flow in the Desk UI.\n\n"
 
 	"WHAT THE RAW CALLS MEAN (use this to decode the trace):\n"
-	"  • `frappe.desk.form.save.savedocs` / `frappe.client.save` / `.insert` — "
+	"  • `frappe.desk.form.save.savedocs` / `frappe.client.save` / `.insert`: "
 	"the user clicked **Save** on a form. If the action is \"Submit\" it was "
 	"the **Submit** button; \"Cancel\" → **Cancel**; a new (`__islocal`) doc → "
 	"they had clicked **New** first. `frappe.client.submit` / `.cancel` / "
 	"`.delete` are the same buttons hit programmatically.\n"
-	"  • `run_doc_method` / `runserverobj` — the user clicked a button on a "
+	"  • `run_doc_method` / `runserverobj`: the user clicked a button on a "
 	"form: a **Create ▸ <Target>** mapping (e.g. Sales Order → Delivery Note / "
 	"Sales Invoice, Purchase Order → Purchase Receipt, Quotation → Sales "
 	"Order), or a custom Action button. The humanized label tells you which "
 	"(\"Make Delivery Note on Sales Order SO-0001\" → they clicked Create ▸ "
 	"Delivery Note on that Sales Order).\n"
-	"  • `frappe.model.workflow.apply_workflow` — the user clicked a **workflow "
+	"  • `frappe.model.workflow.apply_workflow`: the user clicked a **workflow "
 	"action** button (Approve / Reject / Submit for Approval / …).\n"
 	"  • `frappe.desk.search.search_link` / `frappe.client.get_list` from a "
-	"form — the user was typing into a Link field (picking a Customer, Item, "
-	"etc.) — that's part of \"fill in the form\", not its own step.\n"
-	"  • `frappe.desk.reportview.get` / `frappe.client.get_count` — opening a "
-	"**List view** of that DocType. `frappe.desk.query_report.run` — running a "
-	"**Query/Script Report**. `frappe.desk.form.load.getdoc` — **opening an "
+	"form the user was typing into a Link field (picking a Customer, Item, "
+	"etc.) that's part of \"fill in the form\", not its own step.\n"
+	"  • `frappe.desk.reportview.get` / `frappe.client.get_count`: opening a "
+	"**List view** of that DocType. `frappe.desk.query_report.run`: running a "
+	"**Query/Script Report**. `frappe.desk.form.load.getdoc`: **opening an "
 	"existing record**.\n\n"
 
 	"ERPNEXT FLOWS YOU KNOW (recognise these chains and name them):\n"
@@ -373,25 +373,25 @@ _STEPS_SYSTEM_PROMPT = (
 	"Quotation, then make a Delivery Note from it\").\n\n"
 
 	"RULES:\n"
-	"  • Collapse mechanical multi-call sequences into ONE human step — a form "
+	"  • Collapse mechanical multi-call sequences into ONE human step a form "
 	"load + a few Link-field lookups + a save is just \"Create a Sales Invoice "
 	"with a customer and at least one item, then Save\", not five steps. "
 	"Background / polling calls (realtime permission checks, notification "
-	"counts, list counters, asset loads, bare form-metadata loads) are noise — "
+	"counts, list counters, asset loads, bare form-metadata loads) are noise "
 	"ignore them entirely.\n"
 	"  • Use Desk UI language: \"Go to the <DocType> list\", \"Click New\", "
 	"\"Fill in <fields> and Save\", \"Submit it\", \"Open <DocType> <name>\", "
 	"\"Click **Create ▸ <Target>**\", \"Click the <Action> button\", \"Run the "
 	"<Report> report\". Name the DocType whenever you can tell what it was.\n"
-	"  • Do NOT invent data you weren't given — write \"with at least one item "
+	"  • Do NOT invent data you weren't given write \"with at least one item "
 	"row\", not \"with item WIDGET-001\". If an action's purpose genuinely "
 	"isn't clear from the label/cmd, describe it neutrally (\"Call the "
 	"<method> endpoint on <DocType>\") rather than guessing a UI gesture.\n"
-	"  • Keep it tight — usually 2 to 6 steps. Don't restate timings; the "
+	"  • Keep it tight usually 2 to 6 steps. Don't restate timings; the "
 	"report shows those separately. Don't add commentary about performance or "
 	"what's slow.\n\n"
 
-	"OUTPUT — a Markdown ordered list of the steps to reproduce, then a blank "
+	"OUTPUT a Markdown ordered list of the steps to reproduce, then a blank "
 	"line, then ONE sentence beginning \"**Summary:**\" that says what the "
 	"session profiled (e.g. \"**Summary:** creating a Sales Order and then "
 	"making a Delivery Note from it.\"). Nothing before the list, nothing "
@@ -408,38 +408,38 @@ _INDEX_SYSTEM_PROMPT = (
 	"table, the columns the profiled session filtered / joined / ordered on (how "
 	"often, and which appeared together), a few of the actual queries, and the "
 	"table's CURRENT indexes (`SHOW INDEX` output). Recommend the SMALLEST set of "
-	"indexes that actually helps — almost always ONE composite, columns ordered "
+	"indexes that actually helps almost always ONE composite, columns ordered "
 	"equality-then-range-then-ORDER-BY, leftmost = the most selective / always-"
 	"present one.\n\n"
 
 	"RULES:\n"
 	"  • If an existing index already covers a candidate as a leftmost prefix, do "
-	"NOT recommend it — say it's already covered.\n"
+	"NOT recommend it say it's already covered.\n"
 	"  • Never index Frappe's metadata columns (`name`, `creation`, `modified`, "
 	"`modified_by`, `owner`, `parent`, `parentfield`, `parenttype`, `idx`, "
-	"`docstatus`, …) — they're written on every save or already indexed.\n"
+	"`docstatus`, …) they're written on every save or already indexed.\n"
 	"  • Adding an index to a write-hot table (GL Entry, Stock Ledger Entry, Bin, "
 	"Payment Ledger Entry, Serial and Batch Bundle, …) slows every submitted "
-	"document in production — only recommend it if a query that filters this way "
+	"document in production only recommend it if a query that filters this way "
 	"is genuinely slow, and say so.\n"
 	"  • Customize Form ▸ field ▸ Search Index makes only SINGLE-column indexes; a "
 	"composite needs a patch with `frappe.db.add_index('<DocType>', "
 	"['col_a', 'col_b'])`.\n\n"
 
-	"OUTPUT — Markdown, exactly these headings, nothing before or after:\n"
-	"**Recommendation** — the one index to add (e.g. `(against_voucher_type, "
-	"against_voucher_no)` on `GL Entry`), OR \"nothing — the existing indexes "
+	"OUTPUT Markdown, exactly these headings, nothing before or after:\n"
+	"**Recommendation**: the one index to add (e.g. `(against_voucher_type, "
+	"against_voucher_no)` on `GL Entry`), OR \"nothing the existing indexes "
 	"already cover these read patterns\".\n"
-	"**Why** — 1-2 sentences tying it to the queries / explaining the column order.\n"
-	"**How to add** — the `frappe.db.add_index(\"<DocType>\", [\"col_a\", "
+	"**Why**: 1-2 sentences tying it to the queries / explaining the column order.\n"
+	"**How to add**: the `frappe.db.add_index(\"<DocType>\", [\"col_a\", "
 	"\"col_b\"])` patch line (for a single column you may instead say Customize "
 	"Form ▸ field ▸ Search Index). Omit this heading entirely if the "
 	"Recommendation is \"nothing\".\n"
-	"**Skip** — one line per candidate column or combo you're NOT recommending and "
+	"**Skip**: one line per candidate column or combo you're NOT recommending and "
 	"why (already covered by `<index name>` / a Frappe metadata column / not worth "
-	"the write cost). If there's nothing to skip, write \"—\".\n\n"
+	"the write cost). If there's nothing to skip, write \"None\".\n\n"
 
-	"Keep it tight — roughly 120-300 words. Don't restate the table's read/write "
+	"Keep it tight roughly 120-300 words. Don't restate the table's read/write "
 	"numbers back at the reader."
 )
 
@@ -468,7 +468,7 @@ def is_finding_type_excluded(finding_type: str | None) -> bool:
 	safer than a partial-match exclude that would let data through when the
 	operator intended to block it).
 
-	Reads settings via the cached ``get_config()`` reader — adds at most one
+	Reads settings via the cached ``get_config()`` reader adds at most one
 	Redis lookup per call, and that's a single cached hit. Returning False on
 	any read error (no bench, settings cache wedged) is the safe direction:
 	if the operator's intent is to block, the master gates (``ai_enabled``,
@@ -510,9 +510,9 @@ def is_available(section: str | None = None) -> bool:
 
 	When ``section`` is one of ``"findings"`` / ``"indexes"`` / ``"humanize"``,
 	additionally require the matching per-section toggle (``ai_suggest_findings``
-	/ ``ai_suggest_indexes`` / ``ai_humanize_steps``) — turning a section off in
+	/ ``ai_suggest_indexes`` / ``ai_humanize_steps``) turning a section off in
 	Optimus Settings is a hard disable. Fails soft: an unknown ``section`` (or
-	a config attr we couldn't read) doesn't block here — the master
+	a config attr we couldn't read) doesn't block here the master
 	``ai_enabled`` check has already passed."""
 	try:
 		from optimus.settings import get_config
@@ -544,7 +544,7 @@ def suggest_fix(finding: dict) -> dict:
 	that the caller gathered around the callsite.
 
 	Returns ``{"suggestion": <markdown>, "model": str, "provider": str,
-	"generated_at": <iso>, "source_available": bool}`` — ``source_available``
+	"generated_at": <iso>, "source_available": bool}``: ``source_available``
 	is ``False`` when the LLM got neither a source window nor a SQL statement
 	(only the finding's title + numbers), so the UI can mark the result as
 	directional rather than a verified code fix. Raises ``AiFixError``
@@ -554,24 +554,24 @@ def suggest_fix(finding: dict) -> dict:
 	v0.9.0: ``ai_excluded_finding_types`` is consulted first. When the
 	finding's type is on the operator's exclusion list, this returns
 	immediately with ``AiFixError("excluded by ai_excluded_finding_types")``
-	— the payload is never built and no request leaves the host.
+	the payload is never built and no request leaves the host.
 	"""
 	if is_finding_type_excluded(finding.get("finding_type")):
 		raise AiFixError("excluded by ai_excluded_finding_types")
 	provider = _resolve_provider()
 	if not provider.get("model"):
 		raise AiFixError(
-			"No AI model is configured — set 'Model' under Optimus Settings ▸ "
+			"No AI model is configured set 'Model' under Optimus Settings ▸ "
 			"AI Fix Suggestions."
 		)
 	if not provider.get("base_url"):
 		raise AiFixError(
-			"No AI base URL is configured — set 'Base URL' under Profiler "
+			"No AI base URL is configured set 'Base URL' under Profiler "
 			"Settings ▸ AI Fix Suggestions."
 		)
 	if provider.get("needs_key") and not provider.get("api_key"):
 		raise AiFixError(
-			"No API key is configured for this AI provider — set it under "
+			"No API key is configured for this AI provider set it under "
 			"Optimus Settings ▸ AI Fix Suggestions."
 		)
 	system, messages = _build_messages(finding)
@@ -615,7 +615,7 @@ def humanize_steps(
 ) -> str:
 	"""Ask the configured LLM to turn the recorded actions into a friendly
 	"Steps to Reproduce" narrative (Markdown). ``actions`` is a list of
-	``{label, cmd, path, method, doctype, duration_ms}`` dicts (best-effort —
+	``{label, cmd, path, method, doctype, duration_ms}`` dicts (best-effort
 	missing keys are fine). Raises ``AiFixError`` on a config / network
 	problem or an empty response."""
 	if not actions:
@@ -623,7 +623,7 @@ def humanize_steps(
 	provider = _resolve_provider()
 	if not provider.get("model") or not provider.get("base_url"):
 		raise AiFixError(
-			"AI is not fully configured — set the provider, model and base URL "
+			"AI is not fully configured set the provider, model and base URL "
 			"under Optimus Settings ▸ AI Fix Suggestions."
 		)
 	if provider.get("needs_key") and not provider.get("api_key"):
@@ -660,7 +660,7 @@ def suggest_index(table_payload: dict) -> dict:
 	provider = _resolve_provider()
 	if not provider.get("model") or not provider.get("base_url"):
 		raise AiFixError(
-			"AI is not fully configured — set the provider, model and base URL "
+			"AI is not fully configured set the provider, model and base URL "
 			"under Optimus Settings ▸ AI Fix Suggestions."
 		)
 	if provider.get("needs_key") and not provider.get("api_key"):
@@ -682,7 +682,7 @@ def suggest_index(table_payload: dict) -> dict:
 	if not text:
 		raise AiFixError("The AI provider returned an empty response.")
 	# Same guardrail as suggest_fix: if the model recommended indexing a Frappe
-	# metadata column, append a correction note. Plus the raw-SQL guardrail —
+	# metadata column, append a correction note. Plus the raw-SQL guardrail
 	# the index-suggestion path doesn't usually emit code, but a model can
 	# still volunteer a ``frappe.db.sql("ALTER ...")`` fallback that should
 	# be flagged (DDL verbs are excluded from the detector anyway, so this
@@ -701,7 +701,7 @@ def suggest_index(table_payload: dict) -> dict:
 
 
 def _had_concrete_context(finding: dict) -> bool:
-	"""True when the LLM was given something concrete to reason about — a
+	"""True when the LLM was given something concrete to reason about a
 	source window / snippet, or a SQL statement. ``False`` means it only had
 	the finding's title + numbers, so the suggestion is necessarily
 	directional (and the UI should say so)."""
@@ -716,7 +716,7 @@ def _had_concrete_context(finding: dict) -> bool:
 
 def test_connection() -> dict:
 	"""Send a tiny probe to the configured provider. Returns
-	``{"ok": bool, "message": str, "model": str}`` — never raises (the
+	``{"ok": bool, "message": str, "model": str}``: never raises (the
 	failure detail goes in ``message``)."""
 	try:
 		provider = _resolve_provider()
@@ -750,7 +750,7 @@ def test_connection() -> dict:
 	except AiFixError as e:
 		return {"ok": False, "message": str(e), "model": provider["model"]}
 
-	# A connectivity probe is a Settings test, not session work — show its
+	# A connectivity probe is a Settings test, not session work show its
 	# count here, but it does NOT roll into a session's token total.
 	_toks = usage.get("total_tokens") or 0
 	return {
@@ -774,7 +774,7 @@ def _resolve_provider() -> dict:
 	required base_url/model.
 
 	The API key is fetched via ``frappe.utils.password.get_decrypted_password``
-	on every call — it is never cached in ``OptimusConfig`` and never
+	on every call it is never cached in ``OptimusConfig`` and never
 	returned to the client.
 	"""
 	from optimus.settings import get_config
@@ -785,7 +785,7 @@ def _resolve_provider() -> dict:
 
 	defaults = _PROVIDER_DEFAULTS[name]
 	# The Base URL override applies ONLY to bring-your-own providers (those
-	# with no built-in default endpoint — i.e. "OpenAI-compatible"). Hosted
+	# with no built-in default endpoint i.e. "OpenAI-compatible"). Hosted
 	# providers (Anthropic / OpenAI / Kimi) ALWAYS use their default: the
 	# Settings field is hidden for them, so a previously-stored value must not
 	# silently override and route calls to a dead host (that stale-value trap
@@ -796,7 +796,7 @@ def _resolve_provider() -> dict:
 		base_url = (getattr(cfg, "ai_base_url", "") or "").strip().rstrip("/")
 	model = (getattr(cfg, "ai_model", "") or "").strip() or defaults["model"]
 
-	# Always fetch the key (harmless if unset) — some OpenAI-compatible
+	# Always fetch the key (harmless if unset) some OpenAI-compatible
 	# routers (OpenRouter, Together, Groq) need one even though local
 	# endpoints don't, so we let the user set it for any provider.
 	api_key = ""
@@ -820,17 +820,17 @@ def _resolve_provider() -> dict:
 
 
 # ---------------------------------------------------------------------------
-# Output guardrail — never let an "index a metadata column" recommendation
+# Output guardrail never let an "index a metadata column" recommendation
 # through, even if the model ignored the system prompt. Frappe metadata
 # columns (`name`, `idx`, `parent`, `creation`, `modified`, `docstatus`, …)
 # are written on every save (or already indexed), so indexing them is a
-# write-cost trap; the profiler never suggests it anywhere — including here.
+# write-cost trap; the profiler never suggests it anywhere including here.
 # ---------------------------------------------------------------------------
 
 # "add an index on <col>", "Search Index … <col>", "index the <col> column",
-# "ADD INDEX (`<col>`)" — captures the column token that follows the
+# "ADD INDEX (`<col>`)" captures the column token that follows the
 # index-action phrase, skipping connector words ("on", "the", …). The hit is
-# discarded if it's negated ("do NOT index …") — see `_NEGATION_RE`.
+# discarded if it's negated ("do NOT index …") see `_NEGATION_RE`.
 _INDEX_ADVICE_RE = re.compile(
 	r"(?:add\s+(?:an?\s+)?index|search\s+index|index)\b"
 	r"[\s(]*(?:(?:on|the|a|an|for|to|of|column|field)\s+)*"
@@ -842,7 +842,7 @@ _NEGATION_RE = re.compile(r"(?:not|n['’]t|never|avoid|without|no need to|don['
 
 def _metadata_columns() -> frozenset:
 	"""The Frappe standard-metadata column set, from the analyzer base
-	module (single source of truth). Empty set if unimportable — the
+	module (single source of truth). Empty set if unimportable the
 	guardrail then simply does nothing."""
 	try:
 		from optimus.analyzers.base import FRAPPE_METADATA_COLUMNS
@@ -859,19 +859,19 @@ def _metadata_columns() -> frozenset:
 # ``frappe.db.get_value`` / ``frappe.db.get_values`` / ``frappe.qb`` as the
 # idiomatic alternatives. The few-shot examples reinforce that. But a
 # sufficiently confident model still occasionally leaks raw SQL into its
-# proposed fix code — and the system-prompt instruction alone is a soft
+# proposed fix code and the system-prompt instruction alone is a soft
 # nudge with no backstop.
 #
 # This guardrail mirrors ``_flag_metadata_column_index_advice``: detect the
 # anti-pattern in the LLM's output, append a clearly-marked profiler note,
-# never rewrite (markdown is fragile). The note is advisory, not blocking —
+# never rewrite (markdown is fragile). The note is advisory, not blocking
 # a fix that legitimately needs raw SQL (DDL, vendor-specific MariaDB
 # extensions) can be acted on with the operator's judgement.
 
 # ``frappe.db.sql(…, "SELECT …"…)``. The literal can be a regular string,
 # f-string, or raw string; the verb that follows is case-insensitive. The
 # verbs covered are the ones a model is most likely to suggest as a "fix"
-# (DDL like CREATE / ALTER is intentionally outside the scope — those are
+# (DDL like CREATE / ALTER is intentionally outside the scope those are
 # legit administrative paths and the prompt already rarely produces them).
 _RAW_SQL_IN_FIX_RE = re.compile(
 	# ``[a-z]{0,2}`` allows any string prefix (f / r / b / rb / br / fr …);
@@ -899,7 +899,7 @@ def _flag_raw_sql_in_fix(text: str) -> str:
 	"""If the model's proposed fix contains a raw ``frappe.db.sql(...)`` call
 	with a SELECT / INSERT / UPDATE / DELETE / REPLACE literal, append a
 	correction note. Same contract as ``_flag_metadata_column_index_advice``
-	— returns the text unchanged when the fix is clean, otherwise with the
+	returns the text unchanged when the fix is clean, otherwise with the
 	profiler note appended.
 
 	Detection scope:
@@ -907,10 +907,10 @@ def _flag_raw_sql_in_fix(text: str) -> str:
 	* Only matches inside markdown code-fenced blocks (``\\`\\`\\`diff`` /
 	  ``\\`\\`\\`python`` / ``\\`\\`\\`py`` / un-tagged fences). Prose
 	  mentions like "instead of ``frappe.db.sql`` use ..." are
-	  intentionally EXCLUDED — the guardrail must not fire on the LLM's
+	  intentionally EXCLUDED the guardrail must not fire on the LLM's
 	  own commentary.
 	* Inside a ``diff`` block, only ADDITION lines (starting with ``+``
-	  but not ``+++`` — the diff file-header) count as "the proposed
+	  but not ``+++``: the diff file-header) count as "the proposed
 	  fix". REMOVAL lines (``-``) are the BEFORE code being replaced;
 	  flagging them would invert the guardrail (the model is rightly
 	  showing the bad pattern being removed).
@@ -921,9 +921,9 @@ def _flag_raw_sql_in_fix(text: str) -> str:
 
 	* Only detects ``frappe.db.sql``. Other invocations
 	  (``frappe.db.multisql``, future Frappe SQL helpers) are not
-	  detected — widen the pattern in a follow-up if production
+	  detected widen the pattern in a follow-up if production
 	  surfaces them.
-	* DDL verbs (CREATE / ALTER / DROP) are excluded — DDL via raw SQL
+	* DDL verbs (CREATE / ALTER / DROP) are excluded DDL via raw SQL
 	  is sometimes the right answer (e.g. ``ADD INDEX`` when the
 	  Customize-Form route isn't an option).
 	"""
@@ -959,7 +959,7 @@ def _flag_raw_sql_in_fix(text: str) -> str:
 
 		# Two detectors: the verb-anchored one (single-line ``frappe.db.sql("SELECT
 		# …")``) and a multi-line OPENER (``frappe.db.sql("""`` with the SQL verb
-		# on a following line — the common multi-line shape this line-by-line scan
+		# on a following line the common multi-line shape this line-by-line scan
 		# would otherwise miss).
 		if _RAW_SQL_IN_FIX_RE.search(line_to_scan) or _RAW_SQL_OPENER_RE.search(line_to_scan):
 			flagged = True
@@ -975,13 +975,13 @@ def _flag_raw_sql_in_fix(text: str) -> str:
 		"`frappe.db.get_values` (Document API for typical reads) or "
 		"`frappe.qb` (query builder for joins / aggregations / dynamic "
 		"conditions). Use raw SQL only when none of those API surfaces fit "
-		"(rare — e.g. DDL, vendor-specific MariaDB extensions)."
+		"(rare e.g. DDL, vendor-specific MariaDB extensions)."
 	)
 
 
 def _flag_metadata_column_index_advice(text: str) -> str:
 	"""If the model recommended indexing a Frappe metadata column, append a
-	correction note. We don't rewrite the body (markdown is fragile) — we
+	correction note. We don't rewrite the body (markdown is fragile) we
 	add a clearly-marked profiler note so the reader doesn't act on it."""
 	meta = _metadata_columns()
 	if not meta or not text:
@@ -991,7 +991,7 @@ def _flag_metadata_column_index_advice(text: str) -> str:
 		col = m.group("col").strip("`'\"() ").lower()
 		if col not in meta or col in hits:
 			continue
-		# Skip negated mentions ("do NOT index `modified`") — no correction needed.
+		# Skip negated mentions ("do NOT index `modified`") no correction needed.
 		if _NEGATION_RE.search(text[max(0, m.start() - 16):m.start()]):
 			continue
 		hits.append(col)
@@ -1002,8 +1002,8 @@ def _flag_metadata_column_index_advice(text: str) -> str:
 	return text.rstrip() + (
 		"\n\n> **Profiler note:** disregard any suggestion above to index "
 		+ cols
-		+ (" — these are Frappe framework-managed columns" if plural
-		   else " — that is a Frappe framework-managed column")
+		+ (" these are Frappe framework-managed columns" if plural
+		   else " that is a Frappe framework-managed column")
 		+ " (Frappe writes "
 		+ ("them" if plural else "it")
 		+ " on every save, or "
@@ -1028,7 +1028,7 @@ def _build_steps_messages(
 	actions: list[dict], session_title: str | None
 ) -> tuple[str, list[dict]]:
 	"""Build ``(system_prompt, [user_message])`` for the Steps-to-Reproduce
-	humanizer. Pure — no Frappe, no I/O. ``actions`` items use the keys
+	humanizer. Pure no Frappe, no I/O. ``actions`` items use the keys
 	``label`` / ``cmd`` / ``path`` / ``method`` / ``doctype`` /
 	``duration_ms`` (all optional)."""
 	lines: list[str] = []
@@ -1069,7 +1069,7 @@ def _build_steps_messages(
 
 def _build_index_messages(payload: dict) -> tuple[str, list[dict]]:
 	"""Build ``(system_prompt, [user_message])`` for the per-table index
-	suggestion. Pure — no Frappe, no I/O. See ``suggest_index`` for the
+	suggestion. Pure no Frappe, no I/O. See ``suggest_index`` for the
 	``payload`` shape."""
 	t = payload.get("table") or "?"
 	dt = (payload.get("doctype") or "").strip()
@@ -1080,7 +1080,7 @@ def _build_index_messages(payload: dict) -> tuple[str, list[dict]]:
 	parts.append(f"This profiling session: {rc} read(s), {wc} write(s) on this table.")
 	if payload.get("is_write_hot"):
 		parts.append(
-			"This is a write-hot core table — in production it takes many "
+			"This is a write-hot core table in production it takes many "
 			"INSERT/UPDATE rows per submitted document."
 		)
 	rec = payload.get("recommended_index") or {}
@@ -1088,14 +1088,14 @@ def _build_index_messages(payload: dict) -> tuple[str, list[dict]]:
 		parts.append(
 			"Profiler's heuristic pick (most-used filter combination): ("
 			+ ", ".join(rec["columns"])
-			+ f") — those columns were filtered together in {int(rec.get('together_count') or 0)} of {rc} read(s)."
+			+ f") those columns were filtered together in {int(rec.get('together_count') or 0)} of {rc} read(s)."
 		)
 	cands = payload.get("candidates") or []
 	if cands:
 		parts.append(
-			"Columns this session filtered / joined / ordered on (column — clauses — times):\n"
+			"Columns this session filtered / joined / ordered on (column clauses times):\n"
 			+ "\n".join(
-				f"  - {c.get('column')} — {', '.join(c.get('sources') or [])} — {int(c.get('hits') or 0)}×"
+				f"  - {c.get('column')} {', '.join(c.get('sources') or [])} {int(c.get('hits') or 0)}×"
 				for c in cands
 			)
 		)
@@ -1108,13 +1108,13 @@ def _build_index_messages(payload: dict) -> tuple[str, list[dict]]:
 			"CURRENT indexes on this table (from `SHOW INDEX`):\n"
 			+ "\n".join(
 				f"  - {i.get('name')}: (" + ", ".join(i.get("columns") or []) + ")"
-				+ (" — UNIQUE" if i.get("unique") else "")
+				+ (" UNIQUE" if i.get("unique") else "")
 				for i in ex
 			)
 		)
 	else:
 		parts.append(
-			f"CURRENT indexes on this table: not available — be cautious about "
+			f"CURRENT indexes on this table: not available be cautious about "
 			f"redundancy; the operator should run `SHOW INDEX FROM `{t}`` to check."
 		)
 	sq = payload.get("sample_queries") or []
@@ -1128,13 +1128,13 @@ def _build_index_messages(payload: dict) -> tuple[str, list[dict]]:
 def _build_messages(finding: dict) -> tuple[str, list[dict]]:
 	"""Build ``(system_prompt, [user_message])`` from a finding dict.
 
-	Pure — no Frappe, no I/O. ``finding`` keys used: ``finding_type``,
+	Pure no Frappe, no I/O. ``finding`` keys used: ``finding_type``,
 	``severity``, ``title``, ``customer_description``, ``estimated_impact_ms``,
 	``affected_count``, ``technical_detail`` (``callsite``, ``function``,
 	``cumulative_ms``, ``action_wall_time_ms``, ``normalized_query``,
 	``suggested_ddl``, ``explain_row``, ``fix_hint``, ``validation_note``,
 	``example_queries``), ``source_window`` (``[{lineno, content, is_target}]``),
-	and ``phase2_hotline`` (``{lineno, content, total_ms, hits}`` — the hottest
+	and ``phase2_hotline`` (``{lineno, content, total_ms, hits}``: the hottest
 	line from a Phase-2 line-profile pass over the finding's function).
 	"""
 	detail = finding.get("technical_detail") or {}
@@ -1161,7 +1161,7 @@ def _build_messages(finding: dict) -> tuple[str, list[dict]]:
 	if had_callsite:
 		fn = f" ({callsite['function']})" if callsite.get("function") else ""
 		parts.append(
-			f"Callsite (the closest non-framework frame to the cost — the "
+			f"Callsite (the closest non-framework frame to the cost the "
 			f"offending loop/call may be in a function this points into, not "
 			f"necessarily AT this line): {callsite['filename']}:{callsite['lineno']}{fn}"
 		)
@@ -1176,12 +1176,12 @@ def _build_messages(finding: dict) -> tuple[str, list[dict]]:
 		share = ""
 		try:
 			if wall_ms:
-				share = f" — {round(float(cum_ms) / float(wall_ms) * 100)}% of this action's {float(wall_ms):.0f}ms wall time"
+				share = f" {round(float(cum_ms) / float(wall_ms) * 100)}% of this action's {float(wall_ms):.0f}ms wall time"
 		except (TypeError, ValueError, ZeroDivisionError):
 			share = ""
 		parts.append(
 			f"Hot function (the call-tree subtree that dominates this action): "
-			f"`{hot_fn}` — ~{float(cum_ms):.0f}ms{share}. Its source is below; "
+			f"`{hot_fn}`: ~{float(cum_ms):.0f}ms{share}. Its source is below; "
 			"point at the specific lines/loop/call inside it that cost the time."
 		)
 
@@ -1192,17 +1192,17 @@ def _build_messages(finding: dict) -> tuple[str, list[dict]]:
 			marker = ">> " if sl.get("is_target") else "   "
 			lines_out.append(f"{marker}{sl.get('lineno')}: {sl.get('content', '')}")
 		parts.append(
-			"Source around the callsite — THIS IS THE ONLY CODE YOU HAVE; any "
+			"Source around the callsite THIS IS THE ONLY CODE YOU HAVE; any "
 			"\"before\" snippet / diff `-` line in your answer must be copied "
 			"verbatim from here, with its line number. `>>` marks the callsite "
-			"line. This is a window, not necessarily the whole function — if the "
+			"line. This is a window, not necessarily the whole function if the "
 			"loop/call this finding is about isn't in these lines, say so and "
 			"give a directional fix only (no diff):\n```python\n"
 			+ "\n".join(lines_out) + "\n```"
 		)
 	elif had_callsite:
 		parts.append(
-			"Source around the callsite: NOT AVAILABLE — the profiler couldn't "
+			"Source around the callsite: NOT AVAILABLE the profiler couldn't "
 			"read this file, so you have NO source code for this finding. Do not "
 			"write a before/after snippet or a diff (you'd be inventing the "
 			"\"before\"). Give a short directional fix only, framed as \"without "
@@ -1217,7 +1217,7 @@ def _build_messages(finding: dict) -> tuple[str, list[dict]]:
 		parts.append(
 			f"Line-profile (Phase 2) over this function found its hottest line is "
 			f"line {hot['lineno']}"
-			+ (f" — `{hl_content}`" if hl_content else "")
+			+ (f" `{hl_content}`" if hl_content else "")
 			+ (f" ({float(hl_ms):.0f}ms" + (f" over {int(hl_hits)} call(s)" if hl_hits else "") + ")"
 			   if hl_ms else "")
 			+ ". Start your fix there."
@@ -1245,7 +1245,7 @@ def _build_messages(finding: dict) -> tuple[str, list[dict]]:
 	return _SYSTEM_PROMPT, [{"role": "user", "content": content}]
 
 
-_REASONING_MODEL_RE = re.compile(r"^o[0-9]")  # OpenAI o1/o3/o4… — reject `temperature`
+_REASONING_MODEL_RE = re.compile(r"^o[0-9]")  # OpenAI o1/o3/o4… reject `temperature`
 
 
 def _is_reasoning_model(model: str) -> bool:
@@ -1258,7 +1258,7 @@ def _is_reasoning_model(model: str) -> bool:
 
 def _log_http_error(provider: str, where: str, status: int | None, detail: str = "") -> None:
 	"""Best-effort error log. NEVER includes the prompt, the source code, or
-	the API key — only the provider name, the call site, and the HTTP
+	the API key only the provider name, the call site, and the HTTP
 	status."""
 	try:
 		import frappe
@@ -1287,34 +1287,34 @@ def _http_post(url: str, headers: dict, body: dict, *, provider: str, where: str
 	status = resp.status_code
 	if status in (401, 403):
 		_log_http_error(provider, where, status)
-		raise AiFixError("The AI provider rejected the API key — check it in Optimus Settings.")
+		raise AiFixError("The AI provider rejected the API key check it in Optimus Settings.")
 	if status == 404:
-		# Almost always a wrong Base URL — the path segment is missing.
+		# Almost always a wrong Base URL the path segment is missing.
 		# OpenAI-compatible servers (Ollama, LM Studio, vLLM, OpenRouter,
 		# Together, Groq) expose chat completions under `/v1`, so the Base
 		# URL has to include it.
 		_log_http_error(provider, where, status, f"url={url}")
 		hint = (
-			" OpenAI-compatible endpoints serve this under '/v1' — set the Base URL to e.g. "
+			" OpenAI-compatible endpoints serve this under '/v1' set the Base URL to e.g. "
 			"http://localhost:11434/v1 (Ollama), http://localhost:1234/v1 (LM Studio)."
 			if provider == "openai" else ""
 		)
 		raise AiFixError(
-			f"The AI provider returned 404 (Not Found) for {url} — the Base URL in "
+			f"The AI provider returned 404 (Not Found) for {url} the Base URL in "
 			f"Optimus Settings is probably missing a path segment.{hint}"
 		)
 	if status == 429:
 		_log_http_error(provider, where, status)
-		raise AiFixError("The AI provider is rate-limiting requests — try again shortly.")
+		raise AiFixError("The AI provider is rate-limiting requests try again shortly.")
 	if status >= 400:
 		_log_http_error(provider, where, status)
-		# Surface the response body's error text if the provider gave one —
+		# Surface the response body's error text if the provider gave one
 		# helpful for "model not found", "context too long", etc. Capped.
 		detail = ""
 		try:
 			body_text = (resp.text or "").strip()
 			if body_text:
-				detail = " — " + body_text[:300]
+				detail = ": " + body_text[:300]
 		except Exception:
 			detail = ""
 		raise AiFixError(f"The AI provider returned an error (HTTP {status}){detail}")
@@ -1374,7 +1374,7 @@ def _aerele_call_metadata(provider, finding_type=None) -> dict | None:
 	billing portal can attribute each AI call to the originating Optimus
 	Session (for its per-call usage ledger + a per-session spend breakdown).
 
-	Only the **Aerele** provider consumes this — other providers (OpenAI,
+	Only the **Aerele** provider consumes this other providers (OpenAI,
 	Anthropic) get ``None`` so we never send unknown body fields that they
 	might reject. The active session uuid is the one the caller marked on
 	``frappe.local._optimus_spend_session`` (the same hook that powers
@@ -1460,7 +1460,7 @@ def _call_openai_chat(
 	except AiFixError as e:
 		# Some reasoning models reject a non-default `temperature` with HTTP
 		# 400. OpenAI o-series are pre-filtered by `_is_reasoning_model`, but
-		# others — e.g. Moonshot/Kimi "thinking" variants — only allow the
+		# others e.g. Moonshot/Kimi "thinking" variants only allow the
 		# default and say so ("invalid temperature: only 1 is allowed for this
 		# model"). We can't enumerate every such model, so retry once without
 		# `temperature` (letting the model use its own default).

--- a/optimus/analyze.py
+++ b/optimus/analyze.py
@@ -13,7 +13,7 @@ State transitions on the Optimus Session row:
     Stopping  →  Analyzing  →  Failed   (uncaught exception)
 
 The Redis state for the session is cleaned up at the end of a successful
-run — the source recordings are deleted from RECORDER_REQUEST_HASH and the
+run the source recordings are deleted from RECORDER_REQUEST_HASH and the
 profiler:session:* keys are removed. Failed runs do NOT clean up, so a
 developer can manually retry the analyze.
 """
@@ -69,11 +69,11 @@ ANALYZE_PER_ANALYZER_SOFT_CAP_SECONDS = 60
 AI_AUTO_SUGGEST_TIME_BUDGET_SECONDS = 240
 
 # v0.6.0: same toggle also bakes an LLM-vetted index recommendation onto the
-# top N tables in the breakdown — capped tables + its own wall-time budget.
+# top N tables in the breakdown capped tables + its own wall-time budget.
 AI_AUTO_INDEX_MAX_TABLES = 3
 AI_AUTO_INDEX_TIME_BUDGET_SECONDS = 90
 
-# Tighter budget for the same backfill done from api.regenerate_reports —
+# Tighter budget for the same backfill done from api.regenerate_reports
 # that runs synchronously inside a web request, so it must stay well under
 # the gunicorn worker timeout (~120s). Anything not done in this window is
 # left for a re-run of Regenerate Reports (or a full Retry Analyze).
@@ -95,10 +95,10 @@ _BUILTIN_ANALYZERS = [
 	explain_flags.analyze,
 	index_suggestions.analyze,
 	table_breakdown.analyze,
-	call_tree.analyze,        # v0.3.0 — must run after per_action
-	redundant_calls.analyze,  # v0.3.0 — independent
-	infra_pressure.analyze,   # v0.5.0 — reads rec["infra"]
-	frontend_timings.analyze, # v0.5.0 — reads context.frontend_data
+	call_tree.analyze,        # v0.3.0 must run after per_action
+	redundant_calls.analyze,  # v0.3.0 independent
+	infra_pressure.analyze,   # v0.5.0 reads rec["infra"]
+	frontend_timings.analyze, # v0.5.0 reads context.frontend_data
 ]
 
 # Backward-compat alias: the old name is still the public-facing list
@@ -151,7 +151,7 @@ def _get_analyzers() -> list:
 def _publish_progress(percent: float, description: str, session_uuid: str):
 	"""Emit a progress update for the floating widget and form UI.
 
-	Best-effort — never raises. Subscribed to in the floating widget JS
+	Best-effort never raises. Subscribed to in the floating widget JS
 	via frappe.realtime.on("optimus_progress"). Round 2 fix #17.
 	"""
 	try:
@@ -178,21 +178,21 @@ def _publish_session_event(
 	Desk tabs.
 
 	Called from the background analyze job, which runs without a
-	request-scoped user — so we look the user up from the Profiler
+	request-scoped user so we look the user up from the Profiler
 	Session row itself. Mirrors ``api._publish_session_event`` but
 	with doctype-driven user resolution.
 
 	v0.5.1: drives the floating widget state machine without HTTP
 	polling. Events emitted from analyze.run:
 
-	  optimus_session_analyzing  — right after status becomes Analyzing
-	  optimus_session_ready      — success; the widget navigates to the
+	  optimus_session_analyzing right after status becomes Analyzing
+	  optimus_session_ready success; the widget navigates to the
 	                                 report (kept under its original name
 	                                 for backward compat with v0.3.0+
 	                                 subscribers)
-	  optimus_session_failed     — uncaught exception during analyze
+	  optimus_session_failed uncaught exception during analyze
 
-	Best-effort and isolated — a publish failure cannot derail the
+	Best-effort and isolated a publish failure cannot derail the
 	analyze pipeline. Realtime is a UX convenience; the state is always
 	durable on the Optimus Session row.
 	"""
@@ -215,17 +215,17 @@ def _publish_session_event(
 # v0.6.0: hard ceiling on how long analyze waits for the flow's background
 # jobs, regardless of the configured `background_job_wait_seconds`.
 _MAX_BG_JOB_WAIT_SECONDS = 300
-# Throttle between re-enqueue cycles while waiting — keeps a wedged ("deferred"
+# Throttle between re-enqueue cycles while waiting keeps a wedged ("deferred"
 # forever) job from busy-looping our re-enqueues.
 _BG_WAIT_THROTTLE_SECONDS = 2.0
 
 # v0.7.x (M2): global single-flight for the heavy analyze phase. Two analyze
-# jobs running at once roughly DOUBLE peak RAM — the OOM trigger on long flows.
+# jobs running at once roughly DOUBLE peak RAM the OOM trigger on long flows.
 # A best-effort Redis flag (NOT a held lock) lets only one session do the heavy
 # work at a time; others re-enqueue themselves to yield the worker (mirrors the
 # bg-job wait pattern), so a single-worker bench still makes progress.
 # v0.12.0: key centralized in optimus.redis_keys. The constant is kept
-# for code-local readability — every internal use that references the
+# for code-local readability every internal use that references the
 # key still does so via this module-level alias.
 from optimus import redis_keys as _redis_keys
 from optimus import redis_schema as _redis_schema
@@ -242,7 +242,7 @@ _SINGLEFLIGHT_MAX_WAIT_SECONDS = 600
 
 
 def _apply_nice() -> None:
-	"""v0.7.x (M5): best-effort — lower this process's CPU scheduling priority
+	"""v0.7.x (M5): best-effort lower this process's CPU scheduling priority
 	so a heavy analyze yields the CPU to live web traffic. A *positive* nice
 	increment never requires privilege. No-op when configured to 0 or on a
 	platform without ``os.nice``. CPU-politeness only, not a memory lever.
@@ -263,7 +263,7 @@ def _apply_nice() -> None:
 
 def _touch_singleflight(session_uuid: str) -> None:
 	"""(Re)assert ownership of the single-flight flag and refresh its TTL.
-	Best-effort — a cache hiccup must never fail analyze."""
+	Best-effort a cache hiccup must never fail analyze."""
 	try:
 		frappe.cache.set_value(
 			_SINGLEFLIGHT_KEY, session_uuid, expires_in_sec=_SINGLEFLIGHT_TTL_SECONDS
@@ -276,7 +276,7 @@ def is_singleflight_holder(session_uuid: str) -> bool:
 	"""True iff ``session_uuid`` currently holds the single-flight flag. The flag
 	is heartbeated throughout analyze (the analyzer loop + AI phases), so its
 	presence is a reliable liveness signal. The janitor consults this before
-	failing a long-running Analyzing row — the heartbeat is Redis-only (no DB
+	failing a long-running Analyzing row the heartbeat is Redis-only (no DB
 	write mid-analyze), so the row's ``modified`` can't be used for liveness."""
 	try:
 		return frappe.cache.get_value(_SINGLEFLIGHT_KEY) == session_uuid
@@ -285,7 +285,7 @@ def is_singleflight_holder(session_uuid: str) -> bool:
 
 
 def _release_singleflight(session_uuid: str) -> None:
-	"""Release the flag, but only if we still hold it (compare-then-delete) —
+	"""Release the flag, but only if we still hold it (compare-then-delete)
 	a TTL-expired-then-reacquired flag belonging to another session must not be
 	clobbered. Best-effort."""
 	try:
@@ -299,18 +299,18 @@ def _acquire_singleflight(session_uuid: str, docname: str, deadline) -> bool:
 	"""Global single-flight gate for the heavy (memory-hungry) analyze phase.
 
 	Returns:
-	  * ``True``  — proceed with analysis. Either we acquired the flag, or
+	  * ``True`` proceed with analysis. Either we acquired the flag, or
 	    single-flight doesn't apply (inline path / disabled), or we waited past
 	    the deadline and degrade to the pre-M2 behavior rather than strand.
-	  * ``False`` — another session holds the flag; we re-enqueued ourselves
+	  * ``False``: another session holds the flag; we re-enqueued ourselves
 	    (anonymously, carrying ``_singleflight_deadline``) to yield the worker.
 	    The caller must ``return`` now.
 
 	Mirrors ``_bg_wait_for_pending_jobs``: re-enqueue + yield, never a held
 	lock. Skipped when the scheduler is disabled (analyze runs inline in a web
-	request — there's no worker to run our re-enqueued self, and inline peak is
+	request there's no worker to run our re-enqueued self, and inline peak is
 	already bounded by ``optimus_inline_analyze_limit``)."""
-	# Inline path: no worker to yield to — proceed.
+	# Inline path: no worker to yield to proceed.
 	try:
 		if is_scheduler_disabled():
 			return True
@@ -328,10 +328,10 @@ def _acquire_singleflight(session_uuid: str, docname: str, deadline) -> bool:
 	try:
 		holder = frappe.cache.get_value(_SINGLEFLIGHT_KEY)
 	except Exception:
-		return True  # cache unavailable — degrade to pre-M2 behavior
+		return True  # cache unavailable degrade to pre-M2 behavior
 
 	if not holder or holder == session_uuid:
-		# Free, or already ours (our own self-re-enqueue / heartbeat) — take it.
+		# Free, or already ours (our own self-re-enqueue / heartbeat) take it.
 		_touch_singleflight(session_uuid)
 		return True
 
@@ -339,7 +339,7 @@ def _acquire_singleflight(session_uuid: str, docname: str, deadline) -> bool:
 	if deadline is None:
 		deadline = time.time() + max_wait
 	if time.time() >= deadline:
-		return True  # waited long enough — proceed rather than strand
+		return True  # waited long enough proceed rather than strand
 
 	# Keep the UI honest, throttle, and re-enqueue ourselves to yield the worker.
 	try:
@@ -358,7 +358,7 @@ def _acquire_singleflight(session_uuid: str, docname: str, deadline) -> bool:
 		)
 	except Exception:
 		frappe.log_error(title="optimus single-flight re-enqueue")
-		return True  # couldn't re-enqueue — just proceed
+		return True  # couldn't re-enqueue just proceed
 	return False
 
 
@@ -378,7 +378,7 @@ def _rq_job_active(job_id: str) -> bool:
 
 
 def _short_exc(exc_info) -> str | None:
-	"""Last non-empty line of an RQ ``exc_info`` traceback, truncated — the
+	"""Last non-empty line of an RQ ``exc_info`` traceback, truncated the
 	one-liner that names the exception (e.g. ``ValueError: bad doc_name``)."""
 	if not exc_info:
 		return None
@@ -389,7 +389,7 @@ def _short_exc(exc_info) -> str | None:
 def _rq_dt_to_db(dt):
 	"""RQ exposes ``started_at`` / ``ended_at`` as timezone-aware UTC datetimes;
 	``str()`` of one yields ``'...+00:00'`` and MariaDB's DATETIME column rejects
-	the tz offset (err 1292 — it crashed the whole report persist). Convert to
+	the tz offset (err 1292 it crashed the whole report persist). Convert to
 	the site's system timezone and format naive (matching ``session.record_job``'s
 	``enqueued_at``), so it stores cleanly and reads consistently. Falls back to a
 	tz-stripped string if the frappe context can't resolve the system timezone."""
@@ -429,7 +429,7 @@ def _db_datetime_str(val):
 def _capture_job_terminal_status(session_uuid: str, job_id: str) -> None:
 	"""Read a now-inactive RQ job's terminal status + timing and record it on
 	the session's job-meta hash, so analyze can persist it (Completed / Failed /
-	Timeout / Stopped). Best-effort — never blocks the wait."""
+	Timeout / Stopped). Best-effort never blocks the wait."""
 	try:
 		from frappe.utils.background_jobs import get_redis_conn
 		from rq.job import Job
@@ -441,13 +441,13 @@ def _capture_job_terminal_status(session_uuid: str, job_id: str) -> None:
 			status, error = "Completed", None
 		elif rq_status == "failed":
 			# An RQ JobTimeoutException in the traceback means the worker killed
-			# it for exceeding its timeout — report that distinctly.
+			# it for exceeding its timeout report that distinctly.
 			status = "Timeout" if "JobTimeoutException" in exc else "Failed"
 			error = _short_exc(exc)
 		elif rq_status in ("stopped", "canceled"):
 			status, error = "Stopped", _short_exc(exc)
 		else:
-			return  # still active — leave for the running-mark path
+			return  # still active leave for the running-mark path
 		started = getattr(job, "started_at", None)
 		ended = getattr(job, "ended_at", None)
 		duration_ms = None
@@ -470,7 +470,7 @@ def _capture_job_terminal_status(session_uuid: str, job_id: str) -> None:
 
 def _finalize_pending_statuses(session_uuid: str, job_ids) -> None:
 	"""At the wait ceiling: record a terminal status for jobs that finished,
-	and mark any still-active job ``Running`` (so it's reported, not vanished —
+	and mark any still-active job ``Running`` (so it's reported, not vanished
 	the user re-runs Analyze once it finishes to capture its data)."""
 	for jid in job_ids:
 		if _rq_job_active(jid):
@@ -484,14 +484,14 @@ def _bg_wait_for_pending_jobs(session_uuid: str, docname: str, deadline):
 	before we gather recordings.
 
 	Returns:
-	  * ``None`` — there are still-running jobs and we re-enqueued
+	  * ``None``: there are still-running jobs and we re-enqueued
 	    ``analyze.run`` to yield the worker; the caller must ``return`` now.
-	  * ``0`` — nothing to wait for / all jobs finished / the wait is disabled
+	  * ``0``: nothing to wait for / all jobs finished / the wait is disabled
 	    or can't run (scheduler off → analyze is inline): proceed with analysis.
-	  * ``N > 0`` — the wait cap was hit with N jobs still running: proceed,
+	  * ``N > 0``: the wait cap was hit with N jobs still running: proceed,
 	    but the caller should surface a warning.
 
-	Pure best-effort — any failure returns 0 (proceed). Re-enqueuing (rather
+	Pure best-effort any failure returns 0 (proceed). Re-enqueuing (rather
 	than sleeping the whole window) lets a single worker actually run those
 	jobs while we wait.
 	"""
@@ -514,7 +514,7 @@ def _bg_wait_for_pending_jobs(session_uuid: str, docname: str, deadline):
 
 	# When the scheduler is disabled, analyze is running inline in a web
 	# request and there's no worker to run the pending jobs (or our
-	# re-enqueued self) — better to ship the report now than hang.
+	# re-enqueued self) better to ship the report now than hang.
 	try:
 		if is_scheduler_disabled():
 			return 0
@@ -540,12 +540,12 @@ def _bg_wait_for_pending_jobs(session_uuid: str, docname: str, deadline):
 				pass
 
 	if not still_running:
-		return 0  # everything finished — proceed
+		return 0  # everything finished proceed
 	if time.time() >= deadline:
 		_finalize_pending_statuses(session_uuid, still_running)
-		return len(still_running)  # cap hit — proceed; caller warns
+		return len(still_running)  # cap hit proceed; caller warns
 
-	# v0.13: keep the UI honest while we wait — stay on "Capturing Background
+	# v0.13: keep the UI honest while we wait stay on "Capturing Background
 	# Jobs" (set at stop) for the whole drain rather than flipping to
 	# "Analyzing" here; the real "Analyzing" is set below once the jobs finish
 	# and we start gathering recordings. The janitor's stale-stopping sweep
@@ -577,20 +577,20 @@ def _bg_wait_for_pending_jobs(session_uuid: str, docname: str, deadline):
 		)
 	except Exception:
 		frappe.log_error(title="optimus bg-job wait re-enqueue")
-		return 0  # couldn't re-enqueue — just proceed
+		return 0  # couldn't re-enqueue just proceed
 	return None
 
 
 def _auto_arm_phase2(docname: str, context) -> None:
 	"""v0.7.x (P3): when ``optimus_phase2_auto_arm`` is set in site_config, arm
 	a phase-2 line-profile pass on the recommended hot-path functions right
-	after analyze finishes — so the user just re-runs the flow ONCE to get
+	after analyze finishes so the user just re-runs the flow ONCE to get
 	line-level data, with no manual picking.
 
 	Opt-in + admin-only (site_config, not a casual UI toggle): arming
 	instruments the user's NEXT execution of the flow, so it's only sensible
 	for replay-safe flows / non-production. Heavily guarded and fully
-	best-effort — it must NEVER fail analyze (the report is already saved)."""
+	best-effort it must NEVER fail analyze (the report is already saved)."""
 	try:
 		if not frappe.conf.get("optimus_phase2_auto_arm"):
 			return
@@ -681,7 +681,7 @@ def _auto_arm_phase2(docname: str, context) -> None:
 		safe_commit()
 
 		# Auto-arm runs server-side during analyze, when the user isn't on the
-		# form — tell them a pass is armed and what to do next (re-run + Stop),
+		# form tell them a pass is armed and what to do next (re-run + Stop),
 		# since arming alone does nothing until the flow re-executes.
 		functions = [r["dotted_path"].rsplit(".", 1)[-1] for r in eligible][:5]
 		try:
@@ -699,7 +699,7 @@ def _auto_arm_phase2(docname: str, context) -> None:
 			pass
 		frappe.logger().info(
 			f"optimus: auto-armed phase-2 pass {run_uuid} for {docname} "
-			f"({len(eligible)} function(s)) — re-run the flow + Stop to capture line data."
+			f"({len(eligible)} function(s)) re-run the flow + Stop to capture line data."
 		)
 	except Exception:
 		# Never let auto-arm break a finished analyze.
@@ -712,7 +712,7 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 
 	``_bg_wait_until`` is set only when ``run`` re-enqueues itself while
 	waiting for the flow's background jobs to finish (see
-	``_bg_wait_for_pending_jobs``) — external callers never pass it."""
+	``_bg_wait_for_pending_jobs``) external callers never pass it."""
 	# Round 2 fix #6: mark this request-context as "analyzing" so our
 	# before_request / before_job hooks don't recursively activate the
 	# recorder on the DocType writes we're about to do. Without this,
@@ -721,7 +721,7 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 	frappe.local.optimus_analyzing = True
 
 	# v0.7.x (M5): de-prioritize this analyze on the async (worker) path so it
-	# doesn't starve live web traffic. Skipped inline (scheduler disabled) —
+	# doesn't starve live web traffic. Skipped inline (scheduler disabled)
 	# os.nice is sticky per-process and would de-prioritize the shared gunicorn
 	# worker for unrelated later requests.
 	try:
@@ -743,22 +743,22 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 
 	try:
 		# v0.6.0: wait for the background jobs the profiled flow enqueued to
-		# finish before gathering recordings — so jobs a worker picks up
+		# finish before gathering recordings so jobs a worker picks up
 		# shortly after Stop aren't lost. Re-enqueues self (yielding the
 		# worker) between checks; no-op when nothing's pending / the wait is
 		# disabled / no async worker is available.
 		bg_jobs_unfinished = _bg_wait_for_pending_jobs(session_uuid, docname, _bg_wait_until)
 		if bg_jobs_unfinished is None:
-			return  # re-enqueued — this invocation is done
+			return  # re-enqueued this invocation is done
 
-		# v0.7.x (M2): global single-flight — only one session does the heavy,
+		# v0.7.x (M2): global single-flight only one session does the heavy,
 		# memory-hungry analyze at a time so two stops can't stack to ~2× RAM
 		# and OOM the box. If another session holds the flag we re-enqueue
 		# ourselves and yield (skipped on the inline path). Acquired here, before
 		# the big materialization below; heartbeated at the progress milestones;
 		# released in the `finally`.
 		if not _acquire_singleflight(session_uuid, docname, _singleflight_deadline):
-			return  # re-enqueued — this invocation is done
+			return  # re-enqueued this invocation is done
 
 		# Phase: Analyzing
 		frappe.db.set_value("Optimus Session", docname, "status", "Analyzing")
@@ -819,7 +819,7 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 		# for consumption by the frontend_timings analyzer. Reads from the
 		# two atomic Redis lists written by api.submit_frontend_metrics
 		# (v0.5.1+). Falls back to the pre-v0.5.1 single-blob format if
-		# that's what's in Redis — for upgrade safety on sessions
+		# that's what's in Redis for upgrade safety on sessions
 		# captured just before the update.
 		try:
 			from optimus import api as _api
@@ -859,16 +859,16 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 			if time.monotonic() - analyze_start > ANALYZE_TOTAL_BUDGET_SECONDS:
 				skipped = len(analyzers) - i
 				context.warnings.append(
-					f"Analyze partially completed (timeout) — "
+					f"Analyze partially completed (timeout) "
 					f"{skipped} analyzer(s) skipped"
 				)
 				break
 
 			# M2: heartbeat the single-flight flag each iteration. The analyzer
-			# loop can run up to ANALYZE_TOTAL_BUDGET_SECONDS (1200s) — well past
+			# loop can run up to ANALYZE_TOTAL_BUDGET_SECONDS (1200s) well past
 			# the flag's 300s TTL. Without this, the flag would lapse mid-analyze,
 			# a second queued session could acquire it, and two heavy analyzes
-			# would run concurrently at ~2× peak RAM — exactly the OOM the
+			# would run concurrently at ~2× peak RAM exactly the OOM the
 			# single-flight guard exists to prevent. Redis-only, so it also keeps
 			# is_singleflight_holder() truthy for the janitor's liveness check.
 			_touch_singleflight(session_uuid)
@@ -913,7 +913,7 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 
 		# v0.6.0: optionally bake LLM fix suggestions into the report
 		# (Optimus Settings ▸ AI Fix Suggestions ▸ "Suggest AI fixes by
-		# default"). Best-effort + time-budgeted — and double-wrapped here so
+		# default"). Best-effort + time-budgeted and double-wrapped here so
 		# even a bug in the AI path can NEVER fail the analyze. If the LLM
 		# was unavailable / errored, the session still completes; you can
 		# fill the suggestions in afterward via the "Generate AI fixes"
@@ -924,7 +924,7 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 		except Exception:
 			try:
 				context.warnings.append(
-					"AI auto-suggest was skipped after an unexpected error — "
+					"AI auto-suggest was skipped after an unexpected error "
 					"use 'Generate AI fixes' on the session form to fill them in. "
 					"(see error log)"
 				)
@@ -965,7 +965,7 @@ def run(session_uuid: str, _bg_wait_until: float | None = None,
 		# Phase: Ready
 		frappe.db.set_value("Optimus Session", docname, "status", "Ready")
 		safe_commit()
-		# v0.7.x (P3): opt-in — arm a phase-2 pass on the hot paths so the user
+		# v0.7.x (P3): opt-in arm a phase-2 pass on the hot paths so the user
 		# just re-runs the flow once for line data. Best-effort; never fails analyze.
 		_auto_arm_phase2(docname, context)
 		_publish_progress(100, "Report ready", session_uuid)
@@ -1120,11 +1120,11 @@ def _rehydrate_from_bundle(recordings_bundle, uuid: str):
 	full bundle (``{"recordings": {...}}``) or the inner uuid→entry map directly.
 
 	The tree round-trips byte-identically (base64 of the same HMAC-signed
-	pickle), but ``rec``/``sidecar`` came back through JSON — so tuples are now
+	pickle), but ``rec``/``sidecar`` came back through JSON so tuples are now
 	lists and any exotic type was stringified. That's transparent to the
 	analyze/render consumers (string/number/dict fields), but is NOT the pickle
 	Redis stores. The persisted ``sparse``/``infra`` entries are intentionally
-	not re-attached here — they aren't part of the live ``_fetch_recordings``
+	not re-attached here they aren't part of the live ``_fetch_recordings``
 	rec shape (see :func:`_persist_recordings_file`)."""
 	import base64
 
@@ -1161,7 +1161,7 @@ def _fetch_recordings(recording_uuids: list[str], *, recordings_bundle=None):
 	    recordings rather than holding all 200 in RAM at once.
 	  - For each recording, also loads the per-recording pyi tree pickle
 	    from `profiler:tree:<uuid>` and the sidecar log from
-	    `profiler:sidecar:<uuid>`. Both are best-effort — failures
+	    `profiler:sidecar:<uuid>`. Both are best-effort failures
 	    log a warning and yield None for the missing piece.
 
 	Yields recording dicts shaped like:
@@ -1263,7 +1263,7 @@ def _enrich_recordings(recordings: list[dict]) -> list[str]:
 	Idempotent: safe to call on already-enriched recordings.
 
 	Returns a list of warning strings that should be surfaced in the
-	report — things like "we truncated X queries because the session hit
+	report things like "we truncated X queries because the session hit
 	the per-recording cap".
 	"""
 	# Flush any pending transaction state so EXPLAIN sees a consistent
@@ -1282,7 +1282,7 @@ def _enrich_recordings(recordings: list[dict]) -> list[str]:
 
 	# v0.7.x (M6): optional throttle of the EXPLAIN/sqlparse burst so a long
 	# flow doesn't hammer the DB/CPU continuously (and so GC gets breathing
-	# room). Off by default (every=0) — exact current behavior, zero overhead.
+	# room). Off by default (every=0) exact current behavior, zero overhead.
 	# Counts ACTUAL EXPLAIN executions (not cache hits); sleeping changes only
 	# timing, never which queries are EXPLAINed or any result.
 	try:
@@ -1313,7 +1313,7 @@ def _enrich_recordings(recordings: list[dict]) -> list[str]:
 	use_shared_cache = cache_ttl > 0
 
 	# v0.5.3: per-recording cap is admin-configurable. Fall back to
-	# the hardcoded default if settings read fails for any reason —
+	# the hardcoded default if settings read fails for any reason
 	# we must never let a settings hiccup starve the analyze pipeline.
 	try:
 		from optimus.settings import get_config
@@ -1430,7 +1430,7 @@ def _enrich_recordings(recordings: list[dict]) -> list[str]:
 		# a prominent banner at the top of the report, in addition to
 		# the Analyzer Notes entry. Users were missing truncation
 		# warnings when they only appeared in the collapsed bottom
-		# section — "166 queries truncated" buried below stats cards
+		# section "166 queries truncated" buried below stats cards
 		# and findings led to developers reading an incomplete report
 		# without noticing.
 		warnings.append(
@@ -1444,7 +1444,7 @@ def _enrich_recordings(recordings: list[dict]) -> list[str]:
 			"To get full coverage, raise "
 			"<b>Optimus Settings ▸ Max Queries per Recording</b> "
 			"(default 2000, try 5000-10000) and re-run the session "
-			"— OR profile a shorter flow."
+			" OR profile a shorter flow."
 		)
 	return warnings
 
@@ -1453,7 +1453,7 @@ def _shape_key(query: str) -> str:
 	"""Cheap query-shape key for EXPLAIN dedup.
 
 	Lower-cases, collapses whitespace, and truncates. This is NOT the
-	proper sqlparse normalization — we just need "are these two queries
+	proper sqlparse normalization we just need "are these two queries
 	shaped the same" for caching purposes. The REAL normalization happens
 	in mark_duplicates afterward.
 	"""
@@ -1497,7 +1497,7 @@ def _apply_overflow_or_pass(
 	if size < CALL_TREE_OVERFLOW_THRESHOLD_BYTES:
 		return tree_json, None
 
-	# Path 2: hard sanity guard — truncate immediately, never attempt file
+	# Path 2: hard sanity guard truncate immediately, never attempt file
 	if size > hard_max_bytes:
 		warnings.append(
 			f"Action {action_idx}: tree exceeded hard guard "
@@ -1563,7 +1563,7 @@ def _hard_truncate_tree(tree_json: str) -> str:
 	]
 	out = {
 		"_truncated": True,
-		# B.DI2 — preserve the original frame count so the renderer can
+		# B.DI2 preserve the original frame count so the renderer can
 		# show a "captured X frames, only top N shown" banner. Without
 		# these, the truncation is invisible after persistence.
 		"_captured_frames": len(all_nodes),
@@ -1604,11 +1604,11 @@ def _persist(
 	# text left alone.
 	if not (doc.notes or "").strip():
 		# v0.6.0: when AI is enabled, draft a friendly human-readable flow
-		# (with the raw action list kept below); otherwise — or if the LLM
-		# call fails — fall back to the plain labelled list.
+		# (with the raw action list kept below); otherwise or if the LLM
+		# call fails fall back to the plain labelled list.
 		# v0.13: capture the humanizer's token usage here so the steps tokens
 		# show in the report and roll into the session's cumulative spend on
-		# the auto-analyze path too — not only after a manual "Refresh AI
+		# the auto-analyze path too not only after a manual "Refresh AI
 		# suggestions". (usage_out non-None also arms _record_session_spend at
 		# the ai_fix chokepoint, since the analyze run set the spend marker.)
 		_steps_usage: dict = {}
@@ -1634,7 +1634,7 @@ def _persist(
 		context.aggregate.get("table_breakdown", []), default=str
 	)
 	# v0.5.0: infra_pressure and frontend_timings aggregates. Capped to
-	# prevent unbounded growth on pathological 200-recording sessions —
+	# prevent unbounded growth on pathological 200-recording sessions
 	# without caps, v5_aggregate_json could balloon to 1 MB+ and slow
 	# the form load for the Optimus Session record. Truncation is
 	# tail-preferring (keep the last N entries) with a warning surfaced
@@ -1724,9 +1724,9 @@ def _persist(
 
 	# v0.5.1: safety net for Optimus Finding.title's 140-char Frappe
 	# limit. Individual analyzers already shorten filenames in titles
-	# (see n_plus_one + call_tree), but pathological inputs — unusual
+	# (see n_plus_one + call_tree), but pathological inputs unusual
 	# function names, very high occurrence counts, unexpected formats
-	# from future analyzers — can still push past the limit and crash
+	# from future analyzers can still push past the limit and crash
 	# the whole persist with CharacterLengthExceededError. We clamp
 	# here so a single too-long title never destroys the entire
 	# analyze run.
@@ -1742,7 +1742,7 @@ def _persist(
 		doc.append("findings", finding)
 
 	# v0.7.x: one Optimus Background Job row per RQ job the flow enqueued, with
-	# its terminal status — so failed / timed-out jobs are reported instead of
+	# its terminal status so failed / timed-out jobs are reported instead of
 	# vanishing. Belt-and-suspenders: capture a status for any job the wait
 	# didn't (e.g. the wait was skipped/disabled), then read the final hash.
 	try:
@@ -1915,7 +1915,7 @@ def _dedupe_findings_across_actions(
 					f"action{'s' if len(other_entries) != 1 else ''}: {bits}."
 				)
 			else:
-				# Labels missing — generic count.
+				# Labels missing generic count.
 				suffix = (
 					f" Also affects {len(other_entries)} other "
 					f"action{'s' if len(other_entries) != 1 else ''}."
@@ -1930,7 +1930,7 @@ def _dedupe_findings_across_actions(
 			findings.pop(i)
 
 
-# Optimus Finding.title is a Frappe Data field — VARCHAR(140). Titles
+# Optimus Finding.title is a Frappe Data field VARCHAR(140). Titles
 # that exceed this length raise CharacterLengthExceededError at save
 # time, taking down the whole analyze pipeline. We clamp in-place as a
 # safety net: 137 visible chars + the "..." ellipsis marker fits the
@@ -1992,7 +1992,7 @@ def _enrich_findings_with_source_snippets(findings: list[dict]) -> None:
 		except Exception:
 			continue
 		if not isinstance(detail, dict):
-			# Valid JSON that isn't an object — e.g. a stray "string", a
+			# Valid JSON that isn't an object e.g. a stray "string", a
 			# bare ``null``, or a top-level list left by a stale persistence
 			# path. ``.get()`` below would AttributeError; silent skip.
 			continue
@@ -2001,13 +2001,13 @@ def _enrich_findings_with_source_snippets(findings: list[dict]) -> None:
 			# Slow Query findings (optimus/analyzers/top_queries.py) store
 			# callsite as a "path:lineno" string, not the canonical dict
 			# shape every other finding type uses. Skip analyze-time
-			# enrichment here — renderer._normalize_callsite converts the
+			# enrichment here renderer._normalize_callsite converts the
 			# string at render time and renderer._finding_to_dict attaches
 			# the snippet lazily, so no functionality is lost.
 			continue
 		if not callsite.get("filename"):
 			# call_tree (Slow Hot Path / Hook Bottleneck / Repeated Hot Frame)
-			# and line_profile (Hot Line) store the location at the top level —
+			# and line_profile (Hot Line) store the location at the top level
 			# synthesize a callsite dict so the snippet lands where
 			# renderer._finding_to_dict expects it (and stop _finding_to_dict
 			# from having to re-synthesize at render time).
@@ -2048,7 +2048,7 @@ def _enrich_findings_with_ai_suggestions(context, *, recordings: list | None = N
 
 	Best-effort + bounded: a misconfigured / unreachable provider, an
 	individual finding that errors, or hitting ``AI_AUTO_SUGGEST_TIME_
-	BUDGET_SECONDS`` just means fewer (or no) suggestions — never a failed
+	BUDGET_SECONDS`` just means fewer (or no) suggestions never a failed
 	analyze. The network I/O lives here in the orchestrator, never in an
 	analyzer (the pure-analyzer contract is untouched).
 	"""
@@ -2069,7 +2069,7 @@ def _enrich_findings_with_ai_suggestions(context, *, recordings: list | None = N
 
 	if not ai_fix.is_available(section="findings"):
 		context.warnings.append(
-			"AI auto-suggest is on but the AI provider isn't fully configured — "
+			"AI auto-suggest is on but the AI provider isn't fully configured "
 			"no suggestions were generated (see Optimus Settings ▸ AI Fix Suggestions)."
 		)
 		return
@@ -2111,7 +2111,7 @@ def _enrich_findings_with_ai_suggestions(context, *, recordings: list | None = N
 		if time.monotonic() - started > AI_AUTO_SUGGEST_TIME_BUDGET_SECONDS:
 			skipped_for_time = total - idx
 			break
-		# Live progress per finding — the floating widget / form headline
+		# Live progress per finding the floating widget / form headline
 		# show movement during the (potentially minute-long) LLM round
 		# trips instead of a frozen "Analyzing 78%". Range 78→80 leads into
 		# the next milestone ("Writing session data").
@@ -2151,11 +2151,11 @@ def _enrich_findings_with_ai_suggestions(context, *, recordings: list | None = N
 	if failures:
 		context.warnings.append(
 			f"AI auto-suggest: {failures} finding(s) couldn't get a suggestion "
-			"(provider error / timeout — see error log)."
+			"(provider error / timeout see error log)."
 		)
 	if skipped_for_time:
 		context.warnings.append(
-			f"AI auto-suggest: {skipped_for_time} finding(s) skipped — hit the "
+			f"AI auto-suggest: {skipped_for_time} finding(s) skipped hit the "
 			f"{AI_AUTO_SUGGEST_TIME_BUDGET_SECONDS}s budget for AI suggestions."
 		)
 
@@ -2169,13 +2169,13 @@ def _ai_payload_for_finding(
 	actions_by_idx: dict | None = None,
 ) -> dict:
 	"""Build the dict ``ai_fix.suggest_fix`` expects from a finding-like
-	object — a ``Optimus Finding`` child row, or a ``SimpleNamespace``
+	object a ``Optimus Finding`` child row, or a ``SimpleNamespace``
 	shaped like one (``finding_type`` / ``severity`` / ``title`` /
 	``customer_description`` / ``estimated_impact_ms`` / ``affected_count`` /
 	``action_ref`` / ``technical_detail_json`` / ``llm_fix_json``). It's the
 	renderer's normalized finding dict plus a wider source-code window around
-	the callsite, plus — when a Phase-2 line-profile pass instrumented this
-	finding's function — the hottest line from it (number / content / ms /
+	the callsite, plus when a Phase-2 line-profile pass instrumented this
+	finding's function the hottest line from it (number / content / ms /
 	hits). ``phase2_index`` is a
 	``renderer._build_line_drilldown_callsite_index`` result,
 	``{(basename, function): hotline}``.
@@ -2185,12 +2185,12 @@ def _ai_payload_for_finding(
 	finding has an ``action_ref``, the top-N slowest queries from that
 	action's recording are attached to ``technical_detail.example_queries``.
 	This gives the AI **verbatim SQL evidence** for Slow-Hot-Path / N+1
-	findings whose hot function ran raw SQL — without it the model has to
+	findings whose hot function ran raw SQL without it the model has to
 	infer the query shape from the Python source, which is the leading
 	cause of nonsense substitutions (e.g. inventing ``filters={"name":
 	("in", [some_var] * N)}`` to fit an unrelated example pattern).
 	Already-set ``example_queries`` (e.g. from SQL red-flag analyzers) wins
-	— this only fills the gap."""
+	this only fills the gap."""
 	from optimus import ai_fix
 
 	payload = renderer._finding_to_dict(child, file_cache=file_cache)
@@ -2246,7 +2246,7 @@ def _maybe_attach_recorded_queries(
 
 	Skipped silently when any of the inputs is missing or the finding's
 	technical_detail already carries example_queries (a SQL red-flag analyzer
-	set them — those are the most relevant queries by definition; don't
+	set them those are the most relevant queries by definition; don't
 	overwrite)."""
 	if not recordings_by_uuid or not actions_by_idx or action_ref in (None, ""):
 		return
@@ -2268,7 +2268,7 @@ def _maybe_attach_recorded_queries(
 		return
 	detail = payload.setdefault("technical_detail", {}) or {}
 	if detail.get("example_queries"):
-		# Analyzer (SQL red flag) set these; respect — they're the most relevant.
+		# Analyzer (SQL red flag) set these; respect they're the most relevant.
 		return
 	top = []
 	for c in sorted(calls, key=lambda c: -(c.get("duration") or c.get("duration_ms") or 0)):
@@ -2309,31 +2309,31 @@ def _run_ai_backfill(doc, *, cap: int | None = None,
 	re-fetch sees them), and report counts.
 
 	By default this only touches eligible findings that DON'T have a
-	suggestion yet — the "fill the gaps" case (``api.backfill_ai_fixes``,
+	suggestion yet the "fill the gaps" case (``api.backfill_ai_fixes``,
 	the auto-suggest backfill, the analyze pipeline). With
 	``regenerate_all=True`` it (re)generates the suggestion for EVERY
-	eligible finding, overwriting existing ones — the "re-evaluate the whole
+	eligible finding, overwriting existing ones the "re-evaluate the whole
 	report" case (e.g. after changing the AI model/prompt). On a failure
 	mid-re-eval the OLD suggestion is left in place (we only write on
 	success), so there's no data loss.
 
-	The CALLER decides whether to invoke this — the analyze pipeline / plain
+	The CALLER decides whether to invoke this the analyze pipeline / plain
 	``regenerate_reports`` only do so when Optimus Settings has
 	``ai_auto_suggest`` on (via ``_backfill_ai_suggestions``); the explicit
 	"Generate AI fixes" / "Re-evaluate AI fixes" buttons call it whenever the
 	provider is configured (via ``api.backfill_ai_fixes``). Requires
-	``ai_fix.is_available()`` — returns all-zeros if not.
+	``ai_fix.is_available()``: returns all-zeros if not.
 
 	``cap``: max findings to do this run. ``None`` → use Optimus Settings'
 	``ai_auto_suggest_max``; ``0`` → no cap (do as many as fit in
 	``time_budget``). Best-effort + time-budgeted (the callers run inside a
-	web request, so this must stay well under the gunicorn worker timeout) —
+	web request, so this must stay well under the gunicorn worker timeout)
 	a provider error on one finding doesn't stop the rest.
 
 	Returns ``{"added": int, "failed": int, "skipped_time": int,
-	"total_pending": int}`` — ``total_pending`` is the number of findings
-	this run targeted (before the cap): the missing ones, or — with
-	``regenerate_all`` — all eligible ones.
+	"total_pending": int}``: ``total_pending`` is the number of findings
+	this run targeted (before the cap): the missing ones, or with
+	``regenerate_all``: all eligible ones.
 	"""
 	out = {"added": 0, "failed": 0, "skipped_time": 0, "total_pending": 0}
 	_mark_ai_spend_session(getattr(doc, "session_uuid", None))
@@ -2400,7 +2400,7 @@ def _backfill_ai_suggestions(doc) -> bool:
 	"Suggest AI fixes by default" switch and re-rendering an existing
 	session backfills it). Returns True if any suggestion was added.
 
-	The explicit "Generate AI fixes" button bypasses this gate — it calls
+	The explicit "Generate AI fixes" button bypasses this gate it calls
 	``_run_ai_backfill`` directly via ``api.backfill_ai_fixes``, so it works
 	even when ``ai_auto_suggest`` is off.
 	"""
@@ -2420,7 +2420,7 @@ def _backfill_ai_suggestions(doc) -> bool:
 # "Suggest AI fixes by default" toggle, for the top N tables that have a
 # heuristic recommendation) and on-demand (the "Suggest an index (AI)" button
 # → api.suggest_index). The result is stashed on the table's breakdown entry
-# as ``ai_index = {suggestion, model, provider, generated_at}`` — the renderer
+# as ``ai_index = {suggestion, model, provider, generated_at}``: the renderer
 # turns the markdown into safe HTML. Network I/O lives here in the
 # orchestrator / the API endpoint, never in an analyzer.
 # ---------------------------------------------------------------------------
@@ -2428,7 +2428,7 @@ def _backfill_ai_suggestions(doc) -> bool:
 
 def _table_index_sample_queries(recordings: list[dict], table: str, limit: int = 4) -> list[str]:
 	"""A few distinct normalized SELECT queries from the session that touched
-	``table`` — best context for the LLM's index advice. Best-effort."""
+	``table``: best context for the LLM's index advice. Best-effort."""
 	out: list[str] = []
 	seen: set[str] = set()
 	for recording in recordings or []:
@@ -2483,7 +2483,7 @@ def _enrich_table_breakdown_with_ai_suggestions(context, recordings: list[dict])
 	"""When Optimus Settings has ``ai_enabled`` AND ``ai_auto_suggest``, ask
 	the LLM for an index recommendation on the top ``AI_AUTO_INDEX_MAX_TABLES``
 	tables that have a heuristic ``recommended_index``, and stash it on the
-	breakdown entry's ``ai_index``. Best-effort + time-budgeted — failures /
+	breakdown entry's ``ai_index``. Best-effort + time-budgeted failures /
 	a slow provider just mean fewer (or no) AI blocks, never a failed analyze."""
 	breakdown = (context.aggregate or {}).get("table_breakdown") or []
 	eligible = [t for t in breakdown if isinstance(t, dict) and t.get("recommended_index")]
@@ -2528,7 +2528,7 @@ def _run_table_index_ai_backfill(doc, *, table_name: str) -> dict:
 	"""Generate (or regenerate) the LLM index recommendation for one table on
 	a persisted Optimus Session ``doc`` and write it into
 	``table_breakdown_json``. Ungated (the "Suggest an index (AI)" button asks
-	for it explicitly) — but ``ai_fix.suggest_index`` still needs a configured
+	for it explicitly) but ``ai_fix.suggest_index`` still needs a configured
 	provider. Returns ``{"ok": bool, "table": str, "reason"?: str}``; lets
 	``ai_fix.AiFixError`` propagate (the API turns it into ``frappe.throw``)."""
 	_mark_ai_spend_session(getattr(doc, "session_uuid", None))
@@ -2568,14 +2568,14 @@ def _run_table_index_ai_backfill(doc, *, table_name: str) -> dict:
 # v0.5.1: auto-generated "Steps to Reproduce" from captured actions. The
 # dialog no longer asks the user to type notes at start time because (a) it
 # added friction to the one-click "start profiling" flow, and (b) the user
-# already performed the steps — the profiler captured them. We synthesize
+# already performed the steps the profiler captured them. We synthesize
 # a bullet list from the recordings and write it to the `notes` field ONLY
 # when the user hasn't already provided their own text via the DocType
 # form. The developer can then edit the auto-generated list to add
 # business context (what the user was *trying* to do, not what endpoint
 # was hit) before sharing the report. The template still runs notes_html
 # through sanitize_html(always_sanitize=True), so any HTML we emit is
-# re-sanitized at render time — but we still escape labels here because
+# re-sanitized at render time but we still escape labels here because
 # the stored value is also what appears when someone edits the doc.
 _AUTO_NOTES_MAX_ENTRIES = 50
 _AUTO_NOTES_PREAMBLE = (
@@ -2591,9 +2591,9 @@ _AUTO_NOTES_PREAMBLE = (
 #
 # Driven by a real user report whose reproducer read:
 #
-#   GET /api/method/frappe.realtime.has_permission — 25 ms
-#   POST /api/method/frappe.desk.form.save.savedocs — 774.8 ms
-#   GET /api/method/frappe.realtime.has_permission — 6 ms
+#   GET /api/method/frappe.realtime.has_permission 25 ms
+#   POST /api/method/frappe.desk.form.save.savedocs 774.8 ms
+#   GET /api/method/frappe.realtime.has_permission 6 ms
 #
 # Of those three, only the savedocs is a user action. The two
 # has_permission entries are the Desk polling for realtime
@@ -2603,7 +2603,7 @@ _REPRODUCER_NOISE_CMD_PREFIXES = (
 	# 2-3x per second while the Desk has a doctype page open.
 	"frappe.realtime.",
 	# Form-metadata loading issued on every form open. Useful in the
-	# per-action table for timing but clutters the reproducer —
+	# per-action table for timing but clutters the reproducer
 	# "Load Sales Invoice form" says nothing about user intent.
 	"frappe.desk.form.load.getdoctype",
 	"frappe.desk.form.load.getdocinfo",
@@ -2626,7 +2626,7 @@ _REPRODUCER_NOISE_PATH_PREFIXES = (
 
 def _is_reproducer_noise(rec: dict) -> bool:
 	"""Return True when a recording shouldn't appear in the auto-notes
-	reproducer list. Still appears in the per-action breakdown — just
+	reproducer list. Still appears in the per-action breakdown just
 	excluded from the high-level human-readable flow."""
 	cmd = (rec.get("cmd") or "").strip()
 	if cmd:
@@ -2643,13 +2643,13 @@ def _is_reproducer_noise(rec: dict) -> bool:
 
 def _recordings_for_reproducer(recordings: list[dict]) -> list[dict]:
 	"""The signal (non-noise) recordings, in order. Shared by the raw
-	auto-notes list and the AI humanizer — see ``_is_reproducer_noise``."""
+	auto-notes list and the AI humanizer see ``_is_reproducer_noise``."""
 	return [r for r in (recordings or []) if not _is_reproducer_noise(r)]
 
 
 def _build_auto_notes_list_html(recordings: list[dict]) -> str:
-	"""The ordered-list body of the "Steps to Reproduce" note (no preamble) —
-	``<ol><li><label> — <ms></li>…</ol>`` plus a "N background requests
+	"""The ordered-list body of the "Steps to Reproduce" note (no preamble)
+	``<ol><li><label> <ms></li>…</ol>`` plus a "N background requests
 	filtered" footer. Returns "" when there are no signal recordings.
 
 	Labels come from ``per_action.humanized_label`` (English: "Create Sales
@@ -2666,7 +2666,7 @@ def _build_auto_notes_list_html(recordings: list[dict]) -> str:
 	for rec in signal_recordings[:_AUTO_NOTES_MAX_ENTRIES]:
 		label = per_action.humanized_label(rec) or "(unnamed action)"
 		duration_ms = round(rec.get("duration") or 0, 1)
-		items.append(f"<li>{html.escape(label)} — {duration_ms:g} ms</li>")
+		items.append(f"<li>{html.escape(label)}: {duration_ms:g} ms</li>")
 
 	overflow = len(signal_recordings) - _AUTO_NOTES_MAX_ENTRIES
 	if overflow > 0:
@@ -2685,7 +2685,7 @@ def _build_auto_notes_list_html(recordings: list[dict]) -> str:
 
 
 def _build_auto_notes_html(recordings: list[dict]) -> str:
-	"""Auto-generated "Steps to Reproduce" — preamble + the raw labelled
+	"""Auto-generated "Steps to Reproduce" preamble + the raw labelled
 	action list. The fallback when AI humanizing is off or fails. Returns ""
 	when there's nothing to list (no recordings, or all noise) so the caller
 	leaves ``doc.notes`` in its default empty state."""
@@ -2695,11 +2695,11 @@ def _build_auto_notes_html(recordings: list[dict]) -> str:
 	return _AUTO_NOTES_PREAMBLE + body
 
 
-# v0.6.0: LLM-humanized "Steps to Reproduce" — just the friendly narrative.
+# v0.6.0: LLM-humanized "Steps to Reproduce" just the friendly narrative.
 # (The raw labelled action list isn't appended; the per-action breakdown in
 # the report already shows every action with its technical label + timing.)
 _HUMANIZED_NOTES_PREAMBLE = (
-	"<p><em>Steps to Reproduce — drafted by AI from the captured actions. "
+	"<p><em>Steps to Reproduce drafted by AI from the captured actions. "
 	"Edit to add business context (what you were trying to accomplish, any "
 	"steps taken before recording started, expected vs. actual behavior).</em></p>"
 )
@@ -2707,7 +2707,7 @@ _HUMANIZED_NOTES_PREAMBLE = (
 
 def _actions_for_humanizer(recordings: list[dict]) -> list[dict]:
 	"""Compact per-action dicts (label / cmd / path / method / doctype /
-	duration_ms) for ``ai_fix.humanize_steps`` — noise-filtered and capped
+	duration_ms) for ``ai_fix.humanize_steps``: noise-filtered and capped
 	the same way the raw auto-notes list is."""
 	out: list[dict] = []
 	for rec in _recordings_for_reproducer(recordings)[:_AUTO_NOTES_MAX_ENTRIES]:
@@ -2741,7 +2741,7 @@ def _actions_for_humanizer(recordings: list[dict]) -> list[dict]:
 def _assemble_humanized_notes(steps_markdown: str) -> str:
 	"""The HTML stored in ``doc.notes`` for an AI-humanized "Steps to
 	Reproduce": the preamble + the LLM's Markdown steps, rendered + sanitized.
-	No raw captured-actions appendix — the per-action breakdown in the report
+	No raw captured-actions appendix the per-action breakdown in the report
 	already lists every action with its technical label and timing."""
 	return _HUMANIZED_NOTES_PREAMBLE + renderer._markdown_to_safe_html(steps_markdown)
 
@@ -2752,7 +2752,7 @@ def _build_humanized_notes_html(
 ) -> str:
 	"""LLM-humanized "Steps to Reproduce" HTML, or "" when AI isn't
 	enabled/available, there's nothing to summarise, or the LLM call fails
-	(the caller then falls back to ``_build_auto_notes_html``). Best-effort —
+	(the caller then falls back to ``_build_auto_notes_html``). Best-effort
 	never raises."""
 	try:
 		from optimus.settings import get_config
@@ -2835,7 +2835,7 @@ def _build_summary_html(
 
 	# v0.7.x: emit each summary point as a bullet (joined into one <ul>
 	# at the end of the function). Each ``parts`` entry is the bullet's
-	# inner HTML (no <li> wrapper here — added in the final join).
+	# inner HTML (no <li> wrapper here added in the final join).
 	parts = [
 		f"This session covered <strong>{n_actions} operation"
 		f"{'s' if n_actions != 1 else ''}</strong> (page loads, saves and "
@@ -2893,7 +2893,7 @@ def _build_summary_html(
 
 		if tied_finding:
 			# v0.7.x: the "See the Findings section below …" pointer lives once,
-			# on the issue-count sentence below — don't repeat it here.
+			# on the issue-count sentence below don't repeat it here.
 			parts.append(
 				f"The slowest one was <strong>{slowest_label_esc}</strong> at "
 				f"{slowest_ms:.0f}ms - and most of its time went into "
@@ -2946,7 +2946,7 @@ def _build_summary_html(
 			"Findings section below for the ones to ask your developer to fix first."
 		)
 
-	# Wrap into a single <ul> — each parts entry becomes one <li>. Inline
+	# Wrap into a single <ul> each parts entry becomes one <li>. Inline
 	# style mirrors the How-to-read list's pattern for visual consistency
 	# with the rest of the report.
 	bullets = "\n".join(f"<li>{p}</li>" for p in parts)
@@ -2963,7 +2963,7 @@ def _finalize_with_empty_session(docname: str) -> None:
 	doc.total_requests = 0
 	doc.total_queries = 0
 	# v0.7.x: same bullet shape as the populated Summary for visual
-	# consistency — a single <li> inside <ul> reads as a deliberate
+	# consistency a single <li> inside <ul> reads as a deliberate
 	# summary line rather than dangling prose.
 	doc.summary_html = (
 		'<ul class="small" style="margin: 4px 0 0 18px; padding: 0; '
@@ -2981,7 +2981,7 @@ def _render_and_attach_reports(docname: str, recordings: list[dict]) -> None:
 
 	Stored as a PRIVATE attachment on the Optimus Session. Frappe
 	enforces "user must have read permission on attached_to_doctype"
-	for private files — combined with the ``if_owner=1`` permission
+	for private files combined with the ``if_owner=1`` permission
 	rule on Optimus Session for the Optimus User role and the
 	additional gate in ``permissions.file_has_permission``, non-admin
 	users can only download reports for their own sessions.
@@ -2990,7 +2990,7 @@ def _render_and_attach_reports(docname: str, recordings: list[dict]) -> None:
 	doc = frappe.get_doc("Optimus Session", docname)
 
 	# v0.6.0 Round 7: safe-mode reporting removed. Single admin-scoped
-	# raw report only — see product_thesis_self_hosted.md memory for
+	# raw report only see product_thesis_self_hosted.md memory for
 	# the rationale (PII redaction was a moat the user opted to drop in
 	# favor of single-rendering-path simplicity).
 	try:
@@ -3022,7 +3022,7 @@ def _save_report_file(*, docname: str, filename: str, attached_to_field: str, co
 	integrations."). That bypass works correctly when analyze
 	runs as a background RQ job (no request). But when the site
 	has the scheduler disabled, analyze runs INLINE inside
-	api.stop()'s HTTP handler — frappe.request is set, the
+	api.stop()'s HTTP handler frappe.request is set, the
 	bypass doesn't fire, and File's before_insert throws
 	FileTypeNotAllowed when the site's allowed_file_extensions
 	list (System Settings → File Settings) doesn't include HTML.
@@ -3050,7 +3050,7 @@ def _save_report_file(*, docname: str, filename: str, attached_to_field: str, co
 		try:
 			# Temporarily stash the request so File's
 			# validate_file_extension hits its no-request bypass.
-			# Narrow window — only the insert() call, which doesn't
+			# Narrow window only the insert() call, which doesn't
 			# touch request-scoped state.
 			try:
 				frappe.local.request = None
@@ -3099,7 +3099,7 @@ def _persist_recordings_file(docname: str, session_uuid: str, recording_uuids: l
 	path as Redis; ``rec``/``sidecar`` go through ``json.dumps(default=str)``
 	(tuples → lists). Memory note: this re-reads all recordings into a second
 	dict while the analyze ``recordings`` list is still alive, so RAM peaks
-	roughly 2× here — acceptable since persistence runs once at finalize.
+	roughly 2× here acceptable since persistence runs once at finalize.
 	Best-effort: a failure here never aborts analyze.
 	"""
 	import base64
@@ -3160,7 +3160,7 @@ def _load_recordings_bundle(session_doc):
 
 	Returns the parsed bundle dict so post-analyze callers can pass it to
 	``_fetch_recordings(recordings_bundle=...)`` once Redis is cleaned up.
-	Returns None when the session has no snapshot or it can't be read — callers
+	Returns None when the session has no snapshot or it can't be read callers
 	then behave exactly as before the snapshot existed.
 	"""
 	import gzip

--- a/optimus/analyzers/base.py
+++ b/optimus/analyzers/base.py
@@ -11,10 +11,10 @@ The analyzer reads the recording dicts (already enriched by analyze.py with
 sqlparse-formatted queries, EXPLAIN output, normalized queries, and
 exact/normalized copy counts) and returns:
 
-    actions   — Optimus Action child rows (only per_action populates this)
-    findings  — Optimus Finding child rows (each analyzer may emit findings)
-    aggregate — top-level dict-shaped data (e.g. top_queries, table_breakdown)
-    warnings  — non-fatal issues to surface in the report
+    actions Optimus Action child rows (only per_action populates this)
+    findings Optimus Finding child rows (each analyzer may emit findings)
+    aggregate top-level dict-shaped data (e.g. top_queries, table_breakdown)
+    warnings non-fatal issues to surface in the report
 
 Pure means: no Frappe DB access, no Redis access, no I/O. Analyzers operate
 only on the data passed in. Side-effects are limited to the AnalyzerResult
@@ -31,7 +31,7 @@ from typing import Any
 # ---------------------------------------------------------------------------
 # Shared constants and helpers (Round 2 fixes #19 + #20)
 # ---------------------------------------------------------------------------
-# Severity sort order — lower number is higher severity. Used by every
+# Severity sort order lower number is higher severity. Used by every
 # analyzer when sorting its findings list. Moved here from per-module
 # copies to keep the ordering consistent across the pipeline.
 SEVERITY_ORDER: dict[str, int] = {"High": 0, "Medium": 1, "Low": 2}
@@ -40,7 +40,7 @@ SEVERITY_ORDER: dict[str, int] = {"High": 0, "Medium": 1, "Low": 2}
 # callsite for a query. The goal is to blame the user's business logic,
 # not the frappe helper the query was routed through (get_value,
 # get_all, db.count etc.). See the detailed explanation in
-# analyzers/n_plus_one.py — this is just a shared constant now.
+# analyzers/n_plus_one.py this is just a shared constant now.
 #
 # Intentionally narrower than FRAMEWORK_APPS below: walk_callsite uses
 # this to pick a BLAME frame (skip frappe helpers, surface the caller).
@@ -56,14 +56,14 @@ FRAMEWORK_PREFIXES: tuple[str, ...] = (
 
 # v0.5.2: official Frappe-maintained apps. When a finding's BLAME
 # frame resolves inside one of these apps, the user can't practically
-# act on it — fixes live upstream, not in their bench. The renderer
+# act on it fixes live upstream, not in their bench. The renderer
 # routes these into the collapsed Observations subsection (see the
 # split in renderer.py + redundant_calls / explain_flags / n_plus_one
 # filters).
 #
 # Production trigger: a raw session on a Sales Invoice Save+Submit
 # surfaced 10 "Redundant cache lookup: <hash> (106 times)" findings
-# all landing in apps/erpnext/.../sales_invoice.py:300-321 — a loop
+# all landing in apps/erpnext/.../sales_invoice.py:300-321 a loop
 # inside ERPNext that the application developer can't patch.
 FRAMEWORK_APPS: frozenset[str] = frozenset({
 	"frappe",
@@ -83,7 +83,7 @@ FRAMEWORK_APPS: frozenset[str] = frozenset({
 # Well-known third-party libs to catch even when sys.path manipulation bypasses
 # site-packages/ (pyinstrument strips the prefix, so a lib arrives as
 # ``pandas/core/frame.py``). Checked by is_framework_callsite() by matching the
-# resolved app ROOT (first segment) — NOT a substring anywhere — because frappe's
+# resolved app ROOT (first segment) NOT a substring anywhere because frappe's
 # recorder strips the ``apps/`` prefix, so a user callsite is ``<app>/<app>/…`` and
 # a stripped lib is ``<lib>/…``; a lib name DEEPER in a relative path is therefore
 # the user's own submodule (``myapp/myapp/requests/…``), not the library, and must
@@ -102,17 +102,17 @@ _THIRD_PARTY_LIB_NAMES: frozenset[str] = frozenset({
 	"sqlparse", "cryptography", "pytz", "dateutil", "pyinstrument",
 })
 
-# v0.6.0: Frappe's framework-managed columns — every `tab*` table has these.
+# v0.6.0: Frappe's framework-managed columns every `tab*` table has these.
 # Frappe writes (most of) them on every save (`modified`, `modified_by`,
 # `idx`), on insert (`creation`, `owner`), on submit/cancel (`docstatus`), or
 # they're already auto-indexed (`name` is the PK; `parent` is auto-indexed on
 # child tables). Suggesting an index on any of them is a write-cost trap the
-# developer shouldn't be nudged into — so every index-suggestion path
+# developer shouldn't be nudged into so every index-suggestion path
 # (index_suggestions.py, table_breakdown.py's per-table candidates, and the
 # AI "suggest a fix" prompt) skips them.
 #
 # Mirrors `frappe.model.default_fields` + `frappe.model.optional_fields`.
-# Analyzers are pure (no `import frappe`), so this is a hardcoded snapshot —
+# Analyzers are pure (no `import frappe`), so this is a hardcoded snapshot
 # update it if Frappe adds a standard column.
 FRAPPE_METADATA_COLUMNS: frozenset[str] = frozenset({
 	# frappe.model.default_fields
@@ -128,7 +128,7 @@ def is_frappe_metadata_column(name) -> bool:
 	return bool(name) and str(name).strip().lower() in FRAPPE_METADATA_COLUMNS
 
 
-# v0.6.0: Frappe's framework "meta" tables — the ones that store the schema
+# v0.6.0: Frappe's framework "meta" tables the ones that store the schema
 # itself (DocType / DocField / Custom Field / Property Setter), the Single-
 # doctype value store, the naming-series counters, the global-search index,
 # the migration log, and UI/dashboard/print configuration. `bench migrate`
@@ -139,7 +139,7 @@ def is_frappe_metadata_column(name) -> bool:
 # breakdown still lists it (you may still want to know "30ms in tabSingles"),
 # it just won't get index candidates.
 #
-# Curated snapshot — content / log / queue tables (`tabFile`, `tabVersion`,
+# Curated snapshot content / log / queue tables (`tabFile`, `tabVersion`,
 # `tabEmail Queue`, `tabCommunication`, `tabError Log`, …) are deliberately
 # NOT here: those grow large and DO legitimately want application-chosen
 # indexes.
@@ -176,7 +176,7 @@ def is_frappe_meta_table(name) -> bool:
 	return bool(name) and str(name).strip().strip("`").lower() in _FRAPPE_META_TABLES_LOWER
 
 
-# v0.6.x: framework-internal tables — user/session/auth bookkeeping that
+# v0.6.x: framework-internal tables user/session/auth bookkeeping that
 # every Frappe request touches via session.get_user / get_roles / etc.,
 # irrespective of the app code. Distinct from FRAPPE_META_TABLES (= "Frappe
 # owns the schema, no custom indexes survive a migrate"): these *are* real
@@ -198,7 +198,7 @@ _FRAMEWORK_INTERNAL_TABLES_LOWER: frozenset[str] = frozenset(
 
 def is_framework_db_table(name) -> bool:
 	"""True for tables that are noise in the "Time spent per database table"
-	breakdown — schema/meta (``FRAPPE_META_TABLES``), user/session bookkeeping
+	breakdown schema/meta (``FRAPPE_META_TABLES``), user/session bookkeeping
 	(``FRAMEWORK_INTERNAL_TABLES``), or MySQL system tables
 	(``information_schema.*``). Case-insensitive + backtick-tolerant."""
 	if not name:
@@ -218,10 +218,10 @@ def is_framework_db_table(name) -> bool:
 # Core Frappe/ERPNext tables that take many INSERT/UPDATE rows per business
 # transaction (every submitted voucher, every stock move, …). An extra index
 # on one of these costs write time across many flows even though a single
-# profiling session may only show one write — the report flags that so an
+# profiling session may only show one write the report flags that so an
 # index recommendation here is treated conservatively.
 WRITE_HOT_TABLES: frozenset[str] = frozenset({
-	# Accounting / stock ledgers — written in bulk on every submit
+	# Accounting / stock ledgers written in bulk on every submit
 	"tabGL Entry", "tabStock Ledger Entry", "tabPayment Ledger Entry",
 	"tabSerial and Batch Bundle", "tabSerial and Batch Entry",
 	"tabBin", "tabSerial No", "tabBatch", "tabRepost Item Valuation",
@@ -244,13 +244,13 @@ def _last_app_segment(norm: str) -> str | None:
 	Boundary-anchored, so:
 	- a bench nested under a folder that is itself named ``apps``
 	  (``/opt/apps/frappe-bench/apps/erpnext/…``) resolves the REAL app
-	  (``erpnext``), not the bench dir — the LAST ``/apps/`` on an ABSOLUTE path
+	  (``erpnext``), not the bench dir the LAST ``/apps/`` on an ABSOLUTE path
 	  wins; and
 	- an app whose own name merely ends in ``apps`` (``webapps/module.py``) is
 	  NOT mistaken for the bench ``apps/`` dir.
 	A mid-path ``/apps/`` in a RELATIVE path is a user subpackage, not the bench
 	apps dir (the recorder strips the bench prefix, so bench code arrives as
-	``apps/<app>/…`` or ``<app>/<app>/…`` — never ``<app>/apps/…``); so
+	``apps/<app>/…`` or ``<app>/<app>/…``: never ``<app>/apps/…``); so
 	``myapp/apps/foo.py`` resolves to None here, letting the caller fall back to the
 	top segment ``myapp``. Returns None when there's no ``apps/`` boundary at all.
 	"""
@@ -300,12 +300,12 @@ def _extract_app_segment(norm: str) -> str | None:
 
 def installed_apps_allowlist() -> frozenset[str] | None:
 	"""The site's installed Frappe apps, as the ground-truth allowlist for
-	exclusion-mode classification — or ``None`` when frappe isn't importable
+	exclusion-mode classification or ``None`` when frappe isn't importable
 	(off-bench unit tests), in which case callers fall back to the hardcoded
 	third-party heuristic. Lazy frappe import mirrors ``call_tree._top_level_app``;
 	never raises. Analyzers resolve this ONCE and thread it in, so a real site
 	classifies application-vs-library from ground truth instead of guessing from a
-	name — an installed app named like a library (``redis``) is the user's code,
+	name an installed app named like a library (``redis``) is the user's code,
 	and a real library that isn't an installed app is not."""
 	try:
 		import frappe
@@ -325,14 +325,14 @@ def is_framework_callsite(
 
 	Two modes, chosen by whether ``tracked_apps`` is provided:
 
-	**Inclusion mode** — when ``tracked_apps`` is a non-empty tuple, the
+	**Inclusion mode**: when ``tracked_apps`` is a non-empty tuple, the
 	classifier flips: a callsite is framework *unless* its app matches
 	one of the tracked apps. This is what ``Optimus Settings ▸ Tracked
-	Apps`` configures — it lets the site admin say "I only care about
+	Apps`` configures it lets the site admin say "I only care about
 	findings in myapp" and get everything else routed to Observations
 	without having to enumerate every framework app.
 
-	**Exclusion mode** — when ``tracked_apps`` is None or empty, the classifier
+	**Exclusion mode**: when ``tracked_apps`` is None or empty, the classifier
 	uses the site's installed-apps allowlist as ground truth: an app root that is
 	an installed Frappe app (and not a framework/stock app) is the developer's own
 	code; everything else is library/framework. When ``installed_apps`` is None
@@ -341,7 +341,7 @@ def is_framework_callsite(
 	configured the Single.
 
 	Matching is on the resolved app ROOT (the ``apps/<app>/`` segment or the top
-	path segment), never a mid-path substring — so neither ``my_crm/`` nor a user
+	path segment), never a mid-path substring so neither ``my_crm/`` nor a user
 	submodule named ``crm/`` deep in a path is misread as the framework app.
 
 	Used by redundant_calls, explain_flags, n_plus_one, and top_queries to route
@@ -353,14 +353,14 @@ def is_framework_callsite(
 		return False
 	norm = filename.replace("\\", "/")
 
-	# venv / system packages are always un-patchable library code — checked in BOTH
+	# venv / system packages are always un-patchable library code checked in BOTH
 	# modes (a vendored lib under a tracked app's own .venv is not that app's code,
 	# so inclusion mode must not report it as an actionable user finding).
 	if "site-packages/" in norm or "dist-packages/" in norm:
 		return True
 
 	# Server Scripts are the developer's own optimizable code and live in the
-	# database, not in any app — so they stay actionable in BOTH modes (and must
+	# database, not in any app so they stay actionable in BOTH modes (and must
 	# never be caught by the installed-apps allowlist below, whose set has no entry
 	# for the synthetic ``<serverscript>`` filename).
 	if norm.startswith("<serverscript") or norm.startswith("<server-script"):
@@ -374,22 +374,22 @@ def is_framework_callsite(
 		return True
 
 	# Exclusion mode (default). Resolve the app ROOT (the boundary-anchored
-	# ``apps/<app>/`` segment when present, else the top path segment) — never a
+	# ``apps/<app>/`` segment when present, else the top path segment) never a
 	# mid-path substring, so a user submodule named like a framework app or library
 	# (``mybiz/mybiz/crm/…``, ``myapp/myapp/requests/…``) is not misread.
 	user_app = _last_app_segment(norm)
 	app_root = user_app or norm.lstrip("/").split("/", 1)[0]
 
 	# Framework / stock apps (frappe, erpnext, …) are never actionable, even though
-	# they're installed — so this check precedes the installed-apps allowlist.
+	# they're installed so this check precedes the installed-apps allowlist.
 	if app_root in FRAMEWORK_APPS:
 		return True
 
 	# Ground truth beats name-guessing: when the site's installed-apps allowlist is
 	# available, an app root that IS an installed Frappe app is application code
-	# (actionable) — including an app deliberately named like a library (``redis``,
-	# ``requests``). Anything else — a real third-party library, an out-of-bench
-	# checkout, a stray absolute/Windows path — the developer can't patch → framework.
+	# (actionable) including an app deliberately named like a library (``redis``,
+	# ``requests``). Anything else a real third-party library, an out-of-bench
+	# checkout, a stray absolute/Windows path the developer can't patch → framework.
 	if installed_apps:
 		return app_root not in installed_apps
 
@@ -421,7 +421,7 @@ def is_framework_callsite_str(
 	"""
 	if not callsite:
 		return True
-	# The line number is always the trailing ':N' segment — strip it to
+	# The line number is always the trailing ':N' segment strip it to
 	# recover the filename for the path classifier. Recorder stacks use
 	# forward slashes, so a Windows drive-letter ':' isn't a concern.
 	filename = callsite.rsplit(":", 1)[0] if ":" in callsite else callsite
@@ -434,16 +434,16 @@ def is_profiler_own_query(stack: list | None) -> bool:
 
 	Examples of queries that hit this path:
 
-	- ``optimus/infra_capture.py:176`` — the ``SHOW GLOBAL
+	- ``optimus/infra_capture.py:176``: the ``SHOW GLOBAL
 	  STATUS`` snapshot run inside every ``before_request`` /
 	  ``after_request`` hook. Fired ~2× per captured request.
-	- ``optimus/infra_capture.py`` — the one-shot ``SHOW
+	- ``optimus/infra_capture.py``: the one-shot ``SHOW
 	  VARIABLES`` for ``max_connections`` (cached after first call).
 	- Anything else the profiler queries as part of its own bookkeeping.
 
 	These queries are real SQL that MariaDB executed, so they show up
 	in the recorder's call list with stack traces. The user can't act
-	on them, though — they're profiler overhead, not application work.
+	on them, though they're profiler overhead, not application work.
 	Before this helper, n_plus_one would surface them as:
 
 	    "Same query ran 22× at optimus/infra_capture.py:176"
@@ -456,14 +456,14 @@ def is_profiler_own_query(stack: list | None) -> bool:
 
 	- If we find a user frame (not in ``frappe/`` and not in
 	  ``optimus/``) → return False. The query came from user
-	  code routed through framework helpers — keep it.
+	  code routed through framework helpers keep it.
 	- If we exhaust the stack seeing only ``frappe/`` and
 	  ``optimus/`` frames AND at least one was
 	  ``optimus/`` → return True. The deepest non-frappe frame
 	  is inside the profiler, so the query originated there.
 	- If we exhaust with only ``frappe/`` frames → return False. This
 	  is a legitimate framework query (migration, fixture, internal
-	  bg task) — the ``walk_callsite`` fallback still surfaces it.
+	  bg task) the ``walk_callsite`` fallback still surfaces it.
 	"""
 	if not stack:
 		return False
@@ -485,9 +485,9 @@ def is_profiler_own_query(stack: list | None) -> bool:
 			has_profiler_frame = True
 			continue
 		if "frappe/" in filename:
-			# Keep walking — the profiler or user code may be further out.
+			# Keep walking the profiler or user code may be further out.
 			continue
-		# Non-framework frame — this is user code; the query's origin
+		# Non-framework frame this is user code; the query's origin
 		# is the user's business logic, not our instrumentation.
 		return False
 	return has_profiler_frame
@@ -499,11 +499,11 @@ def walk_callsite(stack: list | None) -> dict | None:
 	Shared implementation of the "skip frappe frames" callsite walker.
 	The recorder builds `stack` outermost-to-innermost (after stripping
 	its own frames), so the LAST entry is the closest /apps/ frame to
-	the SQL call — but that's often a frappe framework helper. We walk
+	the SQL call but that's often a frappe framework helper. We walk
 	from innermost toward outermost and return the first frame whose
 	filename isn't inside a framework directory.
 
-	Returns a dict with keys `filename`, `lineno`, `function` — or None
+	Returns a dict with keys `filename`, `lineno`, `function`: or None
 	if the stack is empty / malformed / belongs to profiler
 	instrumentation. Falls back to the innermost frame if every frame
 	is in ``frappe/`` (legitimate for queries issued from inside
@@ -514,7 +514,7 @@ def walk_callsite(stack: list | None) -> dict | None:
 	``optimus/`` (as detected by ``is_profiler_own_query``)
 	return None instead of falling back to the profiler frame. The
 	caller's ``if not callsite: continue`` guard then drops the query
-	— otherwise the profiler's own ``SHOW GLOBAL STATUS`` snapshots
+	otherwise the profiler's own ``SHOW GLOBAL STATUS`` snapshots
 	show up as "Same query ran 22× at optimus/infra_capture
 	.py:176" findings, which are noise the user can't act on.
 	"""
@@ -536,7 +536,7 @@ def walk_callsite(stack: list | None) -> dict | None:
 		return frame
 
 	# Fallback: every frame was in the framework. If the profiler itself
-	# is in the stack, this is our own instrumentation — drop it.
+	# is in the stack, this is our own instrumentation drop it.
 	if is_profiler_own_query(stack):
 		return None
 
@@ -571,13 +571,13 @@ def walk_callsite_str(stack: list | None) -> str | None:
 #   erpnext/doctype/parent_manufacturing_order/parent_manufacturing_order
 #   .py:503
 #
-# That's 144 chars — just past the 140 limit. Shortening the filename to
+# That's 144 chars just past the 140 limit. Shortening the filename to
 # its last 2 path segments yields:
 #
 #   Same query ran 65× at parent_manufacturing_order/parent_manufacturing
 #   _order.py:503
 #
-# ~90 chars — well under the limit — and still uniquely identifies the
+# ~90 chars well under the limit and still uniquely identifies the
 # file for navigation. The full absolute path remains in the finding's
 # technical_detail_json so the developer can jump to it directly.
 #
@@ -590,20 +590,20 @@ def walk_callsite_str(stack: list | None) -> str | None:
 # ---------------------------------------------------------------------------
 # Per-finding-type speedup factors. Applied to the CURRENT average per-query
 # time to estimate what the same query would cost after the recommended
-# fix. These are ceiling estimates — a real fix could do better or worse,
+# fix. These are ceiling estimates a real fix could do better or worse,
 # but they give the developer a rough sense of "is this worth my afternoon".
 #
 # Derivations:
 #   Full Table Scan: scan O(N) → index lookup O(log N). For N=10k-10M the
 #                    ratio is ~20×. Use 0.05.
-#   Missing Index:   same — the suggestion IS to add an index.
+#   Missing Index:   same the suggestion IS to add an index.
 #   Filesort:        sort cost is O(N log N); with an index-ordered read,
 #                    the sort disappears but the read cost remains. Typical
 #                    observed speedup on Frappe DocTypes is ~3×. Use 0.30.
 #   Temporary Table: materialization cost goes away when a covering index
 #                    supports the GROUP BY / DISTINCT. ~2× speedup. Use 0.50.
 #   Low Filter Ratio: the fix is selectivity, so projected_time ≈ current ×
-#                    (filtered% / 100). Special-cased in explain_flags —
+#                    (filtered% / 100). Special-cased in explain_flags
 #                    not a simple factor.
 #   N+1 Query:       N queries × avg → 1 batched query ≈ 2 × avg. Computed
 #                    directly in n_plus_one, not via this table.
@@ -616,7 +616,7 @@ _POST_FIX_SPEEDUP: dict[str, float] = {
 
 # Minimum projected time per query. Even a perfect index lookup costs
 # client/server round-trip + plan time, which is typically ~0.3-0.5ms on
-# a warm MariaDB connection. Don't project below this floor — otherwise
+# a warm MariaDB connection. Don't project below this floor otherwise
 # the report claims "projected 0.0ms" which is nonsense.
 POST_FIX_FLOOR_MS = 0.3
 
@@ -654,7 +654,7 @@ def percentile(values: list[float], pct: int) -> float:
 	analyzers (N+1, redundant calls) to surface the tail of the per-hit
 	duration distribution alongside the consolidated total.
 
-	No numpy dependency — Optimus already ships pure-Python analyzers,
+	No numpy dependency Optimus already ships pure-Python analyzers,
 	and this is exact enough for finding-card P95 readouts.
 	"""
 	if not values:

--- a/optimus/analyzers/call_tree.py
+++ b/optimus/analyzers/call_tree.py
@@ -19,9 +19,9 @@ Aggregates:
   - session_time_breakdown_json: SQL ms + per-app Python ms for the donut
 
 Terminology note (U1): internal field names use ``cumulative_ms``
-(pyinstrument's term — self_time + descendant time). The
+(pyinstrument's term self_time + descendant time). The
 user-facing report tags the same value as ``consolidated``. This
-split is intentional — don't rename one to match the other without
+split is intentional don't rename one to match the other without
 a project-owner sign-off.
 """
 
@@ -200,7 +200,7 @@ def _pyi_to_dict_tree(pyi_session_or_dict) -> dict:
 # ---------------------------------------------------------------------------
 
 
-# Module path prefixes treated as "framework" — graft points roll back
+# Module path prefixes treated as "framework" graft points roll back
 # past these so SQL leaves attach under user code, not under helpers.
 #
 # v0.5.1: the fragments used to include leading slashes ("/frappe/",
@@ -212,7 +212,7 @@ def _pyi_to_dict_tree(pyi_session_or_dict) -> dict:
 # "99% of time was spent in application" (i.e. frappe/app.py::application)
 # instead of descending past the framework frame to the user code
 # below. Dropping the leading slashes makes the filter work against
-# both relative and absolute filenames — a relative filename like
+# both relative and absolute filenames a relative filename like
 # "frappe/handler.py" contains "frappe/", and an absolute filename
 # like "/Users/.../frappe/handler.py" also contains "frappe/".
 _FRAMEWORK_PATH_FRAGMENTS = ("frappe/", "optimus/")
@@ -224,14 +224,14 @@ def _is_framework_frame(node_or_frame: dict) -> bool:
 
 	Used by SQL-to-Python reconciliation and Slow Hot Path findings,
 	which want to blame user code ABOVE the framework boundary and
-	therefore skip aggressively — everything in frappe/* and
+	therefore skip aggressively everything in frappe/* and
 	optimus/*.
 
 	For Repeated Hot Frame + hot-frames leaderboard aggregation, use
 	the NARROWER ``_is_pure_helper_frame`` instead. That function keeps
 	application-layer Frappe code (Document lifecycle, permissions,
 	hooks, naming) visible so users can see legitimate optimization
-	targets inside frappe/* — which is a different question than
+	targets inside frappe/* which is a different question than
 	'whose SQL is this.'
 	"""
 	fn = node_or_frame.get("function") or ""
@@ -246,7 +246,7 @@ def _is_framework_frame(node_or_frame: dict) -> bool:
 
 
 # ---------------------------------------------------------------------------
-# Pure-helper frame detection (v0.5.1 — narrower than framework-frame)
+# Pure-helper frame detection (v0.5.1 narrower than framework-frame)
 # ---------------------------------------------------------------------------
 # The semantic question for the Repeated Hot Frame finding is:
 #
@@ -256,25 +256,25 @@ def _is_framework_frame(node_or_frame: dict) -> bool:
 # user code." Repeated Hot Frame is different: it asks "is this function
 # itself worth optimizing?" Document.run_method, permissions.has_permission,
 # naming.make_autoname, and most of frappe/core/* and frappe/model/* are
-# INSIDE frappe/* yet legitimately slow optimization targets — they run
+# INSIDE frappe/* yet legitimately slow optimization targets they run
 # the user's hooks, their permission rules, or their custom naming
 # configuration. Surfacing them in the leaderboard is correct.
 #
 # So we skip only:
-#   1. optimus/*                 — always (our own tool)
-#   2. /frappe/utils/                    — data conversion, password, redis wrapper
-#   3. /frappe/handler.py, /frappe/app.py — request dispatch plumbing
-#   4. Infrastructure libraries          — werkzeug, gunicorn, rq, redis
+#   1. optimus/* always (our own tool)
+#   2. /frappe/utils/ data conversion, password, redis wrapper
+#   3. /frappe/handler.py, /frappe/app.py request dispatch plumbing
+#   4. Infrastructure libraries werkzeug, gunicorn, rq, redis
 #                                          client, pyinstrument, pytz, dateutil
 #
-# Everything else — including most of frappe/*, all of erpnext/*, and
-# all user apps — is KEPT so users see legitimate optimization targets
+# Everything else including most of frappe/*, all of erpnext/*, and
+# all user apps is KEPT so users see legitimate optimization targets
 # like "Document.run_method consumed 2.4s across 12 actions."
 
 # v0.5.1: suffix matches (via endswith). Specific framework plumbing
 # files where every request passes through the same function on its way
 # from gunicorn to the user's endpoint. Surfacing these in the Repeated
-# Hot Frame leaderboard is meaningless — they're always going to be in
+# Hot Frame leaderboard is meaningless they're always going to be in
 # every action because they ARE the dispatch pipeline. Report on file
 # against ERPNext showed 8 Repeated Hot Frame findings, ALL of them
 # from this list.
@@ -282,7 +282,7 @@ def _is_framework_frame(node_or_frame: dict) -> bool:
 # endswith() works regardless of whether the stored filename is
 # absolute (/Users/.../apps/frappe/frappe/handler.py) or relative
 # (frappe/handler.py) or bench-relative (apps/frappe/frappe/handler.py)
-# — all three end with "frappe/handler.py".
+# all three end with "frappe/handler.py".
 _PURE_HELPER_PATH_SUFFIXES = (
 	# Frappe WSGI entry + request dispatch
 	"frappe/app.py",
@@ -290,7 +290,7 @@ _PURE_HELPER_PATH_SUFFIXES = (
 	"frappe/middlewares.py",
 	# frappe.call, frappe.get_doc (top-level module dispatchers)
 	"frappe/__init__.py",
-	# REST API routing (v0.5.1 addition — missed before because of the
+	# REST API routing (v0.5.1 addition missed before because of the
 	# leading-slash bug, but also needs explicit entries for v1/v2 files)
 	"frappe/api/__init__.py",
 	"frappe/api/v1.py",
@@ -303,14 +303,14 @@ _PURE_HELPER_PATH_SUFFIXES = (
 	"frappe/recorder.py",
 	# v0.5.2: meta-loading plumbing. A real production report had 11
 	# Repeated Hot Frame entries all from meta.py (Meta.__init__,
-	# load_from_db, process, get_meta, ...) — identical cumulative
+	# load_from_db, process, get_meta, ...) identical cumulative
 	# times because they're the same call tree. Users can't optimize
 	# "how Meta loads its fields"; they ARE the framework's cold path.
 	"frappe/model/meta.py",
 	# v0.5.2: entire frappe/model/document.py is framework plumbing.
 	# Document.save / insert / submit etc. look user-recognisable but
 	# their cumulative time is always just the sum of the validate /
-	# on_submit / etc. hooks inside them — which ARE visible as
+	# on_submit / etc. hooks inside them which ARE visible as
 	# separate hot frames in the user's own app code (erpnext/myapp/
 	# validate). Keeping document.py entries in the leaderboard
 	# produces double-counting noise: save → _save → run_method →
@@ -319,7 +319,7 @@ _PURE_HELPER_PATH_SUFFIXES = (
 	# document.py entries and only validate/set_missing_values (the
 	# actual user code) told the user anything new.
 	"frappe/model/document.py",
-	# Form-level meta loading: getdoctype, get_meta_bundle — these are
+	# Form-level meta loading: getdoctype, get_meta_bundle these are
 	# what Desk calls when you open a form. Cumulative time is always
 	# ~= the doctype cache miss cost, which Frappe handles internally.
 	"frappe/desk/form/load.py",
@@ -327,17 +327,17 @@ _PURE_HELPER_PATH_SUFFIXES = (
 	# Query builder internals. Every SQL query the ORM builds passes
 	# through these. Cumulative time on a report session is the sum
 	# across all queries; the hot frame just means "this session had
-	# a lot of SQL" — the top_queries/index_suggestions analyzers
+	# a lot of SQL" the top_queries/index_suggestions analyzers
 	# already surface that signal more actionably.
 	"frappe/query_builder/utils.py",
 	"frappe/model/qb_query.py",
 	# Low-level DB cursor layer. frappe.db.sql / get_values / execute
 	# all land here. Same "every query passes through" story as the
-	# query builder — not a user-actionable hot frame.
+	# query builder not a user-actionable hot frame.
 	"frappe/database/database.py",
 	"frappe/database/mariadb/database.py",
 	"frappe/database/postgres/database.py",
-	# Intentionally NOT filtered: frappe/model/naming.py — a user's
+	# Intentionally NOT filtered: frappe/model/naming.py a user's
 	# naming-series configuration IS optimizable (simpler series,
 	# fewer SQL lookups), so make_autoname staying visible in the
 	# hot-frames leaderboard is correct.
@@ -345,14 +345,14 @@ _PURE_HELPER_PATH_SUFFIXES = (
 
 # v0.5.1: substring matches (via `in`). Whole directories of framework
 # helpers / infrastructure libraries. Fragment values MUST NOT have
-# leading slashes — the stored filenames are typically relative
+# leading slashes the stored filenames are typically relative
 # (`frappe/utils/foo.py`), and `/frappe/utils/` does not occur as a
 # substring of `frappe/utils/foo.py`. See the comment on
 # _FRAMEWORK_PATH_FRAGMENTS for the full history of this bug.
 _PURE_HELPER_PATH_SUBSTRINGS = (
 	"optimus/",
 	"frappe/utils/",          # typing_validations, response, redis_wrapper, etc.
-	# v0.5.2: frappe/model/utils/ is plumbing too — is_virtual_doctype,
+	# v0.5.2: frappe/model/utils/ is plumbing too is_virtual_doctype,
 	# get_parent_doc, etc. Called by the document loader and doesn't
 	# reflect any user decision. Distinct from frappe/utils/ which
 	# wouldn't have matched it because there's a `/model/` in between.
@@ -381,7 +381,7 @@ _PURE_HELPER_FUNCTION_PREFIXES = (
 # pattern: functools.wraps / frappe.hook / erpnext.naming_decorator
 # produce frames named "wrapper", "composer", "runner", "fn". They
 # forward to the real function and their cumulative_ms is essentially
-# identical to the wrapped function's — so showing BOTH in the hot-
+# identical to the wrapped function's so showing BOTH in the hot-
 # frame leaderboard is noise: the user sees two rows with the same
 # time for every decorated method.
 #
@@ -394,7 +394,7 @@ _PURE_HELPER_FUNCTION_NAMES = frozenset({
 	# functools.wraps + frappe.hook decorator internals
 	"wrapper", "composer", "runner", "fn", "hook", "compose",
 	"add_to_return_value",
-	# Private delegation shims — always called by their non-underscored
+	# Private delegation shims always called by their non-underscored
 	# sibling (save → _save, insert → _insert, etc.). Keep the public
 	# entry point in the leaderboard; hide the private one.
 	"_save", "_insert",
@@ -410,7 +410,7 @@ _PURE_HELPER_FUNCTION_NAMES = frozenset({
 
 # v0.5.2: bench/site third-party libraries whose frames pyinstrument
 # leaves without the site-packages/ prefix. MySQLdb / pymysql /
-# requests etc. These aren't Frappe apps — the user can't optimize
+# requests etc. These aren't Frappe apps the user can't optimize
 # them. Already filtered by the donut's _top_level_app but wasn't
 # filtered here, so they leaked into the Repeated Hot Frame
 # leaderboard.
@@ -427,11 +427,11 @@ def _is_pure_helper_frame(
 	plumbing helpers that users can't optimize. Keeps most of frappe/*
 	so hot-frame findings remain useful when application-layer Frappe
 	code (Document lifecycle, permissions, hooks, naming) is the actual
-	bottleneck — and users who ARE Frappe contributors can see those as
+	bottleneck and users who ARE Frappe contributors can see those as
 	legitimate targets too.
 
 	Called by the Repeated Hot Frame aggregator AND by
-	``_is_walker_plumbing_frame`` (the Slow Hot Path / Hook / BG-job walker) — so
+	``_is_walker_plumbing_frame`` (the Slow Hot Path / Hook / BG-job walker) so
 	both surfaces share this predicate. NOT for SQL-to-Python reconciliation, which
 	wants the broader ``_is_framework_frame`` so SQL attributes blame to user code
 	above the framework boundary.
@@ -465,7 +465,7 @@ def _is_pure_helper_frame(
 		return False
 
 	# Any venv / system-packages path is third-party regardless of whether the lib
-	# is in the hardcoded set below — a real ``site-packages/`` path is never the
+	# is in the hardcoded set below a real ``site-packages/`` path is never the
 	# developer's code, so it must not leak into the hot-frame leaderboard.
 	# (Mirrors the same guard in base.is_framework_callsite.)
 	if "site-packages/" in filename or "dist-packages/" in filename:
@@ -473,7 +473,7 @@ def _is_pure_helper_frame(
 
 	# Tracked Apps (inclusion mode): when the operator has configured which apps
 	# to profile in Optimus Settings, a frame OUTSIDE those apps is out of scope,
-	# so treat it as plumbing (skip it) — the same decision the SQL classifier
+	# so treat it as plumbing (skip it) the same decision the SQL classifier
 	# makes via is_framework_callsite's inclusion mode. Off (empty) → no-op.
 	if tracked_apps and is_framework_callsite(filename, tracked_apps, installed_apps):
 		return True
@@ -506,11 +506,11 @@ def _is_pure_helper_frame(
 
 	first_segment = stripped.split("/", 1)[0]
 	# Exclusion mode + on-bench: ground-truth allowlist, keyed on the RESOLVED app
-	# root — the boundary-anchored ``apps/<app>/`` segment (or, for an absolute
+	# root the boundary-anchored ``apps/<app>/`` segment (or, for an absolute
 	# path, the last-``apps/``-wins one), exactly as base.is_framework_callsite and
 	# _top_level_app resolve it. Keying on the raw first segment would read "apps"
-	# for an apps/-prefixed path and "home"/"opt" for an absolute one — neither an
-	# installed app — and wrongly drop the user's own frames, diverging from the SQL
+	# for an apps/-prefixed path and "home"/"opt" for an absolute one neither an
+	# installed app and wrongly drop the user's own frames, diverging from the SQL
 	# classifier this change exists to match. Inclusion mode was already decided
 	# above (line 473); the allowlist must not re-filter a tracked app that isn't
 	# among the site's installed apps. Truthy check (not ``is not None``) so an
@@ -543,16 +543,16 @@ def _is_walker_plumbing_frame(
 	``_is_pure_helper_frame``'s angle-bracket-filename rule classifies as
 	plumbing for the Repeated Hot Frame aggregator (one-off scripts don't
 	aggregate). For the Slow Hot Path walker, they are legitimate
-	user-actionable hot frames — and they stay actionable even when Tracked Apps
+	user-actionable hot frames and they stay actionable even when Tracked Apps
 	is configured, because a Server Script is the developer's own optimizable code
 	(it lives in the database, not in any app), so it is never "out of scope".
 	"""
 	if _is_framework_frame(node):
 		return True
 	filename = (node.get("filename") or "").replace("\\", "/").lstrip("/")
-	# Server Script bodies → user code for the walker, not plumbing — regardless of
+	# Server Script bodies → user code for the walker, not plumbing regardless of
 	# Tracked Apps. Frappe's safe_exec emits ``<serverscript>`` (bare) or
-	# ``<serverscript>: <name>`` — match on the ``<serverscript`` prefix (same as
+	# ``<serverscript>: <name>``: match on the ``<serverscript`` prefix (same as
 	# the sister checks in _display_name_for_node and _top_level_app); the older
 	# ``<serverscript-N>`` form is covered too.
 	if filename.startswith("<serverscript") or filename.startswith("<server-script"):
@@ -590,11 +590,11 @@ def _find_graft_point(root: dict, stack: list):
 				next_child = child
 				break
 		if next_child is None:
-			# No further match — stop descending
+			# No further match stop descending
 			break
 		current = next_child
 		last_matched_index = i
-		# Track the deepest non-framework match — that's where we graft.
+		# Track the deepest non-framework match that's where we graft.
 		if not _is_framework_frame(current):
 			matched_user_node = current
 
@@ -612,7 +612,7 @@ def _coalesce_sql_siblings(node: dict) -> None:
 	Coalescing key: (query_normalized, partial_match). Coalesced nodes
 	get an `is_n_plus_one_hint=True` flag the renderer uses to show
 	`<sql> ×N` instead of N separate rows. The n_plus_one analyzer still
-	emits its own finding — this is just a renderer hint.
+	emits its own finding this is just a renderer hint.
 	"""
 	children = node.get("children") or []
 	if not children:
@@ -652,7 +652,7 @@ def reconcile(pyi_session_or_dict, sql_calls: list, action_wall_time_ms: float) 
 	where the recorder stack ran past the pyi tree's visible depth.
 
 	Time-accounting invariant: pyinstrument has already counted SQL time
-	in every Python ancestor's cumulative_ms. We DO NOT subtract — the
+	in every Python ancestor's cumulative_ms. We DO NOT subtract the
 	leaf's self_ms is informational only. The renderer always reads
 	cumulative_ms from the node itself, never sums children.
 	"""
@@ -696,7 +696,7 @@ def _prune_recursive(node: dict, threshold: float) -> None:
 	dropped_self_ms = 0.0
 	dropped_cumulative_ms = 0.0
 	for child in children:
-		# Never prune SQL leaves — they're always meaningful
+		# Never prune SQL leaves they're always meaningful
 		if child.get("kind") == "sql":
 			kept.append(child)
 			continue
@@ -776,12 +776,12 @@ def _soft_cap_recursive(node: dict, max_nodes: int, state: dict) -> None:
 # of the Medium pair so a single configured threshold drives both.
 DEFAULT_HOT_PATH_PCT = 0.25  # fallback when settings unreachable
 DEFAULT_HOT_PATH_MS = 200
-HOT_PATH_HIGH_PCT_MULTIPLIER = 2.0     # 0.50 / 0.25 — preserves legacy ratio
+HOT_PATH_HIGH_PCT_MULTIPLIER = 2.0     # 0.50 / 0.25 preserves legacy ratio
 HOT_PATH_HIGH_MS_MULTIPLIER = 2.5      # 500 / 200
 # v0.7.x: absolute-impact escape hatch. A subtree consuming >= this many
 # multiples of high_ms is High regardless of relative pct. Picked at 2.0
 # (≥1s at default) so a 1.4s subtree at 49% of a 3s action gets the
-# severity its absolute impact deserves — without this, the TL;DR
+# severity its absolute impact deserves without this, the TL;DR
 # headline picks smaller High findings over larger Medium ones.
 HOT_PATH_HIGH_ABS_MULTIPLIER = 2.0     # 2× high_ms → 1000ms by default
 SQL_DOMINANCE_SUPPRESSION_PCT = 0.80
@@ -821,7 +821,7 @@ def _largest_sql_child(node: dict):
 # v0.5.3: Uninformative function names pyinstrument emits for dynamically
 # executed code. A Server Script body, a `exec()`'d snippet, a module's
 # top level, or a list/generator/dict-comp with no function context all
-# show up as one of these synthetic names — and plugging them directly
+# show up as one of these synthetic names and plugging them directly
 # into a finding title gives nonsensical output like
 # "spent in <module>" or "spent in " (empty).
 _UNINFORMATIVE_FUNCTION_NAMES = frozenset({
@@ -845,10 +845,10 @@ def _display_name_for_node(node: dict) -> str:
 	  1. ``node["function"]`` if it's a real name (not in the
 	     uninformative list).
 	  2. ``short_filename(filename):lineno`` when we can derive a
-	     file location — useful for module-scope or ``<module>``
+	     file location useful for module-scope or ``<module>``
 	     frames so the title reads "spent in myapp/foo.py:42".
 	  3. A type-aware label based on what the synthetic name
-	     suggests — e.g. a Server Script body becomes
+	     suggests e.g. a Server Script body becomes
 	     "<server-script body>". Better than pass-through because
 	     the report reader immediately understands what's slow.
 	  4. "<unnamed code>" as last resort.
@@ -868,7 +868,7 @@ def _display_name_for_node(node: dict) -> str:
 
 	# Detect Server Scripts: Frappe's safe_exec compiles with filename
 	# "<serverscript>" (bare) or "<serverscript>: <scrubbed-name>". Surface
-	# the script name + lineno so the user can locate the issue — the
+	# the script name + lineno so the user can locate the issue the
 	# v0.7.x+ renderer also links these callsites to the Desk Server Script
 	# form (see optimus/server_script_source.py).
 	if filename.startswith("<serverscript") or filename.startswith("<server-script"):
@@ -907,7 +907,7 @@ def _first_user_code_descendant(
 
 	Walks depth-first so the *deepest* hot user-code frame wins over an
 	enclosing wrapper that just relays its work. Skips frames classified
-	as framework OR pure-helper plumbing — same predicates the walker
+	as framework OR pure-helper plumbing same predicates the walker
 	uses to descend past them.
 
 	Used by the BG-job fallback when the regular Slow Hot Path walker
@@ -950,7 +950,7 @@ def _emit_per_action_findings(
 
 	For BG jobs (action_label starts with "RQ Job: ") that don't produce
 	any per-frame finding but ARE slow, emit a Slow Background Job
-	finding rooted at the deepest user-code frame — so the reader has an
+	finding rooted at the deepest user-code frame so the reader has an
 	actionable callsite instead of an unexplained 12s job entry.
 	"""
 	if action_wall_time_ms <= 0:
@@ -1000,7 +1000,7 @@ def _emit_per_action_findings(
 						f"crossed the Slow Hot Path threshold. **{fn_name}** "
 						f"is the deepest user-code frame and accounts for "
 						f"{impact_ms:.0f}ms ({pct_str} of the job). Start "
-						"there — open the Line-Level Drilldown for a "
+						"there open the Line-Level Drilldown for a "
 						"statement-level breakdown of where the time goes."
 					),
 					"technical_detail_json": json.dumps({
@@ -1034,7 +1034,7 @@ def _walk_for_findings(
 	# across actions and produce pct > 100% (impossible per-action),
 	# which would tier-promote a Medium finding to High purely
 	# because of cross-action aggregation. The absolute-ms gate
-	# (cumulative >= med_ms / high_ms) still uses raw cumulative —
+	# (cumulative >= med_ms / high_ms) still uses raw cumulative
 	# the user *did* spend that much time across actions; we only
 	# refuse to inflate the *percentage* tier.
 	raw_pct = cumulative / action_wall_time_ms if action_wall_time_ms else 0
@@ -1100,7 +1100,7 @@ def _walk_for_findings(
 			# v0.7.x: BG-job action_label carries an "RQ Job: " prefix
 			# for disambiguation in the per-action table. Inside a
 			# finding title that already says "In <label>, …", the
-			# prefix reads as boilerplate — strip it to "In job
+			# prefix reads as boilerplate strip it to "In job
 			# <short>" so the hotspot is the visual anchor, not the
 			# wrapper noise.
 			if action_label.startswith("RQ Job: "):
@@ -1116,7 +1116,7 @@ def _walk_for_findings(
 			# name. Pyinstrument's aggregator merges trivially-identical
 			# siblings, but distinct call sites stay separate nodes;
 			# sharing function name across them means this function was
-			# hit from N call sites in one action — useful signal for
+			# hit from N call sites in one action useful signal for
 			# "called from a loop" diagnoses.
 			parent = parent_chain[-1] if parent_chain else None
 			intra_action_repetitions = (
@@ -1136,7 +1136,7 @@ def _walk_for_findings(
 					"customer_description": (
 						f"During *{_label_for_title}*, the **{fn_name}** doc-event hook "
 						f"consumed {pct_str} of its wall time ({impact_ms:.0f}ms). "
-						"Hook functions run on every save/submit — optimizing this "
+						"Hook functions run on every save/submit optimizing this "
 						"would speed up every similar action across your site."
 					),
 					"technical_detail_json": json.dumps({
@@ -1159,8 +1159,8 @@ def _walk_for_findings(
 				# .apply_pricing_rule" and fn_name = "apply_pricing_rule"),
 				# the classic phrasing "In X, N% of time was spent in
 				# X" reads as tautology. The real signal is that the
-				# function's own body is the hot spot — not a subcall
-				# — so surface THAT. User-reported on a real Sales
+				# function's own body is the hot spot not a subcall
+				# so surface THAT. User-reported on a real Sales
 				# Invoice Submit report.
 				self_referential = (
 					action_label == fn_name
@@ -1175,17 +1175,17 @@ def _walk_for_findings(
 					desc = (
 						f"The body of **{fn_name}** itself consumed "
 						f"{pct_str} of the action time ({impact_ms:.0f}ms). "
-						"This isn't a slow subcall — the function's own logic "
+						"This isn't a slow subcall the function's own logic "
 						"is the bottleneck. To pinpoint the exact hot line, "
 						"run a **Line-Level Drilldown** (the *Run Line-Profile "
 						"Pass* button on the session) and pick this function "
-						"from the candidates — that profiles tight loops, "
+						"from the candidates that profiles tight loops, "
 						"expensive computations, and string/regex work at the "
 						"statement level so you can optimize or cache them."
 						"\n\nNote: self-time here is wall-clock (the sampler "
 						"measures elapsed time, not CPU). If this function "
-						"blocks on I/O — `requests.get`, sync DB calls "
-						"outside the recorder, `time.sleep` — that wait "
+						"blocks on I/O `requests.get`, sync DB calls "
+						"outside the recorder, `time.sleep`: that wait "
 						"counts as self-time. Check the call tree for "
 						"hidden I/O before optimising compute."
 					)
@@ -1220,7 +1220,7 @@ def _walk_for_findings(
 					"action_ref": str(action_idx),
 				})
 			# When we emit a finding for this node, do NOT recurse into
-			# its children — children are already represented in the
+			# its children children are already represented in the
 			# subtree's cumulative_ms, and recursing would create
 			# overlapping nested findings.
 			return
@@ -1255,7 +1255,7 @@ def _redacted_module_key(function: str, filename: str = "") -> str | None:
 	modules, or 20 different ``handle`` methods) don't all collapse
 	into one bucket. Pre-v0.5.1 used the bare function name, which
 	produced misleading 'Repeated Hot Frame' findings blaming generic
-	decorator wrappers that the user cannot optimize — every functools
+	decorator wrappers that the user cannot optimize every functools
 	wrapper, werkzeug wrapper, and frappe.whitelist wrapper in the
 	session would roll up under a single 'wrapper' key.
 
@@ -1288,9 +1288,9 @@ def _aggregate_hot_frames(
 	"""Build the cross-action hot frames map → (findings, leaderboard).
 
 	Returns:
-	  findings   — list of Repeated Hot Frame findings (session-wide,
+	  findings list of Repeated Hot Frame findings (session-wide,
 	               no action_ref)
-	  leaderboard — list of top-N dicts for hot_frames_json
+	  leaderboard list of top-N dicts for hot_frames_json
 	"""
 	# {function_key: [(action_idx, self_ms, cumulative_ms), ...]}
 	occurrences: dict = defaultdict(list)
@@ -1316,10 +1316,10 @@ def _aggregate_hot_frames(
 		row = {
 			"function": key,
 			# A.AE1: self-sum is the precise "time in this function
-			# across the whole tree" metric — what the user-app
+			# across the whole tree" metric what the user-app
 			# variant displays.
 			"total_ms": round(total_self_ms, 2),
-			# Cumulative-sum — what the framework variant displays.
+			# Cumulative-sum what the framework variant displays.
 			# See _walk_for_aggregation's comment for the why.
 			"total_cumulative_ms": round(total_cum_ms, 2),
 			"occurrences": len(occs),
@@ -1370,7 +1370,7 @@ def _walk_for_aggregation(
 ) -> None:
 	if node.get("kind") == "python":
 		# v0.5.1: skip PURE HELPER frames only, not all framework code.
-		# This is the narrower _is_pure_helper_frame check — we want to
+		# This is the narrower _is_pure_helper_frame check we want to
 		# keep Document.run_method, permission checks, naming, and other
 		# application-layer Frappe code in the leaderboard because they
 		# can be legitimate optimization targets (e.g. a slow doc-event
@@ -1379,7 +1379,7 @@ def _walk_for_aggregation(
 		# (werkzeug, rq, etc.) are suppressed.
 		#
 		# An earlier v0.5.1 draft used the broader _is_framework_frame
-		# here, which hid ALL frappe/* frames — that was too aggressive
+		# here, which hid ALL frappe/* frames that was too aggressive
 		# and blinded the analyzer to real application-layer bottlenecks
 		# inside Frappe that users could act on.
 		if not _is_pure_helper_frame(node, tracked_apps, installed_apps):
@@ -1389,7 +1389,7 @@ def _walk_for_aggregation(
 			)
 			if key:
 				# v0.7.x A.AE1: track self_ms (immune to recursion
-				# double-counting) for the user-app variant — that's
+				# double-counting) for the user-app variant that's
 				# the exact "time in this function's body across the
 				# whole action's tree" answer.
 				#
@@ -1400,7 +1400,7 @@ def _walk_for_aggregation(
 				# The framework column displays cumulative_ms instead
 				# (renderer.build_hot_frames_table chooses per
 				# variant). Risk: nested same-name framework frames
-				# would double-count cumulative — acceptable on the
+				# would double-count cumulative acceptable on the
 				# collapsed-by-default framework table, where the
 				# column is informational rather than decision-grade.
 				occurrences[key].append(
@@ -1437,7 +1437,7 @@ def _strip_profiler_frames(node: dict) -> dict:
 
 	67% of the action's time was attributed to the profiler's own
 	infra snapshot. The root cause was _start_pyi_session being
-	called BEFORE infra_capture.snapshot() in before_request — the
+	called BEFORE infra_capture.snapshot() in before_request the
 	snapshot was still on the call stack when pyinstrument began
 	sampling. The primary fix (v0.5.1) reorders the hook so the
 	snapshot happens first. This tree-strip pass is belt-and-
@@ -1475,14 +1475,14 @@ def _top_level_app(function: str, filename: str) -> str:
 	function name), with additional filters to keep Python stdlib /
 	synthetic / third-party frames from polluting the bucket list.
 
-	A real production donut showed these noise buckets — all 0ms each:
+	A real production donut showed these noise buckets all 0ms each:
 
-	    Python (inspect.py)    — Python stdlib (single-segment filename)
-	    Python (functools.py)  — Python stdlib
-	    Python (MySQLdb)       — third-party, pyinstrument stripped
+	    Python (inspect.py) Python stdlib (single-segment filename)
+	    Python (functools.py) Python stdlib
+	    Python (MySQLdb) third-party, pyinstrument stripped
 	                             "site-packages/" so the substring
 	                             filter missed it
-	    Python (<built-in>)    — pyinstrument synthetic for C builtins
+	    Python (<built-in>) pyinstrument synthetic for C builtins
 
 	All four should collapse to the ``[other]`` catch-all. The rules
 	that route them correctly:
@@ -1492,12 +1492,12 @@ def _top_level_app(function: str, filename: str) -> str:
 	  2. Synthetic filenames wrapped in angle brackets → [other]
 	  3. Filenames containing ``site-packages/`` or ``dist-packages/``
 	     (third-party libs) → [other]
-	  4. Single-segment filenames (``inspect.py``, ``functools.py``) —
+	  4. Single-segment filenames (``inspect.py``, ``functools.py``)
 	     these are stdlib or loose scripts, not Frappe apps → [other]
 	  5. ``apps/<name>/`` marker → ``<name>``
 	  6. First path segment of a multi-segment filename, filtered to
 	     actual installed Frappe apps via ``frappe.get_installed_apps()``
-	     when available — otherwise accept the first segment (legacy
+	     when available otherwise accept the first segment (legacy
 	     behavior, used by unit tests that can't import frappe)
 
 	Handles the common pyinstrument path shapes:
@@ -1561,7 +1561,7 @@ def _top_level_app(function: str, filename: str) -> str:
 
 	# Pyinstrument's ``file_path_short`` usually strips bench prefixes
 	# already, leaving something like ``frappe/handler.py``. Take the
-	# first path segment as the app name — but only if it looks like
+	# first path segment as the app name but only if it looks like
 	# an actually installed Frappe app. Third-party libs (``MySQLdb/
 	# connections.py``) otherwise produce a first-segment bucket like
 	# "MySQLdb" that has nothing to do with the user's code.
@@ -1573,7 +1573,7 @@ def _top_level_app(function: str, filename: str) -> str:
 	# Intersect with installed apps when we're running inside a real
 	# Frappe site. When frappe isn't importable (unit tests on an
 	# isolated machine) or get_installed_apps fails, fall back to
-	# accepting any first-segment — the legacy behavior that keeps
+	# accepting any first-segment the legacy behavior that keeps
 	# the pre-v0.5.1 tests green without requiring a mocked frappe.
 	try:
 		import frappe
@@ -1660,7 +1660,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 	node_cap = _conf_int("optimus_tree_node_cap", DEFAULT_TREE_NODE_CAP)
 
 	# Tracked Apps (Optimus Settings ▸ Tracked Apps): when set, only frames in
-	# those apps are surfaced as hot-frame / slow-path / BG-job findings — every
+	# those apps are surfaced as hot-frame / slow-path / BG-job findings every
 	# other frame is treated as out-of-scope plumbing, matching how the SQL
 	# analyzers already honour inclusion mode. Empty → profile everything.
 	try:
@@ -1673,7 +1673,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 	installed_apps = installed_apps_allowlist()
 
 	for action_idx, recording in enumerate(recordings):
-		# v0.7.x (M1): pop, don't get — call_tree is the ONLY consumer of the
+		# v0.7.x (M1): pop, don't get call_tree is the ONLY consumer of the
 		# raw pyinstrument Session, and holding all recordings' trees in RAM at
 		# once was the dominant analyze-time memory spike (OOM on long flows).
 		# Popping frees each tree as soon as it's reconciled, so peak drops from
@@ -1697,7 +1697,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 				"function": "<root>", "children": [],
 				"cumulative_ms": 0, "self_ms": 0, "kind": "python",
 			})
-			# Set null call_tree on the action — renderer falls back gracefully
+			# Set null call_tree on the action renderer falls back gracefully
 			if action_idx < len(context.actions):
 				context.actions[action_idx]["call_tree_json"] = None
 			continue
@@ -1710,7 +1710,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 			# v0.5.1: belt-and-suspenders strip of any residual
 			# optimus/* frames that slipped through the hook
 			# ordering fix. See _strip_profiler_frames docstring for
-			# the full rationale — the short version is that even
+			# the full rationale the short version is that even
 			# with _start_pyi_session now running AFTER infra_capture
 			# .snapshot(), pyinstrument can still sample a single
 			# frame of before_request on its way out, or a capture

--- a/optimus/analyzers/explain_flags.py
+++ b/optimus/analyzers/explain_flags.py
@@ -13,7 +13,7 @@ the four most actionable red flags:
     filtered < 10            → reading much more than returned
 
 Each match becomes a finding tagged by table. Findings are deduplicated by
-(finding_type, table) — if 50 queries hit the same full-scan table, we
+(finding_type, table) if 50 queries hit the same full-scan table, we
 report it once with the cumulative impact.
 """
 
@@ -37,7 +37,7 @@ def _item_to_plan_table(item: dict) -> PlanTable:
 
 	The EXPLAIN runner now stores normalized PlanTable dicts, but older
 	persisted recordings / cache entries / fixtures hold raw MariaDB EXPLAIN
-	rows — distinguish by the presence of the ``full_scan`` key and map a
+	rows distinguish by the presence of the ``full_scan`` key and map a
 	legacy row through the MariaDB adapter so old data still analyzes."""
 	if "full_scan" in item:
 		return PlanTable(
@@ -68,20 +68,20 @@ LOW_FILTERED_MIN_ROWS = 100
 # SELECT * FROM tabCustom DocPerm WHERE parent=? ORDER BY creation ASC
 # query where EXPLAIN reported rows=1 (a single-parent lookup with the
 # `parent` index already doing const-ref access). The filesort is on
-# one row — actionable only in the abstract. 100 rows is the same
+# one row actionable only in the abstract. 100 rows is the same
 # floor LOW_FILTERED_MIN_ROWS uses for the same reason.
 MIN_ROWS_TO_FLAG_SORT = 100
 
 # v0.5.2 round 3: noise floor. An aggregated bucket (e.g. "Full Table
 # Scan on tabBankClearanceDetail") with tiny total impact AND tiny
-# count isn't actionable — it's a one-off touch during init / metadata
+# count isn't actionable it's a one-off touch during init / metadata
 # resolution, not a hot path. Surfacing it just inflates the
 # "125 findings" stats card with noise. Production report had ~85
 # such entries all at 0-1ms.
 NOISE_FLOOR_IMPACT_MS = 5.0
 NOISE_FLOOR_COUNT = 5
 
-# Framework-owned DocTypes — any scan/filesort/temp finding on one of
+# Framework-owned DocTypes any scan/filesort/temp finding on one of
 # these routes to Observations because the application developer can't
 # add an index to a stock Frappe/ERPNext DocType. Populated lazily
 # from the DocType + Module Def tables on first use per analyze pass.
@@ -92,7 +92,7 @@ def _get_framework_doctypes() -> frozenset[str]:
 	"""Return the set of DocType names owned by framework apps
 	(frappe, erpnext, hrms, etc.).
 
-	Cached per process. Fall back to empty set on any error — the
+	Cached per process. Fall back to empty set on any error the
 	noise-floor filter still runs, so we don't lose correctness.
 	"""
 	global _framework_doctypes_cache
@@ -213,7 +213,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 
 		# Framework DocType filter: a Full Scan on tabDocField /
 		# tabWorkspace / tabCustom Field / etc. isn't fixable by the
-		# application developer — requires an upstream index patch.
+		# application developer requires an upstream index patch.
 		# Route to Observations by tagging the finding type.
 		if _is_framework_doctype_table(table, framework_doctypes):
 			drop_framework_doctype += 1
@@ -279,7 +279,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			f"Suppressed SQL findings from {drop_framework_callsite} "
 			"call(s) whose callsite was inside Frappe framework code. "
 			"The loop that issues those queries lives inside frappe/* "
-			"— application developers can't add an index to fix them "
+			" application developers can't add an index to fix them "
 			"from their code. If one of these is a hot spot, raise it "
 			"upstream in the Frappe repo."
 		)
@@ -288,7 +288,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			f"Suppressed {drop_alias} EXPLAIN row(s) whose `table` value "
 			"was a SQL alias (a / c / p / addr / ...) rather than a "
 			"real table name. 'Full table scan on a' isn't actionable "
-			"without knowing which table 'a' aliases — the per-query "
+			"without knowing which table 'a' aliases the per-query "
 			"detail in the Top Queries section shows the actual SQL "
 			"if you want to investigate."
 		)
@@ -297,7 +297,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			f"Suppressed {drop_framework_doctype} SQL finding(s) on "
 			"stock Frappe / ERPNext DocTypes (tabDocField, tabWorkspace, "
 			"tabCustom Field, etc.). You can't add an index to a "
-			"framework-owned DocType from your application code — it "
+			"framework-owned DocType from your application code it "
 			"requires an upstream patch. If one of these is a real "
 			"hot spot, check whether a Frappe upgrade has already "
 			"indexed it, or file an upstream issue."
@@ -337,7 +337,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 # ---------------------------------------------------------------------------
 # MariaDB's `rows` and `filtered` columns come back as int/float in the
 # typical PyMySQL path, but certain driver versions and EXPLAIN FORMAT
-# variants have been observed to return Decimal, str, or even None — any
+# variants have been observed to return Decimal, str, or even None any
 # of which would crash a Python 3 `>` comparison with a numeric literal.
 # v0.5.1 adds explicit coercion helpers so one weird row doesn't take out
 # the whole session.
@@ -349,7 +349,7 @@ def _to_int(val) -> int:
 	if val is None:
 		return 0
 	if isinstance(val, bool):
-		# bool is a subclass of int — treat False as 0, True as 1
+		# bool is a subclass of int treat False as 0, True as 1
 		return int(val)
 	if isinstance(val, int):
 		return val
@@ -395,7 +395,7 @@ def _is_framework_origin(
 	Table / Low Filter findings whose issuing code lives in the
 	framework. Same rationale as the Framework N+1 split: the
 	application developer can't add an index for a query that
-	Frappe/ERPNext issues — they'd have to patch upstream.
+	Frappe/ERPNext issues they'd have to patch upstream.
 
 	walk_callsite walks innermost-to-outermost for a non-frappe-core
 	frame; its fallback returns the deepest frame if ALL frames are
@@ -405,7 +405,7 @@ def _is_framework_origin(
 	so findings rooted in erpnext loops don't surface as actionable.
 	"""
 	if not stack:
-		# No stack captured. Don't filter — fall through to the
+		# No stack captured. Don't filter fall through to the
 		# legacy behavior where every query produces findings.
 		# This path is hit on older recordings that pre-date
 		# stack-per-call capture.
@@ -413,7 +413,7 @@ def _is_framework_origin(
 	callsite = walk_callsite(stack)
 	if callsite is None:
 		# Pure-profiler stack → filtered (though those should
-		# already be gone at this stage — defensive).
+		# already be gone at this stage defensive).
 		return True
 	return is_framework_callsite(
 		callsite.get("filename") or "", tracked_apps=tracked_apps, installed_apps=installed_apps
@@ -423,7 +423,7 @@ def _is_framework_origin(
 # v0.5.2 round 4: INFORMATION_SCHEMA / MariaDB metadata views that
 # show up as ``table`` values in EXPLAIN rows. These ARE real tables
 # (in the ``information_schema`` database), but the user can't add
-# indexes to them — they're engine-managed. Production reports have
+# indexes to them they're engine-managed. Production reports have
 # shown "Full table scan on columns" and "Full table scan on tables"
 # cluttering actionable findings; both are INFORMATION_SCHEMA views.
 # Treat them as aliases (suppressed with the SQL-alias warning).
@@ -447,21 +447,21 @@ def _is_likely_alias(table: str) -> bool:
 	that starts with a letter and is short + lowercase-only is
 	almost certainly an alias:
 
-	  ``a``   — alias
-	  ``c``   — alias
-	  ``ap``  — alias
-	  ``cd``  — alias
-	  ``addr`` — alias (common for Address)
-	  ``p``   — alias
-	  ``d``   — alias
+	  ``a`` alias
+	  ``c`` alias
+	  ``ap`` alias
+	  ``cd`` alias
+	  ``addr``: alias (common for Address)
+	  ``p`` alias
+	  ``d`` alias
 
 	These come from EXPLAIN rows for JOIN queries where MariaDB
 	uses the aliased name in the `table` column of its output.
 	A finding of "Full table scan on a" has no actionable signal
-	— the user can't index "a", they'd need the real table name.
+	the user can't index "a", they'd need the real table name.
 
 	Also filters INFORMATION_SCHEMA pseudo-tables (``columns``,
-	``tables``, ``schemata``, etc.) — these are real but not
+	``tables``, ``schemata``, etc.) these are real but not
 	user-indexable, same "no action available" property as a raw
 	alias.
 
@@ -479,22 +479,22 @@ def _is_likely_alias(table: str) -> bool:
 	# view) would otherwise be misclassified as a real Frappe
 	# DocType via the startswith("tab") short-circuit. SQL is case-
 	# insensitive on table names and the engine typically lowercases
-	# them in EXPLAIN output — so "columns" matches, "COLUMNS" also
+	# them in EXPLAIN output so "columns" matches, "COLUMNS" also
 	# matches after lowering.
 	if s.lower() in _SYSTEM_METADATA_TABLES:
 		return True
-	# Real Frappe tables — always kept.
+	# Real Frappe tables always kept.
 	if s.startswith("tab"):
 		return False
 	# Quoted identifiers (with spaces / capitals) are real tables
 	# the user created with a non-standard name.
 	if any(ch.isupper() for ch in s) or " " in s:
 		return False
-	# Non-ASCII characters — assume real table.
+	# Non-ASCII characters assume real table.
 	if not s.isascii():
 		return False
 	# Anything else short + lowercase is probably an alias. 5 chars
-	# is the cutoff — "users", "items" would pass; "a", "ap", "addr"
+	# is the cutoff "users", "items" would pass; "a", "ap", "addr"
 	# would be flagged.
 	if len(s) <= 5 and s.replace("_", "").isalpha() and s.islower():
 		return True
@@ -509,14 +509,14 @@ def _inspect_table(pt, normalized_query, action_idx, query_duration, buckets):
 
 	Returns ``"alias"`` when the table is a SQL alias (skipped, caller counts
 	it for the warning), or ``None`` on normal processing. The plan fields are
-	dialect-blind — the dialect adapter already mapped a MariaDB EXPLAIN row /
+	dialect-blind the dialect adapter already mapped a MariaDB EXPLAIN row /
 	Postgres plan node onto them; ``pt.raw`` keeps the dialect blob for the
 	report + LLM (it's what ``explain_row`` in technical_detail holds).
 	"""
 	table = pt.table or "?"
 
 	# v0.5.2: skip SQL aliases (single-letter JOIN aliases, <derivedN>
-	# subquery markers). "Full table scan on a" is uninterpretable — the user
+	# subquery markers). "Full table scan on a" is uninterpretable the user
 	# can't index "a", they'd need the real underlying table name.
 	if _is_likely_alias(table):
 		return "alias"
@@ -545,7 +545,7 @@ def _inspect_table(pt, normalized_query, action_idx, query_duration, buckets):
 			fix_hint="Add an index on the WHERE/JOIN columns of this query.",
 		)
 
-	# Filesort — only worth flagging when the sort has enough rows to
+	# Filesort only worth flagging when the sort has enough rows to
 	# actually matter (see MIN_ROWS_TO_FLAG_SORT). Otherwise "Filesort
 	# on tabCustom DocPerm" fires on single-row parent lookups that the
 	# user can't act on.
@@ -569,7 +569,7 @@ def _inspect_table(pt, normalized_query, action_idx, query_duration, buckets):
 			fix_hint="Add an index that covers the ORDER BY columns of this query.",
 		)
 
-	# Temporary table — same row floor as Filesort. Materializing a
+	# Temporary table same row floor as Filesort. Materializing a
 	# tiny intermediate table is free; flagging it is noise.
 	if pt.temp_used and rows_examined >= MIN_ROWS_TO_FLAG_SORT:
 		_upsert(
@@ -593,7 +593,7 @@ def _inspect_table(pt, normalized_query, action_idx, query_duration, buckets):
 
 	# Low filter ratio: MariaDB's `filtered` column reports what percentage
 	# of rows examined are actually returned after filtering. Values under
-	# 10 mean the query is reading 10x or more of what it needs — the WHERE
+	# 10 mean the query is reading 10x or more of what it needs the WHERE
 	# clause isn't selective enough (or isn't using an index to filter).
 	# v0.5.1: coerce explicitly so Decimal/str values from unusual drivers
 	# don't silently fall through the isinstance guard.

--- a/optimus/analyzers/frontend_timings.py
+++ b/optimus/analyzers/frontend_timings.py
@@ -98,7 +98,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
         # (context.actions[idx].duration_ms), NOT on the raw
         # recording dict. Pre-v0.5.1 this read `action.get("duration_ms")`
         # from the recording and always got None, so backend_ms was
-        # always 0 in production — making every XHR look like 100%
+        # always 0 in production making every XHR look like 100%
         # network overhead. Prefer context.actions[idx].duration_ms,
         # then fall back through the recording's duration_ms (test
         # fixtures occasionally put it here) and finally the
@@ -158,7 +158,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
         elif name == "fcp":
             bucket["fcp_ms"] = v.get("value_ms")
         elif name == "cls":
-            # CLS accumulates across entries — keep the max seen per page.
+            # CLS accumulates across entries keep the max seen per page.
             current = bucket.get("cls", 0) or 0
             val = v.get("value") or 0
             if val > current:
@@ -196,7 +196,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
                 "fix_hint": (
                     "Look at TTFB: if it's large, the backend is slow "
                     "(see Slow Query / N+1 findings). If TTFB is small, "
-                    "the browser spent time downloading or rendering — "
+                    "the browser spent time downloading or rendering "
                     "check response size and JavaScript execution."
                 ),
             }, default=str),
@@ -227,7 +227,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
                     "response_size_bytes": m["response_size_bytes"],
                     "url": m["url"],
                     "fix_hint": (
-                        "Large response sizes cause this — check the "
+                        "Large response sizes cause this check the "
                         "Heavy Response finding. If response is small, "
                         "suspect network path: CDN, TLS handshake, proxy."
                     ),

--- a/optimus/analyzers/index_suggestions.py
+++ b/optimus/analyzers/index_suggestions.py
@@ -8,7 +8,7 @@ Wraps the existing
 `DBOptimizer` heuristic) to identify a single best missing index per query.
 We run it across the union of unique normalized queries in the session,
 then dedupe and aggregate suggestions by (table, column) so a customer
-sees one suggestion per missing index — with the cumulative time it would
+sees one suggestion per missing index with the cumulative time it would
 save and the queries that would benefit.
 
 This is the per-session aggregation that the existing per-request
@@ -39,7 +39,7 @@ def _scrub_literals(text: str) -> str:
 	replace obvious string literals and long numeric sequences with ?
 	placeholders.
 
-	This is paranoid belt-and-suspenders — the upstream query should
+	This is paranoid belt-and-suspenders the upstream query should
 	already be normalized by mark_duplicates by the time we see it, but
 	if normalization was skipped or the query contained an unusual
 	pattern, we scrub here too.
@@ -64,7 +64,7 @@ MAX_EXAMPLE_QUERIES = 3
 #   "Adding an index to tabDocType.modified would speed up 1526 queries
 #    in this session, saving roughly 892ms total."
 #
-# 892 / 1526 = 0.58ms per query — below MariaDB's per-query overhead.
+# 892 / 1526 = 0.58ms per query below MariaDB's per-query overhead.
 # On a small framework table (tabDocType is typically ~800 rows) the
 # table already fits in memory, the scan is effectively free, and
 # adding a btree index yields no measurable improvement. The user
@@ -73,7 +73,7 @@ MAX_EXAMPLE_QUERIES = 3
 # The severity thresholds (HIGH_IMPACT_MS, MEDIUM_IMPACT_MS) gate
 # severity based on CUMULATIVE time, but a 2ms-per-query × 1000-query
 # suggestion still crosses the 500ms cumulative threshold while being
-# individually actionable — so we need a separate per-query minimum
+# individually actionable so we need a separate per-query minimum
 # to distinguish "many tiny queries" from "a few slow queries."
 #
 # 2ms is the floor: below this, query overhead (network roundtrip +
@@ -92,7 +92,7 @@ MAX_LOGGED_FAILURES = 3
 # shapes Frappe apps legitimately emit. When it can't parse a query, it
 # raises either ``ValueError: too many values to unpack`` (from an internal
 # tuple unpacking) or ``TypeError`` (from an unexpected None in its
-# token stream). These are PARSER LIMITATIONS — the user cannot rewrite
+# token stream). These are PARSER LIMITATIONS the user cannot rewrite
 # their query to make sql_metadata happy, and they cannot add an index to
 # fix a parse failure anyway.
 #
@@ -105,7 +105,7 @@ MAX_LOGGED_FAILURES = 3
 # opportunities they could act on.
 #
 # v0.5.1: parser-limitation exceptions are counted but NOT logged to
-# the Error Log, and the user-facing warning is softer — it explains
+# the Error Log, and the user-facing warning is softer it explains
 # that sql_metadata can't parse these shapes and there's nothing to fix.
 # Real errors (AttributeError, ProgrammingError, RuntimeError, etc.)
 # still go to the Error Log and still produce the loud warning, because
@@ -117,7 +117,7 @@ _PARSER_LIMITATION_EXCEPTIONS = (ValueError, TypeError)
 # DDL, stored-procedure CALL) does not benefit from index suggestions,
 # and sql_metadata raises ValueError on many of them. The pre-v0.5.1
 # version fed everything to the optimizer and reported ~47% 'parse
-# failures' on real sessions — most of which were transaction markers
+# failures' on real sessions most of which were transaction markers
 # and connection-state statements, noise the user couldn't act on.
 _OPTIMIZABLE_QUERY_TYPES = frozenset({"SELECT"})
 
@@ -149,13 +149,13 @@ def _get_query_type(sql: str) -> str:
 # v0.5.1 → v0.6.0: never suggest indexing any of Frappe's standard
 # metadata columns, even when the DBOptimizer heuristic thinks one would
 # help a query. The optimizer only sees read patterns (``ORDER BY modified
-# DESC`` looks like it wants an index) — it can't see the write cost.
+# DESC`` looks like it wants an index) it can't see the write cost.
 #
 # These columns are updated on every save (`modified`, `modified_by`,
 # `idx`), on insert (`creation`, `owner`), on submit/cancel (`docstatus`),
 # or are already auto-indexed (`name` is the PK; `parent` is auto-indexed
 # on child tables). On any non-trivially-written table the maintenance cost
-# of an index there dwarfs the read-side gain — and even where the per-
+# of an index there dwarfs the read-side gain and even where the per-
 # insert cost would equal any other index, surfacing these nudges the
 # developer toward a class of change they should make deliberately, not on
 # a tool's say-so. The query's EXPLAIN row is still in the report if
@@ -163,7 +163,7 @@ def _get_query_type(sql: str) -> str:
 #
 # (Origin: a production report surfaced ``Add index on tabDocType(modified)``
 # and the user corrected with "Modified fields can't be indexed as it would
-# affect the system performance" — then later asked us to extend the rule to
+# affect the system performance" then later asked us to extend the rule to
 # `idx`, `parent`, `parentfield`, `parenttype`, `creation`, etc.)
 #
 # Mirrors ``optimus.analyzers.base.FRAPPE_METADATA_COLUMNS``
@@ -175,9 +175,9 @@ _NEVER_SUGGEST_COLUMNS = FRAPPE_METADATA_COLUMNS
 # ``SHOW INDEX FROM ?`` (DDL/SCHEMA statements expect a bare token, not a
 # bind value), so the only safe pattern is **strict input validation** at
 # the boundary. Allowed shapes:
-#   1. ``tab<DocType name>`` — the Frappe convention; DocType names may
+#   1. ``tab<DocType name>``: the Frappe convention; DocType names may
 #      contain letters, digits, spaces, underscores, hyphens.
-#   2. ``information_schema.<simple-name>`` — schema views the analyzer
+#   2. ``information_schema.<simple-name>``: schema views the analyzer
 #      legitimately introspects.
 # Anything else is rejected outright and the index-introspection helper
 # returns an empty set (its "I couldn't read indexes" fall-through).
@@ -195,7 +195,7 @@ def _is_safe_table_name(name) -> bool:
 	if not isinstance(name, str) or not name:
 		return False
 	# Defence in depth: reject backticks, quotes, semicolons even though
-	# the regexes wouldn't match them — make the intent obvious to readers.
+	# the regexes wouldn't match them make the intent obvious to readers.
 	if any(c in name for c in ("`", "'", '"', ";", "\\", "\n", "\r", "\x00")):
 		return False
 	return bool(_SAFE_TAB_TABLE_RE.match(name) or _SAFE_INFOSCHEMA_RE.match(name))
@@ -205,7 +205,7 @@ def _get_indexed_columns(table: str) -> set[str]:
 	"""Return the set of columns on ``table`` that already have at
 	least one index WHERE this column is the leftmost of the index key.
 
-	Non-leftmost composite columns are NOT counted — MariaDB's btree
+	Non-leftmost composite columns are NOT counted MariaDB's btree
 	can't use the index when a query filters on just that column, so
 	a Missing Index suggestion is still actionable.
 
@@ -236,26 +236,26 @@ def _classify_column(
 
 	Returns ``(status, ddl_or_reason)`` where status is one of:
 
-	  - ``"actionable"``   — column exists, is not indexed, can be
+	  - ``"actionable"`` column exists, is not indexed, can be
 	                         indexed; second element is the DDL string
-	  - ``"already_indexed"`` — column exists and is already the
+	  - ``"already_indexed"``: column exists and is already the
 	                         leftmost of at least one index; drop the
 	                         suggestion, second element explains
-	  - ``"unindexable"``  — column is JSON / geometry or doesn't exist
+	  - ``"unindexable"`` column is JSON / geometry or doesn't exist
 	                         on the table; drop the suggestion, second
 	                         element explains
-	  - ``"never_suggest"`` — column is one of Frappe's standard metadata
+	  - ``"never_suggest"``: column is one of Frappe's standard metadata
 	                         columns (``modified``, ``idx``, ``parent``,
-	                         ``creation``, ``docstatus``, …) — written on
+	                         ``creation``, ``docstatus``, …) written on
 	                         every save / submit, or already auto-indexed;
 	                         drop the suggestion, second element explains
-	  - ``"unknown"``      — information_schema lookup failed (likely
+	  - ``"unknown"`` information_schema lookup failed (likely
 	                         no real DB, dev environment); KEEP the
 	                         suggestion with a plain DDL (legacy
 	                         behavior) so we don't silently suppress
 	                         the old pipeline
 	"""
-	# v0.5.1 → v0.6.0: hard blacklist — Frappe's standard metadata columns
+	# v0.5.1 → v0.6.0: hard blacklist Frappe's standard metadata columns
 	# should never be suggested, regardless of read-side heuristics. Checked
 	# BEFORE the information_schema lookups so we don't waste DB roundtrips
 	# on a suggestion we already know to drop. Case-insensitive defensively
@@ -263,7 +263,7 @@ def _classify_column(
 	if (column or "").strip().lower() in _NEVER_SUGGEST_COLUMNS:
 		return "never_suggest", (
 			f"column `{column}` on `{table}` is a Frappe framework column "
-			f"(written on every save or submit, or already auto-indexed) — "
+			f"(written on every save or submit, or already auto-indexed) "
 			f"not a safe index target. The query's EXPLAIN row is in the "
 			f"report if you want to make this call deliberately."
 		)
@@ -288,7 +288,7 @@ def _classify_column(
 	if types and column not in types:
 		return "unindexable", (
 			f"column `{column}` does not exist on table `{table}` "
-			f"— the optimizer's suggestion is likely a parse error; "
+			f" the optimizer's suggestion is likely a parse error; "
 			f"verify the query and try again"
 		)
 
@@ -312,7 +312,7 @@ def _classify_column(
 	if dialect.prefix_required(dtype):
 		return "actionable", dialect.index_ddl(table, column, is_text_col=True)
 
-	# Regular indexable type (varchar, int, datetime, etc.) — and even if we
+	# Regular indexable type (varchar, int, datetime, etc.) and even if we
 	# don't recognise the dtype (empty string because the column-type lookup
 	# returned no row), fall through to a plain index rather than silently drop.
 	return "actionable", dialect.index_ddl(table, column, is_text_col=False)
@@ -321,7 +321,7 @@ def _classify_column(
 def analyze(recordings: list[dict], context) -> AnalyzerResult:
 	# Frappe's query optimizer fetches table stats with MariaDB-only
 	# introspection (DESCRIBE / SHOW INDEX FROM). On Postgres those statements
-	# raise a syntax error that aborts the whole transaction — and since the
+	# raise a syntax error that aborts the whole transaction and since the
 	# optimizer call below is in a try/except that swallows the error, the
 	# poisoned transaction would silently break every later query in the analyze
 	# (the original symptom: analyze crashed at _persist with
@@ -379,7 +379,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 
 	# Run the optimizer on each unique query and aggregate suggestions.
 	# Track per-exception-type failures so we can surface a warning if
-	# the optimizer couldn't analyze a lot of queries — otherwise the
+	# the optimizer couldn't analyze a lot of queries otherwise the
 	# customer reads "no index suggestions" as "no missing indexes"
 	# when the real answer might be "we couldn't analyze your queries".
 	suggestion_buckets: dict[tuple, dict] = defaultdict(
@@ -388,7 +388,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 	parser_limit_failures: Counter = Counter()
 	real_failures: Counter = Counter()
 	# Frappe framework "meta" tables (tabDocType, tabCustom Field, tabSingles,
-	# tab__global_search, …) — `bench migrate` owns their schema (indexes
+	# tab__global_search, …) `bench migrate` owns their schema (indexes
 	# included) and they're tiny / write-on-every-customization, so we never
 	# suggest an index on them. Skip before we even bucket the suggestion.
 	dropped_meta_table_tables: set[str] = set()
@@ -400,11 +400,11 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			index = _optimize_query(info["raw"])
 		except _PARSER_LIMITATION_EXCEPTIONS as e:
 			# Expected path for complex queries sql_metadata can't parse.
-			# Count but don't log — the user can't act on these.
+			# Count but don't log the user can't act on these.
 			parser_limit_failures[type(e).__name__] += 1
 			continue
 		except Exception as e:
-			# Unexpected path — this might indicate a real profiler bug.
+			# Unexpected path this might indicate a real profiler bug.
 			# Count, log the first few to Error Log (so they're discoverable
 			# for investigation), and continue.
 			real_failures[type(e).__name__] += 1
@@ -412,7 +412,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 				try:
 					import frappe
 
-					# Scrub literals defensively — the query should already
+					# Scrub literals defensively the query should already
 					# be normalized, but if it isn't (edge case), we don't
 					# want literal customer data landing in the Error Log.
 					scrubbed = _scrub_literals(normalized[:1000])
@@ -465,7 +465,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		# might be high in aggregate but pointless in practice if each
 		# individual query is already fast. A real production case had
 		# tabDocType.modified flagged with 892ms / 1526 queries =
-		# 0.58ms per query — below MariaDB's per-query overhead.
+		# 0.58ms per query below MariaDB's per-query overhead.
 		# Indexing would not measurably help the user, so we suppress
 		# the finding entirely. Checked BEFORE classify_column so we
 		# don't waste SHOW INDEX / information_schema queries on
@@ -493,7 +493,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			unindexable_reasons.append(ddl_or_reason)
 			continue
 
-		# status is "actionable" or "unknown" — both keep the
+		# status is "actionable" or "unknown" both keep the
 		# suggestion. "unknown" uses the legacy plain-DDL template,
 		# matching pre-v0.5.1 behavior for environments without a
 		# live DB connection.
@@ -550,7 +550,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		warnings.append(
 			f"Could not analyze {total_real} of {len(unique_queries)} "
 			f"SELECT statements for index suggestions ({failure_summary}). "
-			"The report may be missing some optimization opportunities — "
+			"The report may be missing some optimization opportunities "
 			"see Error Log for the first few failed queries."
 		)
 
@@ -559,7 +559,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 	# telling the user there's nothing to fix. Production sessions on
 	# ERPNext frequently hit this for the item search dialog's complex
 	# query (correlated subquery + ORDER BY if/locate/coalesce expression)
-	# and a few reporting queries with window functions — neither of
+	# and a few reporting queries with window functions neither of
 	# which is user-actionable.
 	total_parser_limit = sum(parser_limit_failures.values())
 	if total_parser_limit:
@@ -567,13 +567,13 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			f"Skipped {total_parser_limit} query(ies) whose shape "
 			"exceeds the DBOptimizer heuristic's sql_metadata parser "
 			"(correlated subqueries, complex ORDER BY expressions, window "
-			"functions). These aren't actionable — index suggestions "
+			"functions). These aren't actionable index suggestions "
 			"require a simpler WHERE/JOIN shape the parser can analyze."
 		)
 	# v0.5.1: separate informational line about non-SELECT statements that
 	# were deliberately skipped, so users understand the distinction between
 	# 'we tried to analyze and failed' (above) and 'we didn't try because
-	# the statement type isn't optimizable' (below). Not a warning — more
+	# the statement type isn't optimizable' (below). Not a warning more
 	# of a 'here's what the 705-query number breaks down to.'
 	if skipped_by_type:
 		warnings.append(
@@ -587,7 +587,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			f"Suppressed {drop_low_per_query} index suggestion(s) with "
 			f"average savings below {MIN_AVG_SAVINGS_PER_QUERY_MS:g}ms "
 			"per query. These queries are already running near MariaDB's "
-			"per-query overhead floor — an index wouldn't measurably help."
+			"per-query overhead floor an index wouldn't measurably help."
 		)
 	if drop_never_suggest:
 		# Include the specific columns in the warning so the user can
@@ -600,7 +600,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 			f"Suppressed {drop_never_suggest} index suggestion(s) on "
 			f"Frappe metadata columns ({sample}{more}). These columns are "
 			"written on every save or submit (or are already auto-indexed), "
-			"so an index there is a write-cost trap — not suggested."
+			"so an index there is a write-cost trap not suggested."
 		)
 	if dropped_meta_table_tables:
 		sample = ", ".join(sorted(dropped_meta_table_tables)[:5])
@@ -609,14 +609,14 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		warnings.append(
 			f"Skipped index suggestion(s) on Frappe framework meta tables "
 			f"({sample}{more}). `bench migrate` owns those tables' schema "
-			"(indexes included) — a hand-added index there is pointless and "
+			"(indexes included) a hand-added index there is pointless and "
 			"would be clobbered on the next migrate."
 		)
 	if drop_already_indexed:
 		warnings.append(
 			f"Suppressed {drop_already_indexed} index suggestion(s) whose "
 			"target column was already indexed (would have been a false "
-			"positive — the DBOptimizer heuristic doesn't check existing "
+			"positive the DBOptimizer heuristic doesn't check existing "
 			"indexes)."
 		)
 	if drop_unindexable:

--- a/optimus/analyzers/infra_pressure.py
+++ b/optimus/analyzers/infra_pressure.py
@@ -21,7 +21,7 @@ import json
 
 from optimus.analyzers.base import SEVERITY_ORDER, AnalyzerResult
 
-# Thresholds — tunable via site_config.json: optimus_infra_*
+# Thresholds tunable via site_config.json: optimus_infra_*
 DEFAULT_CPU_HIGH_PCT = 85
 DEFAULT_CPU_CRITICAL_PCT = 95
 DEFAULT_RSS_DELTA_HIGH_MB = 200
@@ -55,8 +55,8 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 
     # v0.5.2: per_action builds humanized action_labels on
     # context.actions, NOT on the raw recording dict. Pre-v0.5.2 the
-    # infra timeline read rec.get("action_label") — which is always
-    # None on real recordings — so every row in the "Server Resource"
+    # infra timeline read rec.get("action_label") which is always
+    # None on real recordings so every row in the "Server Resource"
     # table rendered as the synthetic "action_0", "action_1", ...
     # fallback. Same bug pattern the frontend_timings analyzer had
     # earlier; same fix: read from context.actions[idx].action_label
@@ -154,7 +154,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
         # DB pool saturation: ratio of open connections to max_connections.
         # When max_connections is unknown (pre-v0.5.0 infra blobs or a DB
         # that refused the SHOW VARIABLES), fall back to the weaker
-        # threads_running/threads_connected proxy rather than skipping —
+        # threads_running/threads_connected proxy rather than skipping
         # the fallback is noisier but still catches the obvious cases.
         if db_max and db_max > 0 and dbc is not None:
             ratio = dbc / db_max
@@ -197,7 +197,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
                 f"The server's CPU was above {cpu_high}% during "
                 f"{len(cpu_breaches)} of {total_actions} steps in your flow "
                 f"(peak {max(cpu_values):.0f}%). This usually means the box is "
-                "overloaded — either your own flow is CPU-bound, or another "
+                "overloaded either your own flow is CPU-bound, or another "
                 "process on the server is competing for CPU while you profile."
             ),
             "technical_detail_json": json.dumps({
@@ -210,7 +210,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
                     "If your own code is hot (check the Call Tree / N+1 "
                     "findings), optimize there first. If the call tree looks "
                     "idle but CPU is still high, something else on the server "
-                    "is using CPU — look at other workers, cron jobs, or a "
+                    "is using CPU look at other workers, cron jobs, or a "
                     "noisy neighbor."
                 ),
             }, default=str),
@@ -261,7 +261,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
                 "fix_hint": (
                     "Investigate cache growth (frappe.cache, doc caches) and "
                     "long-lived object references. If swap is active, the box "
-                    "is undersized — add RAM or move the profiled workload."
+                    "is undersized add RAM or move the profiled workload."
                 ),
             }, default=str),
             "estimated_impact_ms": 0,

--- a/optimus/analyzers/n_plus_one.py
+++ b/optimus/analyzers/n_plus_one.py
@@ -3,7 +3,7 @@
 
 """True N+1 detection: group by callsite, then by normalized SQL. A variant
 recurring at least `n_plus_one_min_occurrences` (a settings value, default 10)
-times WITHIN ONE request is a per-row loop — the distinction a bare copy-count
+times WITHIN ONE request is a per-row loop the distinction a bare copy-count
 can't make."""
 
 import json
@@ -30,7 +30,7 @@ P95_MIN_SAMPLES = 10
 # being flagged. Prevents tiny (<1ms each) queries from generating noisy
 # findings even when they repeat many times. The per-occurrence
 # threshold now lives in Optimus Settings as
-# ``n_plus_one_min_occurrences`` (default 10) — see
+# ``n_plus_one_min_occurrences`` (default 10) see
 # ``optimus.settings``.
 DEFAULT_MIN_TOTAL_TIME_MS = 20
 
@@ -79,7 +79,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 	# generates 10 different query shapes in the same loop (e.g.
 	# frappe/query_builder/utils.py:131 resolving DocField / DocPerm
 	# / Custom Field metadata within one iteration) was emitting 10
-	# separate findings — same fix, 10 rows — which spammed the
+	# separate findings same fix, 10 rows which spammed the
 	# report. Collapsing at callsite level gives ONE finding per
 	# loop with the query variants listed in the detail.
 	#
@@ -114,12 +114,12 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 	for (filename, lineno), bucket in callsite_groups.items():
 		variants: dict = bucket["variants"]
 		# v0.7.x: multi-variant N+1 ("Callsite ran X queries (N variants) at …")
-		# is suppressed — the wording reads as jargon (developers don't think in
+		# is suppressed the wording reads as jargon (developers don't think in
 		# "variants"), the fix hint is generic, and the dominant variant is already
 		# surfaced elsewhere (top queries, table breakdown). Only single-variant
 		# "Same query ran N× at …" is actionable, so bail before any per-variant
 		# work when this callsite has more than one query shape. (A fan-out call
-		# site — 10 different queries each run once — is multi-variant too, and is
+		# site 10 different queries each run once is multi-variant too, and is
 		# excluded here rather than by a separate per-variant max.)
 		if len(variants) > 1:
 			continue
@@ -137,10 +137,10 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		# run_count and loop scoping.
 		dominant_action_counts = Counter(o["action_idx"] for o in canonical_occurrences)
 		# loop_count IS the "N+1 magnitude": how many times the loop ran within a
-		# single request — the busiest one — never the cross-request total (which
+		# single request the busiest one never the cross-request total (which
 		# would inflate the count, the "…in a row" wording, AND the severity).
 		# ``action_ref`` must point at the request where the loop actually ran (the
-		# dominant action), NOT the first request the query merely appeared in — the
+		# dominant action), NOT the first request the query merely appeared in the
 		# report walks THAT action's call tree for inner-loop detail. Taking both
 		# from the same most_common(1) keeps them aligned.
 		dominant_action_idx, loop_count = dominant_action_counts.most_common(1)[0]
@@ -154,8 +154,8 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		# loop to batch), not merely appeared. A query that loops in one request
 		# but also runs once in 100 others has run_count == 1, so the "ran in N
 		# requests" wording and the post-fix projection don't over-count the
-		# single-run requests — those carry no loop to collapse.
-		# A request "looped" only if it hit the N+1 threshold (min_occurrences) — the
+		# single-run requests those carry no loop to collapse.
+		# A request "looped" only if it hit the N+1 threshold (min_occurrences) the
 		# same bar that qualifies the finding. Counting requests with a mere 2–9
 		# sub-threshold repeats would inflate run_count / loop_time / severity and
 		# make the "looped in N requests" wording dishonest (those requests never
@@ -167,7 +167,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		# loop that legitimately recurs in 5 requests keeps all 5 in scope, so its
 		# cumulative-but-recoverable cost still rates severity honestly. A tiny loop
 		# is not rated High just because the same query, run below the threshold
-		# across many unrelated requests, sums past the time floor — that cost is
+		# across many unrelated requests, sums past the time floor that cost is
 		# NOT recoverable by batching this loop.
 		# ``total_time`` (all occurrences) stays for cumulative reporting.
 		loop_durations = [
@@ -185,7 +185,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		# rated on the loop's OWN recoverable time (a trivial loop isn't surfaced
 		# just because the same query also runs once across many unrelated requests),
 		# while a framework finding stays cumulative/informational and gates on the
-		# session-wide total_time its text quotes — so a framework callsite with a
+		# session-wide total_time its text quotes so a framework callsite with a
 		# high cumulative cost but a cheap per-request loop isn't silently dropped.
 		gate_time = total_time if is_framework else loop_time
 		if gate_time < min_total_time:
@@ -233,7 +233,7 @@ def _p95(durations) -> float | None:
 
 
 def _title_for_callsite(short_fn, lineno, count, run_count=1) -> str:
-	"""'Same query ran N×' — hedged 'up to N×' for a multi-request loop, where
+	"""'Same query ran N×' hedged 'up to N×' for a multi-request loop, where
 	``count`` is the busiest request's peak, not a uniform figure."""
 	prefix = "Same query ran up to" if run_count > 1 else "Same query ran"
 	return f"{prefix} {count}× at {short_fn}:{lineno}"
@@ -249,7 +249,7 @@ def _build_user_finding(
 	normalized: str,
 	action_idx: int,
 ) -> dict:
-	"""User-code N+1 finding — severity by loop size & the loop's own time, with a fix hint."""
+	"""User-code N+1 finding severity by loop size & the loop's own time, with a fix hint."""
 	total_count = scope.total_count
 	loop_count = scope.loop_count
 	run_count = scope.run_count
@@ -264,20 +264,20 @@ def _build_user_finding(
 	loop_avg = loop_time / len(loop_durations) if loop_durations else 0
 
 	# Cost quoted is the LOOP's own time (loop_time), never the cross-request
-	# cumulative total — a query that loops in one request but also runs once
+	# cumulative total a query that loops in one request but also runs once
 	# elsewhere must not fold those single runs into "the loop".
 	tail = (
 		"This is usually a Python loop that should fetch its data in one "
 		"query instead of one-at-a-time. Typical fix: a few hours of dev work."
 	)
 	# A sub-1ms loop (only reachable when the min-time gate is configured below
-	# the 20ms default) would render as a misleading "0ms" — say "<1ms" instead.
+	# the 20ms default) would render as a misleading "0ms" say "<1ms" instead.
 	# Guard on ``>= 1`` not ``>= 0.5``: f"{0.5:.0f}" is "0" (round-half-to-even),
 	# so 0.5 must take the "<1ms" branch too.
 	cost = f"{loop_time:.0f}ms" if loop_time >= 1 else "<1ms"
 	if run_count > 1:
 		# The loop spanned several requests; loop_count is the WORST request's
-		# count (the peak), not a uniform per-request figure — "up to N" so it
+		# count (the peak), not a uniform per-request figure "up to N" so it
 		# isn't read as N × run_count.
 		desc = (
 			f"We noticed the same query repeated up to {loop_count} times in a row "
@@ -302,7 +302,7 @@ def _build_user_finding(
 	return {
 		"finding_type": "N+1 Query",
 		# Severity by the per-request loop size (loop_count) and the loop's OWN
-		# recoverable time (loop_time) — never the cross-request cumulative
+		# recoverable time (loop_time) never the cross-request cumulative
 		# total, which single-run requests would inflate.
 		"severity": _severity(loop_count, loop_time),
 		"title": _title_for_callsite(short_fn, lineno, loop_count, run_count),
@@ -341,13 +341,13 @@ def _build_user_finding(
 				# single query. Empirically a batched query with an IN (…)
 				# filter or a JOIN costs ~2× a single tight query (same rows
 				# scanned once, bigger result set). You still pay that batched
-				# query once per LOOPING request, so multiply by run_count —
+				# query once per LOOPING request, so multiply by run_count
 				# otherwise the projection collapses a whole session to one
 				# query and overstates the win. Capped at the current total so
 				# a projection can never read as WORSE than doing nothing.
 				# Uses the LOOP's own per-query average (loop_avg = loop_time /
 				# loop hits), not a session-wide average that single-run requests
-				# would skew. Only the loop collapses — any non-loop appearances
+				# would skew. Only the loop collapses any non-loop appearances
 				# (total_time - loop_time) keep their cost, so they're added back
 				# rather than assumed away. Capped at the current total.
 				"projected_total_ms": round(
@@ -361,21 +361,21 @@ def _build_user_finding(
 				"fix_hint": (
 					"This is a classic N+1 pattern. The Python code at "
 					f"{filename}:{lineno} is running the same query in a loop. "
-					"Refactor to fetch all needed data in a single query — for "
+					"Refactor to fetch all needed data in a single query for "
 					"Frappe specifically, that's usually frappe.get_all() with a "
-					"name-IN filter, or a JOIN against the source table — instead "
+					"name-IN filter, or a JOIN against the source table instead "
 					"of one row at a time."
 				),
 			},
 			default=str,
 		),
-		# Headline economics — read by the TL;DR hero (renderer/_internal.py),
+		# Headline economics read by the TL;DR hero (renderer/_internal.py),
 		# the card impact box (report.html), the report-wide sort, and the AI-fix
-		# prompt (ai_fix.py). Both are scoped to the SAME occurrence set — the loop's
-		# own hits (loop_durations) — so the generic `per_hit = impact / count`
+		# prompt (ai_fix.py). Both are scoped to the SAME occurrence set the loop's
+		# own hits (loop_durations) so the generic `per_hit = impact / count`
 		# consumers compute the loop's real per-query cost. estimated_impact_ms is the
 		# loop's total time; affected_count is the loop's total hit COUNT (not
-		# loop_count, the per-request peak — mixing the two denominators inflated
+		# loop_count, the per-request peak mixing the two denominators inflated
 		# per-hit on multi-request loops). The "in a row" count (loop_count) drives
 		# the title/hero; the session-wide totals stay in the detail JSON above.
 		"estimated_impact_ms": round(loop_time, 2),
@@ -394,7 +394,7 @@ def _build_framework_finding(
 	normalized: str,
 	action_idx: int,
 ) -> dict:
-	"""Framework-level N+1 — always Low, cumulative framing, full technical detail."""
+	"""Framework-level N+1 always Low, cumulative framing, full technical detail."""
 	total_count = scope.total_count
 	loop_count = scope.loop_count
 	run_count = scope.run_count
@@ -402,7 +402,7 @@ def _build_framework_finding(
 	per_hit_durations = scope.per_hit_durations
 	# Framework findings are Low + informational and framed around the
 	# CUMULATIVE session cost (the description says "issued N queries in this
-	# session"), so the title uses total_count too — keeping title and body on
+	# session"), so the title uses total_count too keeping title and body on
 	# the same number. (The user-code finding, by contrast, is about a
 	# per-request loop and uses loop_count.) loop_count/run_count are still
 	# carried in the detail JSON below for anyone optimising the framework.
@@ -419,7 +419,7 @@ def _build_framework_finding(
 			f"{total_count} queries in this session, totalling "
 			f"{total_time:.0f}ms. This is typically the framework "
 			"resolving metadata, permissions, or building queries for "
-			"different inputs — it's rarely something you can change "
+			"different inputs it's rarely something you can change "
 			"in your application code. Listed here for transparency, "
 			"not as an action item. If the cumulative cost is high, "
 			"the fix usually lives in the Frappe codebase itself."

--- a/optimus/analyzers/per_action.py
+++ b/optimus/analyzers/per_action.py
@@ -5,7 +5,7 @@
 
 Produces one Optimus Action row per recording, with a humanized label
 derived best-effort from the recording's path/cmd/form_dict. The action
-row is the unit the customer sorts/filters by in the report — "which step
+row is the unit the customer sorts/filters by in the report "which step
 of my flow took the longest?".
 
 Label detection strategy:
@@ -45,7 +45,7 @@ def _build_action(recording: dict) -> dict:
 def _label(recording: dict) -> str:
 	"""Technical label for the Per-action table / Frontend XHR panel.
 
-	Intentionally NOT humanized — shows the raw cmd (e.g.
+	Intentionally NOT humanized shows the raw cmd (e.g.
 	``frappe.client.save``) or ``METHOD path`` so developers see
 	exactly what hit the server. The Steps-to-Reproduce section
 	uses ``humanized_label`` instead, which reads like English
@@ -54,7 +54,7 @@ def _label(recording: dict) -> str:
 	v0.5.1: cmd falls back to ``_derive_cmd_from_path`` when the
 	recording's stored cmd is empty (Frappe's recorder captures
 	cmd at hook time, BEFORE the REST routing sets form_dict.cmd
-	— see ``_derive_cmd_from_path`` docstring for the full story).
+	see ``_derive_cmd_from_path`` docstring for the full story).
 
 	v0.5.2: ``frappe.desk.form.save.savedocs`` takes an ``action``
 	field in form_dict ("Save"|"Submit"|"Cancel"|"Update") that
@@ -103,7 +103,7 @@ _SAVEDOCS_ACTIONS = frozenset({"Save", "Submit", "Cancel", "Update"})
 #   run_doc_method                     → form_dict.method (any method name)
 #   frappe.model.workflow.apply_workflow → form_dict.action (Approve/Reject/...)
 #
-# run_doc_method is the biggest one for ERPNext — every custom button
+# run_doc_method is the biggest one for ERPNext every custom button
 # defined via frm.add_custom_button(...) goes through it. Without a
 # suffix, 20 distinct buttons in a Sales Invoice session look like one
 # row of "run_doc_method × 20".
@@ -129,7 +129,7 @@ def _multiplex_suffix(cmd: str, form_dict: dict) -> str:
 
 	Looks up the right form_dict key per cmd, validates the value
 	against ``_SAFE_SUFFIX_RE``, and returns it. Unknown / malformed
-	values return "" so the caller falls back to the bare cmd —
+	values return "" so the caller falls back to the bare cmd
 	keeps grouping-by-label stable when payloads are weird.
 	"""
 	if not isinstance(form_dict, dict):
@@ -143,7 +143,7 @@ def _multiplex_suffix(cmd: str, form_dict: dict) -> str:
 
 	# run_doc_method: method is the actual dotted method name, e.g.
 	# "make_payment_entry", "send_email", "update_items". Frappe's
-	# whitelisting layer already validates the method exists — we
+	# whitelisting layer already validates the method exists we
 	# just need to pick something that renders cleanly and doesn't
 	# include literal user data (most doc-method names are plain
 	# Python identifiers, but defensively validate).
@@ -156,7 +156,7 @@ def _multiplex_suffix(cmd: str, form_dict: dict) -> str:
 	# apply_workflow: action is a user-defined Workflow Action name
 	# like "Approve", "Reject", "Submit for Approval". Validate
 	# shape because workflow admins occasionally name actions with
-	# emoji or non-ASCII characters — those round-trip OK through
+	# emoji or non-ASCII characters those round-trip OK through
 	# Frappe but look weird in a technical label.
 	if cmd == _APPLY_WORKFLOW_CMD:
 		action = (form_dict.get("action") or "").strip()
@@ -172,7 +172,7 @@ def humanized_label(recording: dict) -> str:
 
 	Reads like English ("Create Sales Invoice", "Submit Delivery Note",
 	"Open Customer CUST-001", "Search Item") rather than the technical
-	cmd string. Used exclusively by ``analyze._build_auto_notes_html`` —
+	cmd string. Used exclusively by ``analyze._build_auto_notes_html``:
 	the per-action table and frontend XHR panel continue to show the
 	technical label via ``_label``.
 
@@ -183,11 +183,11 @@ def humanized_label(recording: dict) -> str:
 	informative for a developer looking at the technical report.
 
 	Falls back to ``_label`` when the cmd doesn't match any of the
-	humanization rules — so unknown cmds produce the same technical
+	humanization rules so unknown cmds produce the same technical
 	label they would in the per-action table, not an empty string.
 	"""
 	if recording.get("event_type") == "RQ Job":
-		# RQ Jobs use the same label in both views — the
+		# RQ Jobs use the same label in both views the
 		# "Job: <method>" form is already readable.
 		return _label(recording)
 
@@ -285,7 +285,7 @@ def humanized_label(recording: dict) -> str:
 		if doctype:
 			return f"Search {doctype}"
 
-	# No humanization rule matched — defer to the technical label so
+	# No humanization rule matched defer to the technical label so
 	# the caller always gets a non-empty string.
 	return _label(recording)
 
@@ -296,7 +296,7 @@ def _derive_cmd_from_path(path: str) -> str:
 	``_label`` can run on recordings whose ``cmd`` field is empty.
 
 	Returns "" for any other URL shape (``/app/...``, ``/api/
-	resource/...``, static files) — the caller's fallback to
+	resource/...``, static files) the caller's fallback to
 	``METHOD + path`` still applies.
 
 	Why this is needed: frappe.recorder.Recorder.__init__ reads
@@ -339,7 +339,7 @@ def _extract_doc_info(form_dict) -> tuple[str | None, bool]:
 	if isinstance(doc, dict):
 		doctype = doctype or doc.get("doctype")
 		# __islocal is sent as 1 for unsaved docs, absent/0 otherwise.
-		# Cast defensively — Frappe sends both int 1 and string "1"
+		# Cast defensively Frappe sends both int 1 and string "1"
 		# depending on the client.
 		raw_islocal = doc.get("__islocal")
 		is_new = bool(raw_islocal) and raw_islocal not in ("0", 0, False)

--- a/optimus/analyzers/redundant_calls.py
+++ b/optimus/analyzers/redundant_calls.py
@@ -11,7 +11,7 @@ threshold.
 Bucket key uses identifier_safe (sha256 hash) for redundancy
 detection so equivalent values cluster regardless of literal text.
 The finding's technical_detail_json carries BOTH identifier_safe AND
-identifier_raw — the renderer uses identifier_raw.
+identifier_raw the renderer uses identifier_raw.
 """
 
 import json
@@ -45,7 +45,7 @@ def _threshold_for(fn_name: str, cfg) -> int:
 	"""Return the count threshold for a given sidecar fn_name.
 
 	Resolved from Optimus Settings (cached) with site_config.json
-	and hardcoded defaults as fallbacks — see settings.get_config()
+	and hardcoded defaults as fallbacks see settings.get_config()
 	for the precedence chain.
 	"""
 	if fn_name == "get_doc":
@@ -72,7 +72,7 @@ def _title_for(fn_name: str, identifier_safe, count: int) -> str:
 def _customer_description_for(fn_name: str, count: int, callsite: dict | None = None) -> str:
 	"""Build the customer description, appending the callsite when
 	available. v0.5.2 requires the callsite (file:line) for the user
-	to actually navigate to the loop — pre-v0.5.2 the description
+	to actually navigate to the loop pre-v0.5.2 the description
 	said 'the same callsite' without revealing where."""
 	site_hint = ""
 	if callsite:
@@ -85,7 +85,7 @@ def _customer_description_for(fn_name: str, count: int, callsite: dict | None = 
 		return (
 			f"The same document was fetched **{count} times** from the same "
 			"line of code. This is almost always a loop that reloads a "
-			"document inside its body — caching the result outside the loop "
+			"document inside its body caching the result outside the loop "
 			"would eliminate the redundant fetches."
 			f"{site_hint}"
 		)
@@ -100,7 +100,7 @@ def _customer_description_for(fn_name: str, count: int, callsite: dict | None = 
 		return (
 			f"The same permission check ran **{count} times** from the same "
 			"callsite. Permission checks involve role lookups and DocType "
-			"validation — caching the result for the duration of the action "
+			"validation caching the result for the duration of the action "
 			"is the standard fix."
 			f"{site_hint}"
 		)
@@ -117,7 +117,7 @@ def _to_hashable(value):
 
 
 def analyze(recordings: list, context) -> AnalyzerResult:
-	# Read settings once for this analyze pass — avoids N cache
+	# Read settings once for this analyze pass avoids N cache
 	# lookups for an N-bucket analysis.
 	from optimus.settings import get_config
 	cfg = get_config()
@@ -159,7 +159,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 
 	if truncation_seen:
 		context.warnings.append(
-			"Sidecar argument log was truncated for at least one recording — "
+			"Sidecar argument log was truncated for at least one recording "
 			"redundant call detection may be incomplete."
 		)
 
@@ -173,7 +173,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 	drop_no_caller_stack = 0
 	# v0.5.2 round 2: buckets whose count threshold was only reached by
 	# summing ACROSS many actions (e.g. "25 calls" that turned out to
-	# be 1 call in each of 25 requests — not a loop, just a call that
+	# be 1 call in each of 25 requests not a loop, just a call that
 	# naturally fires once per request).
 	drop_cross_request_spread = 0
 
@@ -186,10 +186,10 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 		# v0.5.2 round 2: a "redundant call" is a LOOP, meaning the
 		# threshold must be reached WITHIN a single action. Cross-
 		# request aggregation (25 separate requests each calling cache
-		# once) isn't a loop — it's a framework call that naturally
+		# once) isn't a loop it's a framework call that naturally
 		# fires once per request. Production report had 3 "Redundant
 		# cache lookup: … (25 times)" / "(36 times)" findings from
-		# werkzeug/serving.py:370 — each was 1 call per request across
+		# werkzeug/serving.py:370 each was 1 call per request across
 		# 25/36 requests, not a repeated in-loop lookup.
 		action_counts = Counter(idx for idx, _, _ in occurrences)
 		max_in_any_action = action_counts.most_common(1)[0][1]
@@ -201,7 +201,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 		# stack as the representative (all occurrences of the same
 		# (fn_name, identifier) are by definition from the same cache
 		# key, and we flag them BECAUSE they all fire from the same
-		# repeated loop — so first-occurrence stack is canonical).
+		# repeated loop so first-occurrence stack is canonical).
 		first_stack = occurrences[0][2]
 		if not first_stack:
 			# Recording captured before v0.5.2 OR stack capture failed.
@@ -220,7 +220,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 			# background-task findings don't disappear). Here we
 			# ADDITIONALLY filter any callsite that resolves to an
 			# official Frappe-maintained app (frappe, erpnext, hrms,
-			# …) or a pip-installed third-party lib — the loop inside
+			# …) or a pip-installed third-party lib the loop inside
 			# those isn't actionable for application developers.
 			# Same rationale as the Framework N+1 filter.
 			drop_framework_callsite += 1
@@ -256,7 +256,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 		findings.append({
 			"finding_type": "Redundant Call",
 			# Title/description report the per-action LOOP magnitude
-			# (max_in_any_action), not the cross-action total (count) — the
+			# (max_in_any_action), not the cross-action total (count) the
 			# loop ran max_in_any_action times in its hottest request, and
 			# saying "(50 times)" when 50 = 10×5 requests overstates the loop
 			# ("almost always a loop" reads as 50-in-a-row). Severity already
@@ -279,7 +279,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 				"distinct_actions": len(action_counts),
 				# v0.5.2: surface the callsite so developers can
 				# actually navigate to the loop. Pre-v0.5.2 the only
-				# identifier was a sha256 hash of the cache key —
+				# identifier was a sha256 hash of the cache key
 				# useless for finding the offending code.
 				"callsite": {
 					"filename": callsite.get("filename"),
@@ -297,7 +297,7 @@ def analyze(recordings: list, context) -> AnalyzerResult:
 			f"Suppressed {drop_cross_request_spread} Redundant Call "
 			"candidate(s) where the threshold was reached only by "
 			"summing across multiple requests (e.g. one cache lookup "
-			"per request × 25 requests). That's not a loop — it's a "
+			"per request × 25 requests). That's not a loop it's a "
 			"call that naturally fires once per request. A real "
 			"redundant loop has the threshold met WITHIN a single "
 			"action."

--- a/optimus/analyzers/table_breakdown.py
+++ b/optimus/analyzers/table_breakdown.py
@@ -6,23 +6,23 @@
 Aggregates, per SQL table touched by the session:
 
   - total time + query count (a multi-table JOIN is counted against each
-    table, so the rows sum to MORE than the session total — the renderer
+    table, so the rows sum to MORE than the session total the renderer
     says so);
   - reads (``SELECT``) vs writes (``INSERT`` / ``UPDATE`` / ``DELETE`` /
-    ``REPLACE``) — count and ms each;
-  - **index candidates** — columns the session actually filtered, joined, or
+    ``REPLACE``) count and ms each;
+  - **index candidates**: columns the session actually filtered, joined, or
     ordered on while *reading* the table, ranked by how often they were
     used. The renderer pairs this with the write count so it's clear that
     every added index also costs write time on a write-heavy table. Frappe's
     framework-managed metadata columns (``creation`` / ``modified`` / ``idx``
-    / ``parent`` / ``docstatus`` / …) are never offered as candidates — they
+    / ``parent`` / ``docstatus`` / …) are never offered as candidates they
     go into ``framework_cols_filtered`` instead, which the renderer shows as
     "also filtered on … (not suggested for indexing)". Frappe's framework
     "meta" tables (``tabDocType`` / ``tabCustom Field`` / ``tabSingles`` / …)
-    get ``is_meta_table: True`` and no candidates at all — ``bench migrate``
+    get ``is_meta_table: True`` and no candidates at all ``bench migrate``
     owns their indexes.
 
-Informational only — no findings (``index_suggestions`` / ``explain_flags``
+Informational only no findings (``index_suggestions`` / ``explain_flags``
 emit the EXPLAIN-driven findings; this is the broad "what does this table
 look like" view). Uses ``sql_metadata.Parser`` (a frappe dependency) to
 extract tables, query type, and per-clause columns.
@@ -40,7 +40,7 @@ from optimus.analyzers.base import (
 
 DEFAULT_TOP_N = 15
 # Writes are usually cheap (a few sub-ms INSERT/UPDATE rows), so a write-target
-# table easily ranks below the time cutoff — pull in the most write-active ones
+# table easily ranks below the time cutoff pull in the most write-active ones
 # that didn't make it so a doc-save's writes are still visible.
 DEFAULT_WRITE_TOP_N = 10
 MAX_INDEX_CANDIDATES_PER_TABLE = 6
@@ -67,7 +67,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		from sql_metadata import Parser  # noqa: F401
 	except Exception:
 		return AnalyzerResult(
-			warnings=["sql_metadata not available — table breakdown skipped"]
+			warnings=["sql_metadata not available table breakdown skipped"]
 		)
 
 	stats: dict[str, dict] = defaultdict(lambda: {
@@ -80,7 +80,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 		"col_hits": Counter(),       # (column, source_label) -> count, reads only
 		"framework_cols": set(),     # Frappe metadata cols seen in WHERE/JOIN/ORDER on reads
 		# frozenset(non-metadata WHERE/JOIN columns) -> how many read queries
-		# filtered on exactly that set — drives the composite recommendation.
+		# filtered on exactly that set drives the composite recommendation.
 		"combos": Counter(),
 	})
 
@@ -104,16 +104,16 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 				if is_read:
 					s["read_count"] += 1
 					s["read_duration"] += duration
-					# Index candidates come from READ queries only — that's
+					# Index candidates come from READ queries only that's
 					# what the developer asked for ("fields to index to
 					# improve reads"). Two things are NOT offered as
 					# candidates: (a) Frappe's framework-managed metadata
-					# columns (`modified` / `idx` / `parent` / … — written on
-					# every save, or auto-indexed) — recorded in
+					# columns (`modified` / `idx` / `parent` / … written on
+					# every save, or auto-indexed) recorded in
 					# framework_cols so the report can still surface "also
 					# filtered on … (not suggested)"; (b) anything on a Frappe
 					# framework "meta" table (tabDocType / tabCustom Field /
-					# tabSingles / …) — `bench migrate` owns those tables'
+					# tabSingles / …) `bench migrate` owns those tables'
 					# indexes, so there's nothing to suggest there at all.
 					if not is_frappe_meta_table(table):
 						where_join_cols: list[str] = []
@@ -133,7 +133,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 	# v0.7.x C.AM2: renamed ``duration_ms`` → ``consolidated_time_ms`` to
 	# disambiguate from action.duration_ms (per-request wall) and
 	# top_queries.query_duration_ms (per-call query exec). The value is
-	# the sum of every query touching this table — a consolidated total
+	# the sum of every query touching this table a consolidated total
 	# across the session, not a per-hit measurement.
 	breakdown = [
 		{
@@ -172,7 +172,7 @@ def _build_recommended_index(table: str, s: dict) -> dict | None:
 	read queries filtered on *together*, with columns ordered by overall
 	usage frequency (a rough selectivity proxy) and capped to a sane
 	composite width. Only for real Frappe doctype tables (``tab*``, not a
-	framework meta table) — those are the ones a developer can actually
+	framework meta table) those are the ones a developer can actually
 	index via a patch.
 	"""
 	t = str(table or "")
@@ -205,8 +205,8 @@ def _build_recommended_index(table: str, s: dict) -> dict | None:
 
 
 def _rank_candidates(col_hits: "Counter") -> list[dict]:
-	"""Collapse ``(column, source_label)`` counts into one entry per column —
-	``{column, sources: [...], hits}`` — ranked by total appearances, top
+	"""Collapse ``(column, source_label)`` counts into one entry per column
+	``{column, sources: [...], hits}``: ranked by total appearances, top
 	``MAX_INDEX_CANDIDATES_PER_TABLE``."""
 	per_col: dict[str, dict] = {}
 	for (col, label), n in col_hits.items():
@@ -234,7 +234,7 @@ def _parse_query(query: str) -> dict:
 	index_cols: {table: [(source_label, column), ...]}}``.
 
 	Best-effort: if ``sql_metadata`` can't parse it we return no tables, so
-	the query simply doesn't appear in the breakdown — same as the
+	the query simply doesn't appear in the breakdown same as the
 	pre-existing behaviour.
 	"""
 	verb = _leading_verb(query)
@@ -243,7 +243,7 @@ def _parse_query(query: str) -> dict:
 
 		# disable_logging: sql_metadata logs at error() for query types it can't
 		# classify (COMMIT/ROLLBACK, SHOW GLOBAL STATUS / SHOW VARIABLES from
-		# frappe's tx control + Optimus's infra capture) and then raises — which
+		# frappe's tx control + Optimus's infra capture) and then raises which
 		# we already catch below and treat as "no tables". Silence the noisy log;
 		# behaviour is unchanged.
 		parsed = Parser(query, disable_logging=True)
@@ -288,7 +288,7 @@ def _parse_query(query: str) -> dict:
 
 def _attribute_column(raw_col, tables: list[str], single_table):
 	"""Map a ``sql_metadata`` column reference (``"tabFoo.bar"`` or ``"bar"``)
-	to ``(table, column)`` — or ``None`` when it can't be attributed
+	to ``(table, column)``: or ``None`` when it can't be attributed
 	confidently (an unresolved alias, an expression, or an ambiguous
 	unqualified column in a multi-table query)."""
 	if not isinstance(raw_col, str):
@@ -298,11 +298,11 @@ def _attribute_column(raw_col, tables: list[str], single_table):
 		return None
 	if "." in col:
 		# Frappe table names contain spaces but never dots; column names
-		# never contain dots — so the first dot separates table from column.
+		# never contain dots so the first dot separates table from column.
 		prefix, _, rest = col.partition(".")
 		if rest and prefix in tables:
 			return (prefix, rest)
-		return None  # qualified by an alias we didn't resolve — don't guess
+		return None  # qualified by an alias we didn't resolve don't guess
 	if single_table:
 		return (single_table, col)
-	return None  # unqualified in a multi-table query — ambiguous, skip
+	return None  # unqualified in a multi-table query ambiguous, skip

--- a/optimus/analyzers/top_queries.py
+++ b/optimus/analyzers/top_queries.py
@@ -9,7 +9,7 @@ slow single query in that leaderboard (> 200ms by default).
 
 The leaderboard is scoped to the user's *own* app code: queries whose
 blame callsite resolves to framework / third-party code are dropped
-before truncating to top N — they're noise the developer can't act on
+before truncating to top N they're noise the developer can't act on
 and they crowd real application queries out of the list. The complete,
 unfiltered per-query list is still available in the per-action breakdown.
 """
@@ -34,7 +34,7 @@ HIGH_SEVERITY_MULTIPLIER = 2.5  # High when query > threshold * 2.5 (matches old
 MAX_FINDINGS = 5  # only flag the top 5 slow queries to avoid noise
 
 # Don't pad the "slowest queries" leaderboard with queries that took
-# essentially no time — a panel of 1-3ms queries is noise that reads as
+# essentially no time a panel of 1-3ms queries is noise that reads as
 # "here are your problem queries" when there aren't any. A query has to
 # clear this floor to qualify; if nothing does, the section renders an
 # empty state instead of a list of trivially-fast queries.
@@ -57,7 +57,7 @@ def _resolve_slow_query_threshold() -> tuple[float, float]:
 def _resolve_tracked_apps() -> tuple[str, ...]:
 	"""``Optimus Settings ▸ Tracked Apps`` allowlist, or ``()`` when
 	settings aren't reachable (pure-test path). Passed to
-	``is_framework_callsite_str`` — an empty tuple makes that classifier
+	``is_framework_callsite_str``: an empty tuple makes that classifier
 	fall back to its built-in ``FRAMEWORK_APPS`` exclusion heuristic."""
 	try:
 		from optimus.settings import get_tracked_apps
@@ -96,14 +96,14 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 
 	all_queries.sort(key=lambda q: q["query_duration_ms"], reverse=True)
 
-	# Scope the leaderboard to the user's own app code — framework /
+	# Scope the leaderboard to the user's own app code framework /
 	# third-party queries are dropped here, BEFORE truncating to top N,
 	# so a session full of framework-internal queries still surfaces the
 	# slowest application queries instead of a top-N of un-actionable
 	# noise. (The per-action breakdown in the report keeps every query.)
 	# Also drop trivially-fast queries: a "slowest queries" panel padded
 	# with sub-10ms rows reads as "here are your problem queries" when
-	# there aren't any — if nothing clears the floor, the panel stays
+	# there aren't any if nothing clears the floor, the panel stays
 	# empty rather than listing noise.
 	top = [
 		q for q in all_queries
@@ -131,7 +131,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 						"callsite": q["callsite"],
 						"recording_uuid": q["recording_uuid"],
 						"fix_hint": (
-							"Investigate this query — it may need an index, a "
+							"Investigate this query it may need an index, a "
 							"refactored WHERE clause, or a different access pattern. "
 							"Run EXPLAIN ANALYZE on a representative production query "
 							"to see the actual cost."
@@ -149,7 +149,7 @@ def analyze(recordings: list[dict], context) -> AnalyzerResult:
 
 
 def count_suppressed_findings(top_queries: list[dict], slow_threshold_ms: float) -> int:
-	"""B.DI4 — how many user-app slow queries the findings cap dropped.
+	"""B.DI4 how many user-app slow queries the findings cap dropped.
 
 	Computed at render time (not at analyze time) so adding a new
 	disclosure doesn't require a DocType migration: ``top_queries_json``

--- a/optimus/api.py
+++ b/optimus/api.py
@@ -9,14 +9,14 @@ integrations talk to the profiler. They are decorated with
 `/api/method/optimus.api.<name>`.
 
 Phase 1 surface:
-    start(label)         — begin a session for the calling user
-    stop()               — end the current user's session
-    status()             — is the calling user currently recording?
-    get_active_session() — full metadata for the calling user's session
+    start(label) begin a session for the calling user
+    stop() end the current user's session
+    status() is the calling user currently recording?
+    get_active_session() full metadata for the calling user's session
 
 The actual analyze pipeline (read recordings, run analyzers, render
 report, attach files) is added in Phase 3+. For now, `stop()` simply
-clears the active flag and marks the DocType as `Stopping` — a future
+clears the active flag and marks the DocType as `Stopping`: a future
 phase will hook the analyze step in.
 """
 
@@ -50,7 +50,7 @@ def _require_profiler_user() -> str:
 	The HTTP-level enforcement that the floating widget's role check is
 	mirroring. Without this, any authenticated user could POST to
 	/api/method/optimus.api.start and start a session on
-	themselves — the role check in the widget JS would be purely
+	themselves the role check in the widget JS would be purely
 	cosmetic.
 	"""
 	user = _require_user()
@@ -79,7 +79,7 @@ def _require_session_permission(session_uuid: str, permission_type: str = "read"
 	  - ``frappe.has_permission`` itself raises.
 
 	SECURITY: this fails CLOSED. ``has_permission`` is a core Frappe call that
-	practically never raises; if it does, denying is the safe outcome — a
+	practically never raises; if it does, denying is the safe outcome a
 	permission check that errors must not silently downgrade to the role-only
 	gate (that would let any Optimus User reach another user's session).
 	"""
@@ -134,7 +134,7 @@ def start(
 	        captures a Python call tree per recording and sidecar wraps
 	        capture frappe.get_doc / cache.get_value / has_permission
 	        argument identities. When False, only the existing SQL
-	        recorder runs — same overhead profile as v0.2.0.
+	        recorder runs same overhead profile as v0.2.0.
 	    notes: v0.5.0+. Free-form "steps to reproduce" / context text
 	        rendered at the top of the report. Can also be edited on
 	        the Optimus Session form after the session completes.
@@ -161,7 +161,7 @@ def start(
 	session_uuid = frappe.generate_hash(length=16)
 	now = now_datetime()
 	title = (label or "").strip() or f"Profiling session @ {now.strftime('%Y-%m-%d %H:%M:%S')}"
-	# Session name is a Data field (varchar 140) — cap here so a long label from a
+	# Session name is a Data field (varchar 140) cap here so a long label from a
 	# direct API call is cleanly trimmed instead of silently truncated by the DB.
 	title = title[:140]
 
@@ -193,7 +193,7 @@ def start(
 		},
 	)
 
-	# Flip the user's active flag last — once this is set, the next
+	# Flip the user's active flag last once this is set, the next
 	# request from this user will start being recorded.
 	session.set_active_session(user, session_uuid)
 
@@ -211,11 +211,11 @@ def stop() -> dict:
 
 	Clears the Redis active pointer, marks the Optimus Session row as
 	``Stopping``, and either enqueues the analyze job or runs it inline
-	(v0.5.0: scheduler-aware fallback — see ``_enqueue_analyze``).
+	(v0.5.0: scheduler-aware fallback see ``_enqueue_analyze``).
 
 	Returns:
 	    dict with ``stopped``, ``session_uuid``, ``docname``,
-	    ``ran_inline``, and — only when ran_inline is True — the final
+	    ``ran_inline``, and only when ran_inline is True the final
 	    ``status`` from the Optimus Session row (``Ready`` or ``Failed``).
 
 	    The widget uses both flags to decide its terminal state:
@@ -232,7 +232,7 @@ def stop() -> dict:
 
 	# v0.5.0: when analyze runs inline, the session is already finalized
 	# by the time we return. Read the actual status so the widget can
-	# transition to the right terminal state — otherwise a failed
+	# transition to the right terminal state otherwise a failed
 	# inline analyze would show "Report ready" to the user despite the
 	# session being marked Failed server-side.
 	final_status = None
@@ -258,8 +258,8 @@ def _stop_session(user: str, session_uuid: str) -> tuple[str | None, bool]:
 	and enqueue (or inline-run) the analyze job.
 
 	Returns a tuple ``(docname, ran_inline)``:
-	    docname     — the Optimus Session docname, or None if not found
-	    ran_inline  — True if the session is already finalized by the time
+	    docname the Optimus Session docname, or None if not found
+	    ran_inline True if the session is already finalized by the time
 	                  we return (analyze ran synchronously or was rejected
 	                  by the inline cap and marked Failed). False means
 	                  analyze will run async.
@@ -309,7 +309,7 @@ def _stop_session(user: str, session_uuid: str) -> tuple[str | None, bool]:
 		if wait_seconds > 0 and session.get_pending_jobs(session_uuid):
 			session.set_draining(session_uuid, time.time() + wait_seconds + 60)
 			# v0.13: surface the post-stop background-job capture as its own
-			# status — otherwise the session sits at "Stopping" for the whole
+			# status otherwise the session sits at "Stopping" for the whole
 			# drain window (up to background_job_wait_seconds, default 300s) and
 			# looks stuck. analyze.run keeps it here through the drain, then
 			# flips to "Analyzing" once the jobs finish / the window closes.
@@ -344,10 +344,10 @@ def _publish_session_event(
 	polling. The widget in floating_widget.js subscribes to these
 	event names via ``frappe.realtime.on(...)``:
 
-	  optimus_session_stopping    — user clicked Stop
-	  optimus_session_analyzing   — analyze.run starting (may be delayed)
-	  optimus_session_ready       — analyze finished successfully
-	  optimus_session_failed      — analyze crashed
+	  optimus_session_stopping user clicked Stop
+	  optimus_session_analyzing analyze.run starting (may be delayed)
+	  optimus_session_ready analyze finished successfully
+	  optimus_session_failed analyze crashed
 
 	All events carry ``session_uuid`` and ``docname`` so a widget with
 	multiple open tabs can match on the session it's currently tracking.
@@ -361,7 +361,7 @@ def _publish_session_event(
 	try:
 		frappe.publish_realtime(event_name, payload, user=user)
 	except Exception:
-		# Don't log — realtime is best-effort, the widget falls back
+		# Don't log realtime is best-effort, the widget falls back
 		# to its on-visibility-change status fetch.
 		pass
 
@@ -413,13 +413,13 @@ def _enqueue_analyze(session_uuid: str, docname: str | None = None) -> bool:
 	(``optimus_inline_analyze_limit``, default 50) to stay within
 	gunicorn's ~120s request timeout on heavy sessions. When the cap
 	is exceeded, the session is marked Failed with an actionable
-	error and analyze is NOT invoked — the user sees the failure
+	error and analyze is NOT invoked the user sees the failure
 	immediately rather than having gunicorn kill the request
 	mid-analyze and strand the session half-analyzed.
 
 	The cap lives here (not in ``_stop_session``) so every caller of
-	this function — ``stop``, ``retry_analyze``, ``janitor._sweep_stale``
-	— gets the same protection. Earlier versions only applied it in
+	this function ``stop``, ``retry_analyze``, ``janitor._sweep_stale``
+	gets the same protection. Earlier versions only applied it in
 	``_stop_session``, which meant ``retry_analyze`` on a 200-recording
 	failed session on a scheduler-disabled site would hit the gunicorn
 	timeout.
@@ -429,14 +429,14 @@ def _enqueue_analyze(session_uuid: str, docname: str | None = None) -> bool:
 	    docname: the Optimus Session docname for cap-exceeded failure
 	        handling. When provided, cap violations mark this doc Failed
 	        with a user-facing message. When None, the cap is skipped
-	        (internal callers only — all production paths pass docname).
+	        (internal callers only all production paths pass docname).
 
 	Returns True if the session is already finalized (Ready or Failed)
-	by the time this call returns — that is, analyze ran synchronously
+	by the time this call returns that is, analyze ran synchronously
 	OR was rejected by the inline cap. Returns False when the job was
 	pushed to the async queue and the session is still Stopping.
 
-	Inline execution can fail — analyze.run catches its own exceptions
+	Inline execution can fail analyze.run catches its own exceptions
 	and marks the session as Failed via frappe.db.set_value, then
 	re-raises. We catch the re-raise here so the caller's response
 	isn't a 500 error. Returning True with the session already
@@ -452,7 +452,7 @@ def _enqueue_analyze(session_uuid: str, docname: str | None = None) -> bool:
 		frappe.log_error(title="optimus scheduler check")
 
 	if run_inline:
-		# Inline cap check — refuse huge sessions that would exceed
+		# Inline cap check refuse huge sessions that would exceed
 		# gunicorn's request timeout. Only applied when docname is
 		# provided (all production callers provide it).
 		if docname:
@@ -508,7 +508,7 @@ def _enqueue_analyze(session_uuid: str, docname: str | None = None) -> bool:
 			)
 		except Exception:
 			# analyze.run already marked the session Failed and
-			# re-raised. Swallow here so the caller returns 200 — the
+			# re-raised. Swallow here so the caller returns 200 the
 			# caller reads the final status off the doc and reports
 			# it to the widget.
 			frappe.log_error(
@@ -629,7 +629,7 @@ def submit_frontend_metrics(payload: str) -> dict:
 
 	Called by optimus_frontend.js at stop time (via frappe.call) and
 	at beforeunload (via navigator.sendBeacon). Payload is a JSON
-	string because sendBeacon sends raw Blob — Frappe's dict auto-
+	string because sendBeacon sends raw Blob Frappe's dict auto-
 	parsing doesn't kick in for sendBeacon, so we take a string and
 	parse explicitly.
 
@@ -638,10 +638,10 @@ def submit_frontend_metrics(payload: str) -> dict:
 	pattern over a single JSON dict, which had a read-modify-write race:
 	two concurrent submits (e.g. stop-time frappe.call colliding with a
 	beforeunload beacon) could both read the same existing blob, both
-	compute a merged result, and both write — losing one submission's
+	compute a merged result, and both write losing one submission's
 	contents. RPUSH + LTRIM is atomic in Redis, so concurrent submits
 	just append their entries without data loss. LTRIM enforces the
-	soft cap (tail-preferring — newest entries survive).
+	soft cap (tail-preferring newest entries survive).
 
 	Redis keys:
 	  profiler:frontend:<uuid>:xhr     → list of JSON-encoded XHR entries
@@ -667,7 +667,7 @@ def submit_frontend_metrics(payload: str) -> dict:
 	# Ownership check: only the user who owns the session can write to
 	# its frontend blob. Silent-drop on missing meta because a
 	# beforeunload beacon can legitimately arrive after the session has
-	# already been stopped and its meta deleted — no log spam.
+	# already been stopped and its meta deleted no log spam.
 	meta = session.get_session_meta(session_uuid) or {}
 	if not meta or meta.get("user") != user:
 		return {"accepted": False, "reason": "session not found"}
@@ -684,7 +684,7 @@ def submit_frontend_metrics(payload: str) -> dict:
 
 	# Atomic append: RPUSH + LTRIM. Each entry is JSON-encoded as a
 	# Redis list element. frappe.cache.rpush accepts one value at a
-	# time — we loop, which is O(n) round trips but fine at the
+	# time we loop, which is O(n) round trips but fine at the
 	# submission sizes we cap at (≤ 1000 XHRs, ≤ 200 vitals per call).
 	if xhr:
 		for entry in xhr:
@@ -733,7 +733,7 @@ def _read_frontend_data(session_uuid: str) -> dict:
 	with the shape the frontend_timings analyzer expects.
 
 	Decodes each list entry from JSON. Bad entries are silently
-	skipped — the analyzer can handle partial data.
+	skipped the analyzer can handle partial data.
 	"""
 	import json as _json
 
@@ -771,7 +771,7 @@ def health() -> dict:
 	called manually by an admin to sanity-check the profiler's health.
 
 	Permission: any role that can use the profiler (Optimus User or
-	System Manager). Doesn't expose session contents — just aggregate
+	System Manager). Doesn't expose session contents just aggregate
 	counts.
 	"""
 	_require_profiler_user()
@@ -844,7 +844,7 @@ def _session_count_by_severity() -> dict:
 # v0.4.0: onboarding toast state endpoints. Used by floating_widget.js
 # to decide whether to render the one-time onboarding toast.
 # v0.12.0: key construction moved to optimus.redis_keys.onboarding_seen.
-# The TTL constant stays here as the policy lever — bump from the 1-year
+# The TTL constant stays here as the policy lever bump from the 1-year
 # default if a real complaint surfaces. The PREFIX constant is gone; the
 # read/write sites below call redis_keys.onboarding_seen(user) directly.
 ONBOARDING_CACHE_TTL_SECONDS = 365 * 24 * 60 * 60  # 1 year
@@ -858,7 +858,7 @@ def check_onboarding_seen() -> dict:
 	row (they're an experienced user; suppress the toast).
 	"""
 	user = _require_user()
-	# Suppress for experienced users — anyone with at least one Ready session
+	# Suppress for experienced users anyone with at least one Ready session
 	try:
 		existing = frappe.db.count(
 			"Optimus Session",
@@ -871,7 +871,7 @@ def check_onboarding_seen() -> dict:
 	# v0.12.13: onboarding_seen is the second value migrated to the
 	# v0.12.0 versioned envelope. ``unwrap_value`` returns either the
 	# wrapped payload (new-shape writers, v0.12.13+) or the legacy bare
-	# value (pre-v0.12.13 writers — strings like "1"). Both shapes
+	# value (pre-v0.12.13 writers strings like "1"). Both shapes
 	# are truthy, so ``bool(payload)`` resolves the dismissed flag
 	# regardless of which writer set it.
 	from optimus import redis_keys, redis_schema
@@ -944,10 +944,10 @@ def export_session(session_uuid: str) -> dict:
 	Lets dev shops (or automation) consume the profiler's output
 	programmatically without parsing the HTML report. Returns the full
 	session including all child rows, top queries, table breakdown, and
-	finding technical details — everything in the report, in a
+	finding technical details everything in the report, in a
 	machine-friendly shape.
 
-	Permission model: mirrors the report download gate — only the
+	Permission model: mirrors the report download gate only the
 	recording user or a System Manager can export. Other Optimus Users
 	get a permission error even if they somehow guessed the uuid.
 	"""
@@ -1056,7 +1056,7 @@ def retry_analyze(session_uuid: str) -> dict:
 	Allows the recording user or a System Manager to recover from
 	transient analyzer errors (worker crash, DB timeout, etc.) without
 	dropping into a Frappe console. The session must be in `Failed`
-	state — retrying a Ready or Recording session is a no-op.
+	state retrying a Ready or Recording session is a no-op.
 	"""
 	user = _require_profiler_user()
 	if not session_uuid:
@@ -1105,7 +1105,7 @@ def retry_analyze(session_uuid: str) -> dict:
 	# on sites where bench disable-scheduler is in effect. Earlier
 	# versions called frappe.enqueue directly here, which on scheduler-
 	# disabled sites would re-hit the exact hung-forever bug that the
-	# v0.5.0 scheduler fallback was designed to fix — Retry would push
+	# v0.5.0 scheduler fallback was designed to fix Retry would push
 	# to a queue no worker consumes and the session would stay stuck
 	# in Stopping forever. Passing docname also lets the inline cap
 	# check mark this session Failed (with a clear message) if the
@@ -1147,18 +1147,18 @@ def regenerate_reports(session_uuid: str) -> dict:
 
 	Characteristics:
 
-	  - **Fast** — milliseconds vs. minutes. No DB-heavy analyzer
+	  - **Fast**: milliseconds vs. minutes. No DB-heavy analyzer
 	    passes, no EXPLAIN calls. Just template rendering.
-	  - **Safe to run repeatedly** — idempotent. Each invocation
+	  - **Safe to run repeatedly**: idempotent. Each invocation
 	    replaces the existing report File attachment and clears
 	    the cached PDF.
-	  - **Best-effort recordings** — fetches the original recordings
+	  - **Best-effort recordings**: fetches the original recordings
 	    from Redis by UUID. If they've expired (TTL exceeded),
 	    per-query drill-down / Full recordings sections render empty
 	    but every other section (findings, stats, hot frames, exec
 	    summary, analyzer notes) stays intact because those are
 	    persisted on the Optimus Session row.
-	  - **Allowed on Ready OR Failed sessions** — re-rendering a
+	  - **Allowed on Ready OR Failed sessions**: re-rendering a
 	    Failed session whose analyze partially completed is often
 	    how this feature pays for itself (unblocks a demo when a
 	    render-time bug was fixed).
@@ -1183,7 +1183,7 @@ def regenerate_reports(session_uuid: str) -> dict:
 	# sessions" contract. The pre-v0.12.9 code accepted any status,
 	# which would attach an incomplete report to a still-running
 	# analyze (Recording / Stopping / Analyzing) that the pipeline
-	# would then overwrite — confusing for operators, and surfaced
+	# would then overwrite confusing for operators, and surfaced
 	# in v0.12.4 by the integration test that exercised this gap.
 	if row["status"] not in ("Ready", "Failed"):
 		frappe.throw(
@@ -1235,7 +1235,7 @@ def regenerate_reports(session_uuid: str) -> dict:
 	except Exception:
 		frappe.log_error(title="optimus regenerate ai backfill")
 
-	# Invalidate the cached PDF — next /api/method/download_pdf call
+	# Invalidate the cached PDF next /api/method/download_pdf call
 	# will regenerate it from the freshly-rendered HTML.
 	try:
 		from optimus import pdf_export
@@ -1260,7 +1260,7 @@ def regenerate_reports(session_uuid: str) -> dict:
 def suggest_fix(session_uuid: str, finding_ref: str, regenerate=0) -> dict:
 	"""Generate (or return the cached) AI-suggested fix for one finding.
 
-	On-demand only — never called during analyze. The finding's context
+	On-demand only never called during analyze. The finding's context
 	(type, callsite, a window of surrounding source, normalized SQL +
 	EXPLAIN, the static fix hint) is sent to the LLM configured in
 	Optimus Settings ▸ AI Fix Suggestions; the result is stored on the
@@ -1315,13 +1315,13 @@ def suggest_fix(session_uuid: str, finding_ref: str, regenerate=0) -> dict:
 
 	if not ai_fix.is_available():
 		frappe.throw(
-			"AI fix suggestions aren't configured — enable them in Profiler "
+			"AI fix suggestions aren't configured enable them in Profiler "
 			"Settings ▸ AI Fix Suggestions and set a provider, model, and API key."
 		)
 	from optimus.settings import get_config
 	if not get_config().ai_suggest_findings:
 		frappe.throw(
-			'AI fix suggestions on findings are turned off — enable '
+			'AI fix suggestions on findings are turned off enable '
 			'"Fix suggestions on findings" under Optimus Settings ▸ AI.'
 		)
 
@@ -1338,7 +1338,7 @@ def suggest_fix(session_uuid: str, finding_ref: str, regenerate=0) -> dict:
 	if (child.finding_type or "") not in ai_fix.AI_ELIGIBLE_FINDING_TYPES:
 		frappe.throw(
 			f"AI fix suggestions aren't offered for '{child.finding_type}' "
-			"findings — they don't carry enough code/SQL context."
+			"findings they don't carry enough code/SQL context."
 		)
 	# v0.9.0: per-type opt-out (Critical Risk #2). Refuse on-demand calls
 	# for types listed in ``ai_excluded_finding_types`` with a clear message
@@ -1362,13 +1362,13 @@ def suggest_fix(session_uuid: str, finding_ref: str, regenerate=0) -> dict:
 	# Build the LLM context: the finding dict + a wide source window + (when a
 	# Phase-2 line-profile pass instrumented this finding's function) its
 	# hottest line + (best-effort) the top-N slowest SQL queries from this
-	# action's recording — shared with the analyze-time auto-suggest path.
+	# action's recording shared with the analyze-time auto-suggest path.
 	from optimus import analyze as _analyze_mod
 
 	# v0.6.x: fetch the single action's recording from Redis so the AI gets
 	# verbatim SQL evidence to ground against (the leading cause of bogus AI
 	# refactorings was the model inferring SQL shape from Python source
-	# instead of reading the actual query). Best-effort — if the recording
+	# instead of reading the actual query). Best-effort if the recording
 	# expired from Redis, fall through with just the source-window context.
 	recordings_by_uuid: dict = {}
 	actions_by_idx: dict = {}
@@ -1388,7 +1388,7 @@ def suggest_fix(session_uuid: str, finding_ref: str, regenerate=0) -> dict:
 				recs = list(_analyze_mod._fetch_recordings([rec_uuid], recordings_bundle=_analyze_mod._load_recordings_bundle(doc)))
 				recordings_by_uuid = {r.get("uuid"): r for r in recs if r.get("uuid")}
 	except Exception:
-		# Never let a recording-fetch error block the AI suggestion — fall
+		# Never let a recording-fetch error block the AI suggestion fall
 		# through with whatever context we already have.
 		recordings_by_uuid = {}
 
@@ -1410,7 +1410,7 @@ def suggest_fix(session_uuid: str, finding_ref: str, regenerate=0) -> dict:
 		)
 		safe_commit()
 	except Exception:
-		# Failing to persist isn't fatal — the operator still gets the
+		# Failing to persist isn't fatal the operator still gets the
 		# suggestion in the dialog, just not cached / in the report.
 		frappe.log_error(title="optimus suggest_fix persist")
 
@@ -1420,10 +1420,10 @@ def suggest_fix(session_uuid: str, finding_ref: str, regenerate=0) -> dict:
 @frappe.whitelist()
 def test_ai_connection() -> dict:
 	"""Probe the configured AI provider. System-Manager-only (config-
-	adjacent — Optimus Settings itself is SysMgr-only). Returns
+	adjacent Optimus Settings itself is SysMgr-only). Returns
 	``{"ok": bool, "message": str, "model": str}``; never raises on a
 	provider failure (the detail is in ``message``)."""
-	# The settings probe isn't billable to any session — clear the spend marker
+	# The settings probe isn't billable to any session clear the spend marker
 	# so its tokens don't land on whatever session this worker last served.
 	from optimus import analyze as _analyze_mod
 
@@ -1443,7 +1443,7 @@ def test_ai_connection() -> dict:
 @frappe.whitelist()
 def ai_capabilities() -> dict:
 	"""The per-section LLM toggles, for the Optimus Session form to decide
-	which AI buttons to show. Any logged-in profiler user — no Profiler
+	which AI buttons to show. Any logged-in profiler user no Profiler
 	Settings read permission needed (the server still enforces the toggles).
 	Returns ``{enabled, findings, indexes, humanize}`` (all bools)."""
 	_require_profiler_user()
@@ -1462,19 +1462,19 @@ def backfill_ai_fixes(session_uuid: str, regenerate_all=0) -> dict:
 	"""Generate AI fix suggestions for eligible findings on the session, then
 	re-render the report so they show up.
 
-	- ``regenerate_all`` falsy (default) — "Generate AI fixes": fill only the
+	- ``regenerate_all`` falsy (default) "Generate AI fixes": fill only the
 	  eligible findings that don't have a suggestion yet. Use this after the
 	  LLM was unavailable during analyze (with "Suggest AI fixes by default"
-	  on, the analyze still completes — the AI part is just skipped), or to
+	  on, the analyze still completes the AI part is just skipped), or to
 	  populate suggestions on demand without turning auto-suggest on.
-	- ``regenerate_all`` truthy — "Re-evaluate AI fixes": (re)generate the
+	- ``regenerate_all`` truthy "Re-evaluate AI fixes": (re)generate the
 	  suggestion for EVERY eligible finding, overwriting the existing ones.
 	  Use this after changing the AI model or prompt. A failure mid-re-eval
 	  leaves the old suggestion in place (only successful runs overwrite).
 
 	Either way it bypasses the ``ai_auto_suggest`` toggle (you're asking for
 	it explicitly) but still requires the provider to be configured, and is
-	bounded by the same per-call time budget — if it reports findings skipped
+	bounded by the same per-call time budget if it reports findings skipped
 	for time, just run it again.
 
 	Permission: recording user / System Manager / Administrator (mirrors
@@ -1514,13 +1514,13 @@ def backfill_ai_fixes(session_uuid: str, regenerate_all=0) -> dict:
 
 	if not ai_fix.is_available():
 		frappe.throw(
-			"AI fix suggestions aren't configured — enable them in Profiler "
+			"AI fix suggestions aren't configured enable them in Profiler "
 			"Settings ▸ AI Fix Suggestions and set a provider, model, and API key."
 		)
 	from optimus.settings import get_config
 	if not get_config().ai_suggest_findings:
 		frappe.throw(
-			'AI fix suggestions on findings are turned off — enable '
+			'AI fix suggestions on findings are turned off enable '
 			'"Fix suggestions on findings" under Optimus Settings ▸ AI.'
 		)
 
@@ -1592,13 +1592,13 @@ def humanize_steps(session_uuid: str) -> dict:
 
 	if not ai_fix.is_available():
 		frappe.throw(
-			"AI isn't configured — enable it under Optimus Settings ▸ "
+			"AI isn't configured enable it under Optimus Settings ▸ "
 			"AI Fix Suggestions and set a provider, model, and API key."
 		)
 	from optimus.settings import get_config
 	if not get_config().ai_humanize_steps:
 		frappe.throw(
-			'AI-humanized "Steps to Reproduce" is turned off — enable it '
+			'AI-humanized "Steps to Reproduce" is turned off enable it '
 			'under Optimus Settings ▸ AI.'
 		)
 
@@ -1647,7 +1647,7 @@ def _humanize_steps_core(doc, *, title: str | None = None) -> dict:
 		return {
 			"updated": False,
 			"reason": (
-				"This session has no user actions to summarise — it was all "
+				"This session has no user actions to summarise it was all "
 				"background / polling traffic (or the recordings have expired)."
 			),
 		}
@@ -1678,7 +1678,7 @@ def suggest_index(session_uuid: str, table_name: str) -> dict:
 
 	The deterministic "index candidate" (most-used filter combination +
 	`frappe.db.add_index` patch) is always in the report; this adds the AI's
-	take on top — which composite, whether your existing indexes already
+	take on top which composite, whether your existing indexes already
 	cover it, and the write-cost call. Requires AI to be configured.
 	Permission: recording user / System Manager / Administrator (mirrors
 	``download_pdf``).
@@ -1716,13 +1716,13 @@ def suggest_index(session_uuid: str, table_name: str) -> dict:
 
 	if not ai_fix.is_available():
 		frappe.throw(
-			"AI isn't configured — enable it under Optimus Settings ▸ "
+			"AI isn't configured enable it under Optimus Settings ▸ "
 			"AI Fix Suggestions and set a provider, model, and API key."
 		)
 	from optimus.settings import get_config
 	if not get_config().ai_suggest_indexes:
 		frappe.throw(
-			'AI index recommendations are turned off — enable '
+			'AI index recommendations are turned off enable '
 			'"Index recommendations (DB-tables breakdown)" under Optimus Settings ▸ AI.'
 		)
 
@@ -1782,7 +1782,7 @@ def _refill_indexes_for_doc(doc) -> dict:
 		if out.get("ok"):
 			added += 1
 		else:
-			# Helper returned a reason (e.g. provider missing for one call) —
+			# Helper returned a reason (e.g. provider missing for one call)
 			# treat as skipped, not failed, since the doc state is unchanged.
 			skipped += 1
 	return {"added": added, "failed": failed, "skipped": skipped}
@@ -1793,12 +1793,12 @@ def refill_ai_suggestions(session_uuid: str) -> dict:
 	"""Single-button entry point. Re-fills every AI-generated section of the
 	report in one round-trip:
 
-	1. ``_run_ai_backfill(doc, cap=0, regenerate_all=True)`` — overwrites
+	1. ``_run_ai_backfill(doc, cap=0, regenerate_all=True)``: overwrites
 	   every eligible finding's fix suggestion.
-	2. ``_humanize_steps_core(doc)`` — rewrites Steps to Reproduce.
-	3. ``_refill_indexes_for_doc(doc)`` — runs the per-table index helper
+	2. ``_humanize_steps_core(doc)``: rewrites Steps to Reproduce.
+	3. ``_refill_indexes_for_doc(doc)``: runs the per-table index helper
 	   for tables with a candidate but no AI advice yet.
-	4. ``regenerate_reports(session_uuid)`` — one final re-render.
+	4. ``regenerate_reports(session_uuid)``: one final re-render.
 
 	Each step is gated by its per-section toggle (``ai_suggest_findings``,
 	``ai_humanize_steps``, ``ai_suggest_indexes``); a toggle-off step is
@@ -1839,7 +1839,7 @@ def refill_ai_suggestions(session_uuid: str) -> dict:
 
 	if not ai_fix.is_available():
 		frappe.throw(
-			"AI isn't configured — enable it under Optimus Settings ▸ "
+			"AI isn't configured enable it under Optimus Settings ▸ "
 			"AI Fix Suggestions and set a provider, model, and API key."
 		)
 
@@ -1874,7 +1874,7 @@ def refill_ai_suggestions(session_uuid: str) -> dict:
 
 	steps = {"updated": False, "reason": None}
 	if cfg.ai_humanize_steps:
-		# Re-fetch the doc — the backfill above may have mutated rows.
+		# Re-fetch the doc the backfill above may have mutated rows.
 		doc = frappe.get_doc("Optimus Session", row["name"])
 		steps = _humanize_steps_core(doc, title=row.get("title") or None)
 	else:
@@ -1933,7 +1933,7 @@ def get_config_profiles() -> dict:
 			"Only System Manager can read the Optimus sensitivity profiles."
 		)
 	from optimus import settings
-	# Plain dict of dicts — JSON-serializable as-is for the whitelist response.
+	# Plain dict of dicts JSON-serializable as-is for the whitelist response.
 	return {name: dict(values) for name, values in settings._PROFILES.items()}
 
 
@@ -1943,11 +1943,11 @@ def get_config_profiles() -> dict:
 # Three whitelisted endpoints that the Optimus Session form's "Phase 2:
 # Line Profile" section calls into:
 #
-#   get_phase2_candidates(session_uuid) — populate the curated picker
-#   start_line_profile_pass(session_uuid, picks) — begin a phase-2 run
-#   stop_line_profile_pass(run_uuid) — end the run, enqueue analyze
+#   get_phase2_candidates(session_uuid) populate the curated picker
+#   start_line_profile_pass(session_uuid, picks) begin a phase-2 run
+#   stop_line_profile_pass(run_uuid) end the run, enqueue analyze
 #
-# Phase-2 implementation lives in optimus.line_profile.* —
+# Phase-2 implementation lives in optimus.line_profile.*
 # this surface is the thin transport layer.
 
 
@@ -1983,7 +1983,7 @@ def _picker_empty_hint(action_count, with_tree, parsed_ok, candidate_count, igno
 			f"Call trees loaded, but all {ignored_apps_filtered} candidate "
 			"frame(s) belong to apps on your Ignored Apps list, so none are "
 			"offered here. Remove that app from Optimus Settings › Ignored "
-			"Apps (keep at least one entry — clearing the list restores the "
+			"Apps (keep at least one entry clearing the list restores the "
 			"framework-app defaults), or type the function you want below."
 		)
 	if candidate_count == 0:
@@ -2016,7 +2016,7 @@ def get_phase2_candidates(session_uuid: str) -> dict:
 	from optimus.line_profile import picker as _lp_picker
 
 	_require_profiler_user()
-	# SECURITY: ownership gate — a phase-2 read exposes the session's captured
+	# SECURITY: ownership gate a phase-2 read exposes the session's captured
 	# call-tree internals (function names, file paths). Without this, any Optimus
 	# User holding another user's session_uuid could read it.
 	parent_docname = _require_session_permission(session_uuid, "read")
@@ -2042,11 +2042,11 @@ def get_phase2_candidates(session_uuid: str) -> dict:
 	# list before their children, each row tagged with ``depth`` so
 	# the JS dialog can render hierarchy via indented labels.
 	candidates = _lp_picker._build_tree_indented_candidates(trees)
-	# Pre-filter count for the diagnostic/hint — captured before the ignored
+	# Pre-filter count for the diagnostic/hint captured before the ignored
 	# filter reassigns ``candidates`` below.
 	raw_candidate_count = len(candidates)
 
-	# Drop candidates whose app is on the Ignored Apps list — the report
+	# Drop candidates whose app is on the Ignored Apps list the report
 	# already excludes those apps, so offering them here would be inconsistent.
 	try:
 		from optimus.settings import get_ignored_apps
@@ -2104,7 +2104,7 @@ def start_line_profile_pass(session_uuid: str, picks, auto_expand=True) -> dict:
 
 	When ``auto_expand`` is true (the default), each curated pick is
 	walked down phase-1's call tree via ``picker.expand_hot_chain`` so
-	the run instruments the full hot chain in one shot — the developer
+	the run instruments the full hot chain in one shot the developer
 	doesn't have to re-pick descendants. Free-form picks pass through
 	unchanged (we have no chain to walk for them).
 	"""
@@ -2115,12 +2115,12 @@ def start_line_profile_pass(session_uuid: str, picks, auto_expand=True) -> dict:
 	from optimus.line_profile import picker as _lp_picker
 
 	user = _require_profiler_user()
-	# SECURITY: ownership gate — this instruments code and writes Phase Two Run
+	# SECURITY: ownership gate this instruments code and writes Phase Two Run
 	# rows onto the session (save(ignore_permissions=True)). Only the owner /
 	# System Manager may start a pass on it.
 	_require_session_permission(session_uuid, "write")
 
-	# The picks arg often arrives as a string from JS — accept both shapes.
+	# The picks arg often arrives as a string from JS accept both shapes.
 	if isinstance(picks, str):
 		try:
 			picks_list = _json.loads(picks)
@@ -2137,7 +2137,7 @@ def start_line_profile_pass(session_uuid: str, picks, auto_expand=True) -> dict:
 		auto_expand = auto_expand.lower() in ("true", "1", "yes")
 	auto_expand = bool(auto_expand)
 
-	# Phase-1 must not be active for the same user — phase 1 and phase 2
+	# Phase-1 must not be active for the same user phase 1 and phase 2
 	# read separate Redis flags but only one can be active at a time.
 	if session.get_active_session_for(user):
 		frappe.throw(
@@ -2167,7 +2167,7 @@ def start_line_profile_pass(session_uuid: str, picks, auto_expand=True) -> dict:
 	# Auto-expand curated picks via phase-1's call tree. Curated picks come
 	# in as {dotted_path, source: "curated"}; the expansion adds their hot
 	# user-code descendants up to the framework boundary. Free-form picks
-	# (source != "curated") aren't expanded — we don't know if they appeared
+	# (source != "curated") aren't expanded we don't know if they appeared
 	# in phase 1 at all.
 	expansions: list[dict] = []
 	if auto_expand:
@@ -2221,7 +2221,7 @@ def start_line_profile_pass(session_uuid: str, picks, auto_expand=True) -> dict:
 				trees, dotted, max_depth=_max_depth, min_ms=_min_ms,
 			)
 			if not chain:
-				# Picked function wasn't in any phase-1 call tree (rare —
+				# Picked function wasn't in any phase-1 call tree (rare
 				# the picker UI sources from those same trees). Pass it
 				# through so the resolver can still attempt it.
 				if dotted and dotted not in seen:
@@ -2295,7 +2295,7 @@ def force_stop_phase2() -> dict:
 	"""Recovery endpoint: clears the calling user's phase-2 active flag and
 	marks any of their in-flight Phase 2 Run rows as Failed.
 
-	Idempotent — safe to call when nothing is stuck. Use this when the
+	Idempotent safe to call when nothing is stuck. Use this when the
 	form rejects ``start_line_profile_pass`` with "phase-2 already
 	active" and the previous run never reached Stop (worker crash, tab
 	close, or interrupted reproduction).
@@ -2330,7 +2330,7 @@ def force_stop_phase2() -> dict:
 
 	# v0.6.x: group stuck rows by their parent Optimus Session so each
 	# parent doc is loaded + saved EXACTLY ONCE per batch (was N loads + N
-	# saves when one session held multiple stuck runs — the common case
+	# saves when one session held multiple stuck runs the common case
 	# for a user spamming the picker).
 	rows_by_parent: dict[str, list[dict]] = {}
 	for row in stuck_rows:
@@ -2384,7 +2384,7 @@ def stop_line_profile_pass(run_uuid: str) -> dict:
 
 	# Find the run row + parent session. ``frappe.db.get_value`` with a
 	# filter dict + ``as_dict=True`` is the right primitive for a single
-	# child-table lookup on v16 — Frappe's ``get_list`` against child
+	# child-table lookup on v16 Frappe's ``get_list`` against child
 	# DocTypes (``istable: 1``) occasionally returns rows where the
 	# requested ``Select`` columns are stripped, which surfaced as a
 	# ``KeyError: 'status'`` in production. ``_require_profiler_user()``
@@ -2403,7 +2403,7 @@ def stop_line_profile_pass(run_uuid: str) -> dict:
 
 	parent_docname = row.parent
 	session_uuid = frappe.db.get_value("Optimus Session", parent_docname, "session_uuid")
-	# SECURITY: ownership gate on the resolved parent session — a run_uuid is not
+	# SECURITY: ownership gate on the resolved parent session a run_uuid is not
 	# self-authorizing; only the session owner / System Manager may stop its run.
 	_require_session_permission(session_uuid, "write")
 
@@ -2487,7 +2487,7 @@ def retry_phase2_analyze(run_uuid: str) -> dict:
 	or when the analyzer crashed and the user wants another shot.
 
 	Resets the row to Analyzing, then runs inline so the response carries
-	the final status (Ready or Failed) — no waiting for a worker to come
+	the final status (Ready or Failed) no waiting for a worker to come
 	online.
 	"""
 	from optimus.line_profile import analyzer as _lp_analyzer
@@ -2539,11 +2539,11 @@ def retry_phase2_analyze(run_uuid: str) -> dict:
 
 @frappe.whitelist()
 def retry_phase2_analyzes_batch(run_uuids) -> dict:
-	"""Batch variant of ``retry_phase2_analyze`` — accepts a list of
+	"""Batch variant of ``retry_phase2_analyze``: accepts a list of
 	``run_uuid``s and retries each in a single server round-trip.
 
 	v0.6.x: addresses the Lens-audit *"frappe.call(...) inside a loop"*
-	finding on the form's "Retry Phase 2" affordance — instead of N
+	finding on the form's "Retry Phase 2" affordance instead of N
 	client→server round-trips (one per stuck run, which is the common
 	case when a worker died and every Analyzing row needs a kick), the
 	UI fires ONE call and the loop runs server-side.

--- a/optimus/boot.py
+++ b/optimus/boot.py
@@ -5,7 +5,7 @@
 
 Runs once per Desk session init (before any page renders) to attach
 ``optimus_enabled`` to ``frappe.boot``. The floating widget reads
-this value synchronously to decide whether to mount itself — so a
+this value synchronously to decide whether to mount itself so a
 site admin toggling ``Optimus Settings ▸ Profiler Enabled`` off
 hides the widget on the next Desk load, without needing a separate
 HTTP round-trip to the settings endpoint.
@@ -15,7 +15,7 @@ HTTP round-trip to the settings endpoint.
 def boot_session(bootinfo):
 	"""Attach profiler config to frappe.boot.
 
-	Fails open — on ANY error reading settings, we default the widget
+	Fails open on ANY error reading settings, we default the widget
 	to visible. A misconfigured settings read should never hide the
 	widget entirely (that would silently break the primary UI without
 	explanation). The site admin can still disable via the DocType

--- a/optimus/capture.py
+++ b/optimus/capture.py
@@ -10,7 +10,7 @@ Owns:
      frappe.cache.get_value / frappe.permissions.has_permission for
      argument capture (with PII-safe hashing)
 
-Argument values that may contain user data are stored in two forms —
+Argument values that may contain user data are stored in two forms
 ``identifier_raw`` (rendered in the report) and ``identifier_safe``
 (a sha256[:12] hash, used as the bucket key for redundant-call
 detection). Doctype names and ptypes are NOT hashed because they're
@@ -26,7 +26,7 @@ single attribute lookup; they never read Redis.
 import hashlib
 import sys as _sys
 
-# Optional dependency — capture degrades gracefully if pyinstrument is
+# Optional dependency capture degrades gracefully if pyinstrument is
 # not installed (e.g. air-gapped environments, broken pip cache).
 try:
 	import pyinstrument  # noqa: F401
@@ -64,7 +64,7 @@ def _capture_caller_stack() -> list:
 	- Depth-bounded at ``_CALLER_STACK_MAX_DEPTH`` so a runaway
 	  recursion doesn't build a huge sidecar entry.
 	- Returns [] on any failure (non-CPython interpreter, f_back
-	  unexpectedly None) rather than raising — observability code
+	  unexpectedly None) rather than raising observability code
 	  never breaks the host call.
 	"""
 	try:
@@ -134,7 +134,7 @@ def _identify_args(fn_name: str, args: tuple, kwargs: dict):
 	if fn_name == "cache_get":
 		# This wraps RedisWrapper.get_value (a method), so args[0] is the
 		# RedisWrapper instance (self) and args[1] is the actual key. We
-		# wrap at the class level — not at frappe.cache — because
+		# wrap at the class level not at frappe.cache because
 		# frappe.cache is None at app-import time (no site bound yet).
 		key = args[1] if len(args) > 1 else kwargs.get("key")
 		# Cache keys may be bytes (Frappe sometimes builds them with the
@@ -166,7 +166,7 @@ def _identify_args(fn_name: str, args: tuple, kwargs: dict):
 		name = str(name) if name is not None else None
 		return (doctype, name, ptype), (doctype, _hash_identifier(name), ptype)
 
-	# Unknown — return None tuples so the bucket key is hashable but
+	# Unknown return None tuples so the bucket key is hashable but
 	# meaningless (the redundant_calls analyzer skips such entries).
 	return (None, None), (None, None)
 
@@ -200,7 +200,7 @@ def _make_wrap(orig, fn_name: str, local_proxy=None):
 	  - Drops entries past SIDECAR_CAP_PER_RECORDING and flags truncation.
 	  - Stores the original on `wrapped._profiler_original` so uninstall
 	    can restore it. If `orig` is itself an already-wrapped function
-	    (has `_profiler_original`), our wrap chains through `orig` —
+	    (has `_profiler_original`), our wrap chains through `orig`:
 	    we never double-wrap.
 	"""
 	def wrapped(*args, **kwargs):
@@ -218,7 +218,7 @@ def _make_wrap(orig, fn_name: str, local_proxy=None):
 
 		# Build the sidecar entry on a best-effort basis. A failure here
 		# (malformed args, exotic types) MUST NOT prevent the user's call
-		# from running — observability code never breaks the host call.
+		# from running observability code never breaks the host call.
 		try:
 			identifier_raw, identifier_safe = _identify_args(fn_name, args, kwargs)
 			entry = {
@@ -230,7 +230,7 @@ def _make_wrap(orig, fn_name: str, local_proxy=None):
 				# only callsites) AND surface file:line in the
 				# finding detail so users can actually navigate to
 				# the loop they need to fix. Pre-v0.5.2 findings
-				# showed only a hashed cache key with no callsite —
+				# showed only a hashed cache key with no callsite
 				# users couldn't act on them.
 				"caller_stack": _capture_caller_stack(),
 			}
@@ -283,7 +283,7 @@ def _start_pyi_session(local_proxy, interval_ms: float = DEFAULT_SAMPLER_INTERVA
 		local_proxy.optimus_pyinstrument = prof
 		return prof
 	except Exception:
-		# Any failure to start pyinstrument is non-fatal — degrade to
+		# Any failure to start pyinstrument is non-fatal degrade to
 		# SQL-only capture for this recording.
 		return None
 
@@ -339,7 +339,7 @@ def _wrap_targets():
 	`frappe.init(site)` runs). Wrapping the class method ensures every
 	cache instance created later uses the wrapped version. Because this
 	is a method wrap, the wrapper sees `self` as args[0] and the actual
-	key as args[1] — handled in `_identify_args` for `cache_get`.
+	key as args[1] handled in `_identify_args` for `cache_get`.
 	"""
 	import frappe
 	import frappe.permissions

--- a/optimus/dbdialect/__init__.py
+++ b/optimus/dbdialect/__init__.py
@@ -6,7 +6,7 @@
 ``get_dialect()`` returns the adapter for the active ``frappe.db.db_type``
 (mariadb / postgres). It is memoized on the db_type *string* (not on the
 ``frappe.db`` object) so it survives the per-test ``frappe.db`` proxy swaps
-(frappe.db is a Werkzeug Local proxy) — we read the string fresh each call and
+(frappe.db is a Werkzeug Local proxy) we read the string fresh each call and
 only build a new adapter when the db_type changes.
 """
 
@@ -44,7 +44,7 @@ def active_db_type() -> str:
 
 	# frappe.db is a Werkzeug Local proxy: reading .db_type when no DB is bound
 	# (unit tests) raises RuntimeError("object is not bound"), which getattr's
-	# default does NOT catch — so guard explicitly.
+	# default does NOT catch so guard explicitly.
 	dbt = None
 	try:
 		dbt = getattr(frappe.db, "db_type", None)
@@ -76,7 +76,7 @@ def get_dialect() -> Dialect:
 
 				frappe.log_error(
 					title="optimus unknown db_type",
-					message=f"db_type={dbt!r} not recognized — using the MariaDB dialect",
+					message=f"db_type={dbt!r} not recognized using the MariaDB dialect",
 				)
 			except Exception:
 				pass

--- a/optimus/dbdialect/base.py
+++ b/optimus/dbdialect/base.py
@@ -3,14 +3,14 @@
 
 """Database-dialect abstraction for the Optimus analysis engine.
 
-A profiler's value — slow-query / index / plan findings — comes from running
+A profiler's value slow-query / index / plan findings comes from running
 EXPLAIN and inspecting the database's plan output, which is MariaDB-specific.
 To support PostgreSQL too, every dialect-specific operation lives behind the
 ``Dialect`` interface, and the analyzers consume the *normalized* dataclasses
 below instead of touching raw EXPLAIN rows. ``optimus.dbdialect.get_dialect()``
 returns the right adapter for the active ``frappe.db.db_type``.
 
-This module is dialect-NEUTRAL — no SQL here. The MariaDB / Postgres SQL lives
+This module is dialect-NEUTRAL no SQL here. The MariaDB / Postgres SQL lives
 in ``mariadb.py`` / ``postgres.py``.
 """
 
@@ -63,7 +63,7 @@ def to_float(val):
 
 def to_int_or_none(val):
 	"""Coerce an infra metric (a SHOW GLOBAL STATUS value) to int, returning
-	None for an absent/unparseable value — so a missing metric stays None (the
+	None for an absent/unparseable value so a missing metric stays None (the
 	InfraSnapshot 'absent' sentinel) rather than silently reading as 0."""
 	if val is None:
 		return None
@@ -104,7 +104,7 @@ class IndexInfo:
 	name: str
 	columns: list                  # ordered by sequence-in-index
 	unique: bool = False
-	leftmost: str | None = None    # columns[0] if any — the col a b-tree accelerates a single-col filter on
+	leftmost: str | None = None    # columns[0] if any the col a b-tree accelerates a single-col filter on
 
 
 @dataclass
@@ -128,7 +128,7 @@ class Dialect(ABC):
 	# ``DBOptimizer``) can run on this database. That optimizer fetches table
 	# stats with MariaDB-only introspection (``DESCRIBE`` / ``SHOW INDEX FROM``),
 	# so on Postgres it raises a syntax error that ABORTS the whole transaction
-	# (Postgres poisons the txn on any failed statement — every later query then
+	# (Postgres poisons the txn on any failed statement every later query then
 	# fails until rollback). The index-suggestions analyzer gates on this flag so
 	# it never invokes the optimizer on a dialect that can't run it. True by
 	# default (MariaDB); Postgres overrides to False until a PG-native table-stats

--- a/optimus/dbdialect/mariadb.py
+++ b/optimus/dbdialect/mariadb.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""MariaDB dialect adapter — Optimus's current behaviour, behind the Dialect
+"""MariaDB dialect adapter Optimus's current behaviour, behind the Dialect
 interface.
 
 The EXPLAIN / index-introspection / infra-metric logic here is lifted
@@ -29,7 +29,7 @@ from optimus.dbdialect.base import (
 )
 
 # MariaDB TEXT/BLOB columns need a key-length prefix to index; JSON/GEOMETRY
-# can't take a plain b-tree index. (Mirrors index_suggestions — de-duplicated
+# can't take a plain b-tree index. (Mirrors index_suggestions de-duplicated
 # when that analyzer is rewired to call the dialect.)
 _PREFIX_REQUIRED_TYPES = frozenset({
 	"text", "tinytext", "mediumtext", "longtext",
@@ -38,7 +38,7 @@ _PREFIX_REQUIRED_TYPES = frozenset({
 _UNINDEXABLE_TYPES = frozenset({"json", "geometry"})
 _TEXT_INDEX_PREFIX_LENGTH = 255  # index_suggestions.TEXT_INDEX_PREFIX_LENGTH
 
-# MariaDB can't parameterise an identifier in ``SHOW INDEX FROM ?`` — the table
+# MariaDB can't parameterise an identifier in ``SHOW INDEX FROM ?``: the table
 # name is interpolated, so it must pass this whitelist first (index_suggestions
 # ._SAFE_TAB_TABLE_RE / _SAFE_INFOSCHEMA_RE / _is_safe_table_name).
 _SAFE_TAB_TABLE_RE = re.compile(r"^tab[A-Za-z0-9 _\-]+$")
@@ -57,7 +57,7 @@ class MariaDBDialect(Dialect):
 	name = "mariadb"
 
 	def __init__(self) -> None:
-		# max_connections is a server config — cached for the adapter's life
+		# max_connections is a server config cached for the adapter's life
 		# (the factory keeps one adapter per process). Mirrors the old
 		# module-level infra_capture._db_max_connections_cached.
 		self._max_connections_cached: int | None = None
@@ -77,7 +77,7 @@ class MariaDBDialect(Dialect):
 
 	@staticmethod
 	def _row_to_plan_table(row: dict) -> PlanTable:
-		"""Map one MariaDB EXPLAIN row to the normalized PlanTable — the exact
+		"""Map one MariaDB EXPLAIN row to the normalized PlanTable the exact
 		field reads from explain_flags._inspect_row."""
 		extra = (row.get("Extra") or row.get("extra") or "").lower()
 		return PlanTable(

--- a/optimus/dbdialect/postgres.py
+++ b/optimus/dbdialect/postgres.py
@@ -5,12 +5,12 @@
 
 Maps Postgres plan/catalog output onto the same normalized shapes the analyzers
 consume, so the analysis engine is dialect-blind. Plan analysis uses
-``EXPLAIN (FORMAT JSON)`` (plan-only — NEVER ``EXPLAIN ANALYZE``, which would
+``EXPLAIN (FORMAT JSON)`` (plan-only NEVER ``EXPLAIN ANALYZE``, which would
 execute the user's statement). The Sort / temp-table flags are plan-only
 heuristics: exact spill detection needs ANALYZE, so a ``Sort`` node over a
 relation is treated as the filesort analog and ``HashAggregate`` / ``Materialize``
 as the temporary-table analog. ``selectivity_pct`` has no plan-only Postgres
-equivalent (it needs ANALYZE row counts), so it's left None — the Low Filter
+equivalent (it needs ANALYZE row counts), so it's left None the Low Filter
 Ratio finding simply doesn't fire rather than mis-fire.
 
 The raw introspection SQL here is validated against a real ``--db-type postgres``
@@ -79,7 +79,7 @@ def _walk_plan(root: dict) -> list:
 
 	BY DESIGN, an ancestor Sort/temp flag attaches to EVERY scan beneath it. In a
 	``Sort → Join → (Scan A, Scan B)`` plan the sort applies to the joined output,
-	but both A and B are tagged ``sort_without_index`` — Postgres's plan-tree model
+	but both A and B are tagged ``sort_without_index``: Postgres's plan-tree model
 	doesn't decompose a sort back to a single relation the way MariaDB's row-per-
 	table EXPLAIN does. The over-attribution is bounded: ``selectivity_pct`` is None
 	on PG so Low Filter Ratio never fires, and the Filesort finding still needs a
@@ -130,7 +130,7 @@ class PostgresDialect(Dialect):
 		"""Run a query under a savepoint and roll back to it on failure.
 
 		CRITICAL on Postgres: a failed query aborts the WHOLE transaction
-		(InFailedSqlTransaction) — every later query then fails until a
+		(InFailedSqlTransaction) every later query then fails until a
 		rollback. Catching the Python exception is NOT enough; the savepoint
 		rollback is what restores the transaction so analyze (EXPLAIN on each
 		captured query + introspection) and the request (the infra snapshot)
@@ -147,7 +147,7 @@ class PostgresDialect(Dialect):
 			result = frappe.db.sql(*args, **kwargs)
 		except Exception:
 			# Roll back to the savepoint so the failed statement doesn't poison
-			# the rest of the transaction — but never let a rollback error mask
+			# the rest of the transaction but never let a rollback error mask
 			# the ORIGINAL exception (the caller's try/except turns the re-raised
 			# original into its safe default).
 			try:
@@ -214,7 +214,7 @@ class PostgresDialect(Dialect):
 		return out
 
 	def index_ddl(self, table: str, column: str, is_text_col: bool) -> str:
-		# Postgres b-trees index the full value — no prefix length. Long/searched
+		# Postgres b-trees index the full value no prefix length. Long/searched
 		# text may want an expression or GIN/trigram index instead.
 		schema = _db_schema()
 		return (
@@ -251,7 +251,7 @@ class PostgresDialect(Dialect):
 		return snap
 
 	def prefix_required(self, data_type: str) -> bool:
-		return False  # Postgres b-tree indexes the full value — no prefix syntax
+		return False  # Postgres b-tree indexes the full value no prefix syntax
 
 	def unindexable(self, data_type: str) -> bool:
 		return (data_type or "").lower() in _UNINDEXABLE_TYPES

--- a/optimus/hooks.py
+++ b/optimus/hooks.py
@@ -24,7 +24,7 @@ required_apps = ["frappe"]
 # Cache-Control: max-age=43200, 12h). A real user report showed
 # realtime-event code shipped in v0.5.2 was still running the v0.5.1
 # HTTP-polling code in the browser because the cache-buster URL
-# /assets/.../floating_widget.js?v=0.5.1 was unchanged — the version
+# /assets/.../floating_widget.js?v=0.5.1 was unchanged the version
 # wasn't bumped when JS was edited. Using mtime auto-invalidates on
 # every file edit during development, and still includes __version__
 # so release-to-release upgrades invalidate cleanly on production
@@ -37,7 +37,7 @@ from optimus import __version__ as _frappe_profiler_version
 def _asset_version(relative_path: str) -> str:
 	"""Return ``<__version__>.<mtime>`` for a file under public/, or
 	just ``<__version__>`` if the file can't be stat'd (unlikely on a
-	healthy install — defensive so the hooks file never fails to
+	healthy install defensive so the hooks file never fails to
 	load).
 
 	The mtime component means ANY edit to the JS/CSS auto-invalidates
@@ -78,7 +78,7 @@ before_uninstall = "optimus.install.before_uninstall"
 # ------------
 # Attaches `optimus_enabled` to `frappe.boot` so the floating widget
 # can hide itself when the master kill-switch is off. Without this,
-# an admin who disables Optimus Settings still sees the widget —
+# an admin who disables Optimus Settings still sees the widget
 # which is a dead button (clicking Start does nothing because
 # before_request short-circuits). See floating_widget.js for the
 # corresponding client-side guard.
@@ -91,7 +91,7 @@ boot_session = "optimus.boot.boot_session"
 # (and is a no-op without the global flag). Our hook then decides per-user
 # whether to force-activate the recorder for this request.
 #
-# For HTTP, after_request runs in application()'s finally BEFORE frappe.recorder.dump() (WSGI ClosingIterator), so the recorder hash isn't written yet — data to attach must ride an Optimus sidecar key merged at analyze time, never an RMW of the recorder hash (jobs reverse the order: dump before after_job).
+# For HTTP, after_request runs in application()'s finally BEFORE frappe.recorder.dump() (WSGI ClosingIterator), so the recorder hash isn't written yet data to attach must ride an Optimus sidecar key merged at analyze time, never an RMW of the recorder hash (jobs reverse the order: dump before after_job).
 
 before_request = [
 	"optimus.hooks_callbacks.before_request",

--- a/optimus/hooks_callbacks.py
+++ b/optimus/hooks_callbacks.py
@@ -8,7 +8,7 @@ Phase 2, `before_job` / `after_job`) via `hooks.py`. Their job is to:
 
 1. Decide whether the current request belongs to an active profiler session.
 2. If yes, activate `frappe.recorder` for this request only (per-user
-   isolation — other users' concurrent traffic is NOT recorded).
+   isolation other users' concurrent traffic is NOT recorded).
 3. After the request, register the new recording UUID with the session
    so the analyze pipeline can find all recordings that belong to a flow.
 
@@ -23,23 +23,23 @@ Hook order
 ----------
 Frappe loads `frappe`'s own hooks first, then app hooks. So on each request:
 
-  1. `frappe.recorder.record()`        — frappe's own (no-op without flag)
-  2. `optimus.hooks_callbacks.before_request()` — ours, may activate
+  1. `frappe.recorder.record()` frappe's own (no-op without flag)
+  2. `optimus.hooks_callbacks.before_request()`: ours, may activate
   3. <request handling>
-  4. `frappe.recorder.dump()`          — frappe's own, dumps the recorder
+  4. `frappe.recorder.dump()` frappe's own, dumps the recorder
                                           we activated
-  5. `optimus.hooks_callbacks.after_request()` — ours, registers
+  5. `optimus.hooks_callbacks.after_request()`: ours, registers
                                           the new UUID with the session
 
 Step 4 happens before step 5 because frappe's `after_request` runs before
-ours (loaded first). That ordering is essential — we need the recording
+ours (loaded first). That ordering is essential we need the recording
 to be dumped to Redis before we ask the analyze pipeline to fetch it later.
 """
 
 import time
 
 import frappe
-import frappe.recorder  # imported at module top so function-local `import frappe.recorder` doesn't rebind `frappe` as a local variable (Python scope rule: any `import frappe.X` inside a function makes `frappe` a function-local for the entire scope, breaking earlier `frappe.local` reads — caused by Python 3.14 stricter scope detection on a pre-existing pattern)
+import frappe.recorder  # imported at module top so function-local `import frappe.recorder` doesn't rebind `frappe` as a local variable (Python scope rule: any `import frappe.X` inside a function makes `frappe` a function-local for the entire scope, breaking earlier `frappe.local` reads caused by Python 3.14 stricter scope detection on a pre-existing pattern)
 
 from optimus import capture as _capture
 from optimus import session
@@ -57,7 +57,7 @@ from optimus import session
 #   - per_action rows (N extra "optimus.api.status" rows per session)
 #   - top_queries / table_breakdown (queries from status polling / recorder
 #     lookups obscure the real hot spots)
-#   - the auto-generated "Steps to Reproduce" bullet list — the widget
+#   - the auto-generated "Steps to Reproduce" bullet list the widget
 #     polls every ~2s while Recording, so a 30-second flow ends up with
 #     a reproducer list that's 90% status polls
 #   - total wall-clock / total query totals on the Optimus Session form
@@ -65,11 +65,11 @@ from optimus import session
 # Filtered at capture time (before_request) rather than at display time so
 # ALL downstream analyzers see a clean recording list, not just auto-notes.
 _IGNORED_CMD_PREFIXES = (
-	# The profiler's own whitelisted API — widget poll, metrics submit,
+	# The profiler's own whitelisted API widget poll, metrics submit,
 	# retry, fetch, etc. None of these represent real application work.
 	"optimus.api.",
 	# Frappe's built-in Recorder doctype. If the user has the Recorder UI
-	# open in another tab while profiling (not uncommon — devs often have
+	# open in another tab while profiling (not uncommon devs often have
 	# both tools handy), its whitelisted calls (export_data, delete,
 	# get_request_details, pluck, start, stop) would otherwise be captured
 	# and attributed to the profiling session. They're the recorder's own
@@ -84,11 +84,11 @@ def _extract_cmd_from_request() -> str:
 
 	Two sources, checked in order:
 
-	1. ``frappe.local.form_dict.cmd`` — set by ``make_form_dict`` for
+	1. ``frappe.local.form_dict.cmd``: set by ``make_form_dict`` for
 	   legacy ``?cmd=foo.bar`` RPC calls. Available at before_request
 	   time because ``make_form_dict`` runs BEFORE the hook dispatcher.
 
-	2. ``frappe.local.request.path`` parsed for ``/method/<name>`` — the
+	2. ``frappe.local.request.path`` parsed for ``/method/<name>``: the
 	   only source for modern ``/api/method/foo.bar`` and
 	   ``/api/v2/method/foo.bar`` URLs, because Frappe's REST API routing
 	   (``handle_rpc_call`` in ``frappe/api/v1.py`` and ``v2.py``) only
@@ -98,10 +98,10 @@ def _extract_cmd_from_request() -> str:
 	   which was empty at hook time for these URLs.
 
 	Works for both v1 and v2 API paths because both route shapes use
-	``.../method/<name>`` — we find the substring ``/method/`` and take
+	``.../method/<name>``: we find the substring ``/method/`` and take
 	everything after it.
 
-	Returns "" when neither source produces a non-empty cmd — the caller
+	Returns "" when neither source produces a non-empty cmd the caller
 	treats that as "don't skip" so that request-path-less contexts
 	(OPTIONS preflights, health checks, pre-init edge cases) fall
 	through to the normal path rather than being filtered.
@@ -146,7 +146,7 @@ def _should_skip_request() -> bool:
 	``/api/method/foo`` URL shapes), then does a prefix match against
 	``_IGNORED_CMD_PREFIXES``. Non-method URLs (``/app/...``,
 	``/api/resource/...``, static files) resolve to "" and fall through
-	as 'not noise', which is the intended behavior — we only skip
+	as 'not noise', which is the intended behavior we only skip
 	endpoints that the profiler / recorder EXPOSES via whitelisted
 	methods, not general page loads or REST resource access.
 
@@ -228,13 +228,13 @@ def before_request(*args, **kwargs):
 	"""Activate the recorder if the current user has an active profiler session.
 
 	Runs on every HTTP request. The hot path (no active session) is one
-	Redis GET — `get_active_session_for(user)` — and an early return.
+	Redis GET `get_active_session_for(user)`: and an early return.
 	"""
 	try:
 		# v0.5.3: deferred sidecar-wrap install. The module-level
 		# install in optimus/__init__.py skips when frappe
 		# isn't fully initialized (to avoid breaking the bench test
-		# runner's bootstrap — see the rationale there). By the time
+		# runner's bootstrap see the rationale there). By the time
 		# the first real before_request fires, frappe is guaranteed
 		# to be up, so we lazy-install here. Idempotent via the
 		# wrap's own `_profiler_original` marker.
@@ -285,7 +285,7 @@ def before_request(*args, **kwargs):
 
 		# If frappe's own recorder already activated (someone has the
 		# standalone Recorder UI running globally), piggyback on its
-		# instance — do NOT create a second Recorder because that would
+		# instance do NOT create a second Recorder because that would
 		# overwrite frappe.local._recorder and orphan the first one's
 		# SQL patch, corrupting both recordings.
 		if getattr(frappe.local, "_recorder", None) is not None:
@@ -295,12 +295,12 @@ def before_request(*args, **kwargs):
 		# We pass force=True so the recorder runs regardless of the
 		# global RECORDER_INTERCEPT_FLAG, leaving the standalone
 		# Recorder UI's flag untouched.
-		# (frappe.recorder is imported at module top — see comment there.)
+		# (frappe.recorder is imported at module top see comment there.)
 		frappe.recorder.record(force=True)
 
 		# v0.5.1: snapshot infra metrics FIRST, BEFORE pyinstrument starts.
 		# Pre-v0.5.1 the order was reversed: _start_pyi_session was called
-		# here and THEN infra_capture.snapshot() ran — which meant pyi
+		# here and THEN infra_capture.snapshot() ran which meant pyi
 		# captured its own ~30ms SHOW GLOBAL STATUS / psutil work as part
 		# of the user's action. A production report on a 47ms realtime
 		# subscribe request showed 31ms (67%!) attributed to
@@ -308,7 +308,7 @@ def before_request(*args, **kwargs):
 		# making it look like the profiler was the bottleneck.
 		#
 		# Moving the snapshot before _start_pyi_session means pyi never
-		# samples the snapshot code path — its first sample lands after
+		# samples the snapshot code path its first sample lands after
 		# before_request returns, in the actual request handler. Fast
 		# actions (<50ms) now show true user-code time instead of being
 		# dominated by instrumentation overhead.
@@ -362,7 +362,7 @@ def after_request(*args, **kwargs):
 			session_uuid, recording_uuid, user=user
 		)
 		if not registered:
-			# Cap hit — the recording is in RECORDER_REQUEST_HASH but not
+			# Cap hit the recording is in RECORDER_REQUEST_HASH but not
 			# registered against our session. The cap_warning is already
 			# written to session meta; log here so the drop is visible
 			# in the error log / journalctl for debugging.
@@ -374,7 +374,7 @@ def after_request(*args, **kwargs):
 		frappe.log_error(title="optimus after_request")
 	finally:
 		# v0.3.0: dump pyinstrument session and sidecar log to Redis under
-		# per-recording-UUID keys. Best-effort — failures here log but
+		# per-recording-UUID keys. Best-effort failures here log but
 		# never break the request.
 		recording_uuid_for_dump = getattr(
 			getattr(frappe.local, "_recorder", None), "uuid", None
@@ -422,7 +422,7 @@ def after_request(*args, **kwargs):
 		# the custom header to JavaScript, even for same-origin requests.
 		#
 		# Gated on `optimus_session_id` specifically (not just the
-		# recorder UUID) — the standalone Frappe Recorder UI may be
+		# recorder UUID) the standalone Frappe Recorder UI may be
 		# activated globally on this site, which sets frappe.local._recorder
 		# and gives us a recording UUID, but THAT recording doesn't belong
 		# to any profiler session. Injecting the header for non-session
@@ -438,7 +438,7 @@ def after_request(*args, **kwargs):
 				# v0.5.3: pass the response object from the hook
 				# kwargs (Frappe passes `response=response,
 				# request=request` via run_after_request_hooks).
-				# Required for v15 compat — v15 doesn't stage
+				# Required for v15 compat v15 doesn't stage
 				# headers on frappe.local.response_headers, so
 				# we set them directly on response.headers.
 				_inject_correlation_header(
@@ -468,18 +468,18 @@ def after_request(*args, **kwargs):
 #
 # Hook order on each job (frappe loads first, our app loads after):
 #
-#   1. frappe.recorder.record       (frappe's own — no-op without flag)
-#   2. frappe.monitor.start         (frappe's own — unrelated)
-#   3. optimus.before_job   (ours — may activate via force=True)
+#   1. frappe.recorder.record       (frappe's own no-op without flag)
+#   2. frappe.monitor.start         (frappe's own unrelated)
+#   3. optimus.before_job   (ours may activate via force=True)
 #   4. <method runs>
-#   5. frappe.recorder.dump         (frappe's own — dumps the recorder we activated)
-#   6. frappe.monitor.stop          (frappe's own — unrelated)
+#   5. frappe.recorder.dump         (frappe's own dumps the recorder we activated)
+#   6. frappe.monitor.stop          (frappe's own unrelated)
 #   7. frappe.utils.file_lock.release_document_locks
-#   8. optimus.after_job    (ours — registers UUID with session)
+#   8. optimus.after_job    (ours registers UUID with session)
 #
 # The kwargs dict is passed by reference from frappe.utils.background_jobs.execute_job,
 # so popping `_profiler_session_id` here removes it from the dict that the
-# user's method will receive. This is essential — without popping, methods
+# user's method will receive. This is essential without popping, methods
 # whose signatures don't include **kwargs would crash with an unexpected
 # keyword argument error.
 
@@ -497,7 +497,7 @@ def before_job(method=None, kwargs=None, **rest):
 		# v0.5.2: honor the master kill-switch here too. If the admin
 		# turned the profiler off, we still need to pop our marker
 		# from kwargs so the user's method doesn't see an unexpected
-		# keyword argument — that happens below after the kill-switch
+		# keyword argument that happens below after the kill-switch
 		# check short-circuits the recorder activation path.
 		from optimus.settings import is_enabled
 		if not is_enabled():
@@ -516,7 +516,7 @@ def before_job(method=None, kwargs=None, **rest):
 		if kwargs is None:
 			return
 		if not isinstance(kwargs, dict):
-			# Unexpected — frappe should always pass a dict. Log once so
+			# Unexpected frappe should always pass a dict. Log once so
 			# we can debug if it ever happens in practice.
 			frappe.log_error(
 				title="optimus before_job unexpected kwargs",
@@ -525,7 +525,7 @@ def before_job(method=None, kwargs=None, **rest):
 			return
 
 		# Pop our marker so the user's method doesn't see it. This MUST
-		# happen regardless of whether we proceed to activate recording —
+		# happen regardless of whether we proceed to activate recording
 		# if we leave the marker in kwargs, the user's method will be
 		# called with an unexpected keyword argument and crash.
 		session_uuid = kwargs.pop("_profiler_session_id", None)
@@ -533,7 +533,7 @@ def before_job(method=None, kwargs=None, **rest):
 			return
 
 		# v0.7.x+: record this job's method + Running/started_at in the
-		# session's jobs hash BEFORE the user/active-session gates — so the
+		# session's jobs hash BEFORE the user/active-session gates so the
 		# bg-jobs report shows it even when we don't activate the recorder
 		# for it (orphan case: ``active != session_uuid`` because the user
 		# started a new session after Stop, but the old session's job is
@@ -563,7 +563,7 @@ def before_job(method=None, kwargs=None, **rest):
 		# pointer matches while the session is running. After Stop the
 		# pointer is cleared, but the session keeps a short "draining"
 		# window during which jobs the flow enqueued are still recorded
-		# (analyze.run waits for them) — but ONLY when the user has NO
+		# (analyze.run waits for them) but ONLY when the user has NO
 		# active session, so a late job never bleeds into a *different*
 		# session the user started after stopping this one. If the user
 		# started a brand-new session (active != session_uuid and not
@@ -572,7 +572,7 @@ def before_job(method=None, kwargs=None, **rest):
 		if active != session_uuid and not (active is None and session.is_draining(session_uuid)):
 			return
 
-		# All checks passed — activate the recorder for this job.
+		# All checks passed activate the recorder for this job.
 		frappe.local.optimus_session_id = session_uuid
 
 		# Same clobber protection as before_request: if the standalone
@@ -581,10 +581,10 @@ def before_job(method=None, kwargs=None, **rest):
 		if getattr(frappe.local, "_recorder", None) is not None:
 			return
 
-		# (frappe.recorder is imported at module top — see comment there.)
+		# (frappe.recorder is imported at module top see comment there.)
 		frappe.recorder.record(force=True)
 
-		# v0.5.1: snapshot BEFORE _start_pyi_session — mirrors the order
+		# v0.5.1: snapshot BEFORE _start_pyi_session mirrors the order
 		# fix in before_request. See the rationale comment there.
 		try:
 			from optimus import infra_capture
@@ -638,7 +638,7 @@ def after_job(method=None, kwargs=None, result=None, **rest):
 		_dump_capture_state_to_redis(recording_uuid=recording_uuid_for_dump)
 
 		# v0.5.0: write the infra diff to Redis for this job's recording.
-		# No correlation header to inject — background jobs have no HTTP
+		# No correlation header to inject background jobs have no HTTP
 		# response, and no browser to correlate with.
 		try:
 			start_snap = getattr(frappe.local, "optimus_infra_start", None)
@@ -654,7 +654,7 @@ def after_job(method=None, kwargs=None, result=None, **rest):
 		except Exception:
 			frappe.log_error(title="optimus infra end snapshot (job)")
 
-		# v0.6.0: this job ran — drop its RQ id from the session's
+		# v0.6.0: this job ran drop its RQ id from the session's
 		# pending-jobs set so analyze.run's wait can end early. Best-effort.
 		# v0.7.x+: also write terminal status + ended_at + duration_ms from
 		# here, while the RQ record is still alive. Falls back to the
@@ -675,7 +675,7 @@ def after_job(method=None, kwargs=None, result=None, **rest):
 				# report can join the captured query data to the job's row.
 				if recording_uuid_for_dump:
 					session.set_job_recording(_su, _rq_jid, recording_uuid_for_dump)
-				# v0.7.x+: authoritative terminal-status write — see the
+				# v0.7.x+: authoritative terminal-status write see the
 				# helper's docstring for why this beats the analyze-time
 				# RQ re-fetch (which silently drops GC'd job records).
 				_track_bg_job_finished(_su, _rq_jid)
@@ -726,7 +726,7 @@ def _dump_capture_state_to_redis(recording_uuid: str | None) -> None:
 	from optimus.session import SESSION_TTL_SECONDS, sign_blob
 
 	if not recording_uuid:
-		# No recorder ran on this request — nothing to dump.
+		# No recorder ran on this request nothing to dump.
 		_clear_capture_locals()
 		return
 
@@ -797,7 +797,7 @@ def _clear_capture_locals() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Background-job status tracking — authoritative writes from the worker
+# Background-job status tracking authoritative writes from the worker
 # ---------------------------------------------------------------------------
 # Pre-fix, the bg-job tracking pipeline relied on analyze re-reading each
 # enqueued job's terminal status from RQ at persist time
@@ -819,15 +819,15 @@ def _clear_capture_locals() -> None:
 #
 # These two helpers move the authoritative writes into the hooks, where:
 #   * before_job calls ``_track_bg_job_started`` right after popping the
-#     marker — has access to the method arg (fixes #1) and the worker's
+#     marker has access to the method arg (fixes #1) and the worker's
 #     wall-clock time (fixes the "no started_at" half of #2).
-#   * after_job calls ``_track_bg_job_finished`` in its finally block —
+#   * after_job calls ``_track_bg_job_finished`` in its finally block
 #     RQ record is still alive, so we capture status + ended_at +
 #     duration_ms ourselves (fixes the other half of #2).
 #
 # analyze's existing ``_capture_job_terminal_status`` stays as the fallback
 # for jobs the hooks couldn't cover (worker SIGKILL on timeout, crash before
-# after_job fires — frappe runs after_job in a try/finally so this is rare
+# after_job fires frappe runs after_job in a try/finally so this is rare
 # but possible). Its persist-time loop only fires for jobs whose status the
 # hooks did NOT already write (``if not _jm.get("status"):``), so no
 # double-work and no overwrite churn.
@@ -836,12 +836,12 @@ def _clear_capture_locals() -> None:
 # ``analyze._bg_wait_for_pending_jobs`` is hard-capped at
 # ``_MAX_BG_JOB_WAIT_SECONDS = 300`` (analyze.py:215). A job that runs longer
 # than 5 min ALWAYS exceeds the cap; at the cap, ``_finalize_pending_statuses``
-# marks the still-active job as ``status="Running"`` (no end times — analyze
+# marks the still-active job as ``status="Running"`` (no end times analyze
 # can't predict when it'll finish), ``_persist`` writes the Optimus
 # Background Job child row from that snapshot, and ``_cleanup_redis`` then
 # DELETES the jobs hash. When the long job actually finishes minutes later,
 # the worker's ``_track_bg_job_finished`` writes to a deleted Redis key
-# (orphan) and the persisted row stays ``Running`` forever — there's no
+# (orphan) and the persisted row stays ``Running`` forever there's no
 # in-band path to update it because re-analyze isn't viable (recordings /
 # meta / jobs hash are all gone).
 #
@@ -851,7 +851,7 @@ def _clear_capture_locals() -> None:
 # row exists at ``status="Running"``, it writes the terminal status +
 # ended_at + duration_ms + error directly via ``frappe.db.set_value`` +
 # commit. Guarded by an idempotency check (only updates Running placeholders
-# — never clobbers a fresher Completed) and a SEPARATE try/except from the
+# never clobbers a fresher Completed) and a SEPARATE try/except from the
 # Redis path so neither failure suppresses the other.
 #
 # Both helpers are best-effort: any failure is swallowed so a tracking bug
@@ -864,7 +864,7 @@ def _track_bg_job_started(session_uuid: str, method) -> None:
 	in ``_track_bg_job_finished``.
 
 	Called from ``before_job`` once the marker is validated, BEFORE the
-	user/active-session gates — so even orphan jobs (whose recorder we
+	user/active-session gates so even orphan jobs (whose recorder we
 	won't activate) get their status reported in the session's bg-jobs
 	list. The ``record_job`` call is idempotent (uses ``setdefault`` for
 	method on the Redis hash) so it's safe even when the fast-path in the
@@ -877,7 +877,7 @@ def _track_bg_job_started(session_uuid: str, method) -> None:
 		job_id = getattr(rq_job, "id", None) if rq_job is not None else None
 		if not job_id:
 			return
-		# frappe.enqueue accepts a callable too — extract its name so the
+		# frappe.enqueue accepts a callable too extract its name so the
 		# row's Method column doesn't render "<function foo at 0x…>".
 		method_str = method if isinstance(method, str) else getattr(method, "__name__", str(method))
 		session.record_job(session_uuid, job_id, method_str)
@@ -901,11 +901,11 @@ def _track_bg_job_finished(session_uuid: str, job_id: str) -> None:
 	"""Write the terminal status + ended_at + duration_ms while the RQ job
 	record is still alive in the worker. Two write paths, in order:
 
-	1. **Redis jobs hash** — primary. analyze's ``session.get_jobs(...)``
+	1. **Redis jobs hash**: primary. analyze's ``session.get_jobs(...)``
 	   reads from here at persist time. The in-flight case where analyze is
 	   still mid-wait gets the authoritative final state via this write.
 
-	2. **Optimus Background Job DocType row** — late-finish fallback. If
+	2. **Optimus Background Job DocType row**: late-finish fallback. If
 	   analyze has already finalized this session (status in {"Ready",
 	   "Failed"}) and ``_cleanup_redis`` has deleted the jobs hash, the
 	   Redis write above is an orphan; this path updates the persisted row
@@ -915,7 +915,7 @@ def _track_bg_job_finished(session_uuid: str, job_id: str) -> None:
 	Failure detection: Frappe runs after_job hooks inside a ``try/finally``
 	wrapping the user's method, so an in-flight exception is visible via
 	``sys.exc_info()``. RQ's timeout-killer raises ``JobTimeoutException``
-	(its class name, regardless of import path) — we map that distinctly so
+	(its class name, regardless of import path) we map that distinctly so
 	the report can flag timeouts separately from generic user-code failures.
 
 	Each write path has its own ``try/except: pass`` so a Redis hiccup
@@ -932,7 +932,7 @@ def _track_bg_job_finished(session_uuid: str, job_id: str) -> None:
 			status, error = "Completed", None
 		else:
 			# Match on the class name (not isinstance) so we don't have to
-			# import rq.timeouts at the worker hot path — and so vendored
+			# import rq.timeouts at the worker hot path and so vendored
 			# / re-exported variants still match.
 			name = exc_type.__name__
 			status = "Timeout" if name == "JobTimeoutException" else "Failed"
@@ -948,7 +948,7 @@ def _track_bg_job_finished(session_uuid: str, job_id: str) -> None:
 			except Exception:
 				duration_ms = None
 	except Exception:
-		# Couldn't even compute the terminal state — bail rather than write
+		# Couldn't even compute the terminal state bail rather than write
 		# half-baked data anywhere.
 		return
 
@@ -975,7 +975,7 @@ def _track_bg_job_finished(session_uuid: str, job_id: str) -> None:
 			"name",
 		)
 		if not docname:
-			return  # session not yet persisted — Redis path is the only path
+			return  # session not yet persisted Redis path is the only path
 		session_status = frappe.db.get_value("Optimus Session", docname, "status")
 		if session_status not in ("Ready", "Failed"):
 			return  # analyze still mid-wait; let it pick up the Redis write
@@ -985,7 +985,7 @@ def _track_bg_job_finished(session_uuid: str, job_id: str) -> None:
 			"name",
 		)
 		if not child_name:
-			return  # no row was persisted for this job — don't INSERT a phantom
+			return  # no row was persisted for this job don't INSERT a phantom
 		cur_status = frappe.db.get_value("Optimus Background Job", child_name, "status")
 		if cur_status not in (None, "Running"):
 			return  # idempotency: don't clobber a fresher Completed / Failed
@@ -1013,7 +1013,7 @@ def _track_bg_job_finished(session_uuid: str, job_id: str) -> None:
 # optimus_frontend.js shim to tie each XHR timing back to a specific
 # server recording. Without the Access-Control-Expose-Headers entry,
 # browsers refuse to surface custom response headers to JavaScript
-# even for same-origin requests — it's the most common frontend
+# even for same-origin requests it's the most common frontend
 # instrumentation failure mode.
 
 
@@ -1038,7 +1038,7 @@ def _inject_correlation_header(recording_uuid: str, response=None) -> None:
 
 	Symptom that motivated this fix: on v15, "Per-XHR timings" in the
 	Frontend panel rendered empty because ``optimus_frontend.js``
-	couldn't read the recording-id header — it was never set. Our
+	couldn't read the recording-id header it was never set. Our
 	v16-only staging dict was silently dropped during response build.
 	"""
 	# v16 path: write to the staged dict if Frappe exposes it.
@@ -1051,7 +1051,7 @@ def _inject_correlation_header(recording_uuid: str, response=None) -> None:
 			existing = ""
 		# Token-by-token check, NOT a substring ``in`` check. A naive
 		# ``in`` would falsely match when another app has already
-		# added "X-Optimus-Recording-Id-Legacy" or similar — our real
+		# added "X-Optimus-Recording-Id-Legacy" or similar our real
 		# header would then NOT be appended, the browser would refuse
 		# to surface it to JavaScript, and the entire frontend
 		# correlation feature would silently break. Split on commas

--- a/optimus/infra_capture.py
+++ b/optimus/infra_capture.py
@@ -22,7 +22,7 @@ import os
 
 import frappe
 
-# Counter-style metrics — diff() subtracts start from end to produce deltas.
+# Counter-style metrics diff() subtracts start from end to produce deltas.
 # Everything else is a gauge that passes through as the end value.
 _COUNTER_KEYS = {
     "db_slow_queries_total",
@@ -185,7 +185,7 @@ def _read_db(out: dict) -> None:
 def _read_redis(out: dict) -> None:
     # frappe.cache IS a redis.Redis subclass (RedisWrapper at
     # frappe/utils/redis_wrapper.py:38). There is no `.redis` child
-    # attribute — call info() directly on frappe.cache. An earlier
+    # attribute call info() directly on frappe.cache. An earlier
     # v0.5.0 version used `getattr(frappe.cache, "redis", None)` which
     # silently returned None in production (tests masked the bug
     # because the FakeCache mock matched the broken code exactly).

--- a/optimus/install.py
+++ b/optimus/install.py
@@ -56,7 +56,7 @@ def after_install():
 		safe_commit()
 
 	# v0.4.0: auto-assign the Optimus User role to every existing
-	# System Manager. Idempotent — users who already have it are skipped.
+	# System Manager. Idempotent users who already have it are skipped.
 	# Wrapped in try/except so a failure can't abort the install.
 	try:
 		_assign_profiler_user_to_system_managers()
@@ -69,7 +69,7 @@ def after_install():
 	# v0.5.2 round 3: pre-populate Optimus Settings ▸ Tracked Apps
 	# with the site's custom apps (anything not in the built-in
 	# FRAMEWORK_APPS set). Admin gets a sensible default inclusion-
-	# mode allowlist on day one — they don't have to remember that
+	# mode allowlist on day one they don't have to remember that
 	# Tracked Apps exists for the framework filter to actually match
 	# their mental model of "user code".
 	try:
@@ -81,7 +81,7 @@ def after_install():
 			pass
 
 	# v0.13.x: pre-populate Optimus Settings ▸ Ignored Apps with the two
-	# framework apps operators most commonly can't (or won't) patch —
+	# framework apps operators most commonly can't (or won't) patch
 	# ``frappe`` and ``erpnext``. Mirrors the tracked-apps seed: writes
 	# only when the table is empty (idempotent, never clobbers an
 	# operator's existing configuration). Operators who DO want frappe /
@@ -101,7 +101,7 @@ def after_install():
 # ``optimus.analyzers.base`` minus ``optimus`` itself (we're a third-
 # party app, not Frappe-org). Operators who actively contribute to one
 # of these (ERPNext core devs, HRMS maintainers, etc.) remove the rows
-# they care about post-install — the seed is a sensible default that
+# they care about post-install the seed is a sensible default that
 # trades a tiny first-time setup step for a clean day-one report on
 # the typical custom-app stack.
 #
@@ -137,7 +137,7 @@ def _seed_ignored_apps_with_framework_apps():
 	An app that isn't installed can't produce findings, so seeding it is
 	pure UI clutter. The intersection with ``frappe.get_installed_apps()``
 	mirrors what ``_seed_tracked_apps_from_installed_apps`` does for the
-	tracked-apps table — keep the seeded rows grounded in reality.
+	tracked-apps table keep the seeded rows grounded in reality.
 
 	Idempotent: if ``ignored_apps`` already has any rows (either from a
 	previous install run on the same site, or from manual operator
@@ -145,18 +145,18 @@ def _seed_ignored_apps_with_framework_apps():
 	seed is a fresh-install convenience, never a retroactive rewrite.
 	"""
 	if not frappe.db.exists("DocType", "Optimus Settings"):
-		# Migration hasn't created the Single yet — skip silently
+		# Migration hasn't created the Single yet skip silently
 		# (mirror the tracked-apps seed's early-return).
 		return
 
 	settings = frappe.get_single("Optimus Settings")
 	if settings.ignored_apps:
-		# Respect existing config — never overwrite.
+		# Respect existing config never overwrite.
 		return
 
 	installed = set(frappe.get_installed_apps() or [])
 	# Preserve _DEFAULT_IGNORED_APPS's alphabetical order in the seeded
-	# rows — iterate the tuple, not the set, so the resulting table is
+	# rows iterate the tuple, not the set, so the resulting table is
 	# stable + predictable.
 	to_seed = [app for app in _DEFAULT_IGNORED_APPS if app in installed]
 	if not to_seed:
@@ -178,12 +178,12 @@ def _seed_tracked_apps_from_installed_apps():
 	from optimus.analyzers.base import FRAMEWORK_APPS
 
 	if not frappe.db.exists("DocType", "Optimus Settings"):
-		# Migration hasn't created the Single yet — skip silently.
+		# Migration hasn't created the Single yet skip silently.
 		return
 
 	settings = frappe.get_single("Optimus Settings")
 	if settings.tracked_apps:
-		# Respect existing config — never overwrite.
+		# Respect existing config never overwrite.
 		return
 
 	installed = frappe.get_installed_apps() or []
@@ -203,7 +203,7 @@ def _assign_profiler_user_to_system_managers():
 	Idempotent: existing Optimus Users are left untouched. Never removes
 	roles. Safe to call repeatedly.
 
-	v0.6.x: was an N+1 — one ``get_doc("User", name)`` per user in the
+	v0.6.x: was an N+1 one ``get_doc("User", name)`` per user in the
 	system. Now uses a single ``Has Role`` query to find users with
 	System Manager (and read their existing roles in the same fetch), so
 	we only ``get_doc`` + ``save`` the subset that actually needs the new
@@ -217,7 +217,7 @@ def _assign_profiler_user_to_system_managers():
 	# the `roles` field on User, Page, Report, Workspace, … so without it the
 	# query also returns System-Manager roles on Pages/Reports/Workspaces
 	# (Printing, Prepared Report Analytics, ToDo, …) whose `parent` is NOT a
-	# User — and the later get_doc("User", parent) then DoesNotExistErrors on a
+	# User and the later get_doc("User", parent) then DoesNotExistErrors on a
 	# fresh install.
 	role_rows = frappe.get_all(
 		"Has Role",
@@ -247,7 +247,7 @@ def on_user_role_change(doc, method=None):
 	"""validate hook on User: auto-add Optimus User when System Manager
 	is present.
 
-	Wired via hooks.py: doc_events["User"]["validate"]. Silent — never
+	Wired via hooks.py: doc_events["User"]["validate"]. Silent never
 	raises and never produces a user-facing message. Idempotent.
 	"""
 	try:
@@ -277,7 +277,7 @@ def before_uninstall():
 	  re-install would lose those assignments).
 	- The `Optimus Session` MariaDB rows (frappe's uninstall flow
 	  drops the DocType tables naturally).
-	- The attached report files (same — frappe's File doctype cleanup
+	- The attached report files (same frappe's File doctype cleanup
 	  handles these).
 	"""
 	# v0.3.0: restore the three monkey-patched functions on uninstall.

--- a/optimus/janitor.py
+++ b/optimus/janitor.py
@@ -17,7 +17,7 @@ two failure modes:
 Both cases are handled by force-stopping the session: clear the Redis
 state, mark the row as Stopping, and enqueue analyze.run. If the analyze
 itself was the failure cause, it will retry once and end up in `Failed`
-on the next attempt — at least the row no longer pretends to be live.
+on the next attempt at least the row no longer pretends to be live.
 """
 
 import frappe
@@ -57,8 +57,8 @@ def sweep_stale_sessions():
 	except Exception:
 		frappe.log_error(title="optimus janitor sweep_stuck_analyzing")
 
-	# v0.7.x: sessions stranded in "Stopping" (analyze never ran — no worker,
-	# backlog, or an OOM-killed worker left a zombie job) — re-enqueue analyze.
+	# v0.7.x: sessions stranded in "Stopping" (analyze never ran no worker,
+	# backlog, or an OOM-killed worker left a zombie job) re-enqueue analyze.
 	try:
 		_sweep_stale_stopping()
 	except Exception:
@@ -78,7 +78,7 @@ def sweep_old_sessions():
 
 	Only deletes sessions in terminal states (Ready or Failed) older than
 	the configured retention (default: 90 days). Active sessions are
-	never touched here — the 5-minute janitor handles those.
+	never touched here the 5-minute janitor handles those.
 
 	Also cleans up:
 	- Attached report files so MariaDB and file storage shrink together
@@ -102,7 +102,7 @@ def _sweep_orphan_redis_state():
 
 	Round 2 fix #11. A failed analyze that never retries leaves its
 	meta and recordings sets in Redis forever. This daily sweep catches
-	those orphans — scans for profiler:session:* keys, extracts the
+	those orphans scans for profiler:session:* keys, extracts the
 	uuid, checks if the Optimus Session row still exists, and deletes
 	if not.
 
@@ -130,8 +130,8 @@ def _sweep_orphan_redis_state():
 
 	# Scan BOTH per-session key families so a session whose only surviving keys
 	# are frontend metrics is still discovered. (profiler:session:<uuid>:* and
-	# profiler:frontend:<uuid>:*). Per-RECORDING keys — profiler:tree/sidecar/
-	# infra:<recording_uuid> — carry a recording uuid (no session linkage in the
+	# profiler:frontend:<uuid>:*). Per-RECORDING keys profiler:tree/sidecar/
+	# infra:<recording_uuid> carry a recording uuid (no session linkage in the
 	# key), so they can't be orphan-checked here; they rely on SESSION_TTL expiry.
 	markers = ("profiler:session:", "profiler:frontend:")
 
@@ -204,7 +204,7 @@ def _sweep_orphan_redis_state():
 
 
 def _sweep_old_sessions():
-	# v0.13.x: settings precedence — DocType (via get_config) first,
+	# v0.13.x: settings precedence DocType (via get_config) first,
 	# legacy site_config fallback second, hardcoded default last. The
 	# DocType wins when both are set so the operator's UI choice always
 	# takes precedence over a stale site_config knob.
@@ -218,7 +218,7 @@ def _sweep_old_sessions():
 	# v0.13.x: 0 = forever (Strict-as-unlimited semantics). The daily
 	# sweep becomes a no-op; sessions accumulate indefinitely. Honored
 	# here so the field description's "Set to 0 to keep forever" promise
-	# matches the runtime — pre-v0.13.x this was silently overridden by
+	# matches the runtime pre-v0.13.x this was silently overridden by
 	# the legacy ``or DEFAULT_RETENTION_DAYS`` fallback.
 	if retention_days <= 0:
 		return
@@ -306,7 +306,7 @@ def _sweep_old_sessions():
 			}
 		except Exception:
 			# Defensive: if the bulk fetch fails (DB hiccup, perm), the
-			# loop below still runs — it just won't find any File docs to
+			# loop below still runs it just won't find any File docs to
 			# delete and the orphans-cleanup is a no-op for this pass.
 			file_name_by_url = {}
 
@@ -315,7 +315,7 @@ def _sweep_old_sessions():
 		try:
 			# Delete attached report files first so we don't leave
 			# orphaned File docs behind. v0.6.0 Round 7: dropped the
-			# safe_report_file / safe_report_pdf_file slots — single
+			# safe_report_file / safe_report_pdf_file slots single
 			# raw report + lazy PDF.
 			for file_url in (
 				row.get("raw_report_file"),
@@ -365,7 +365,7 @@ def _sweep_stale_recording():
 	# ``started_at`` is fixed at session creation, so a genuinely LIVE long flow
 	# (45min of real traffic) crosses the cutoff and would be wrongly stopped. The
 	# real liveness signal is the Redis active pointer, whose TTL is refreshed on
-	# every captured request — so only force-stop rows whose pointer is gone or
+	# every captured request so only force-stop rows whose pointer is gone or
 	# has moved to a different session (the true "user walked away" condition).
 	def _pointer_gone(row) -> bool:
 		try:
@@ -398,7 +398,7 @@ def _sweep_stale_recording():
 
 		# Enqueue analyze for whatever recordings did get captured before
 		# the user walked away. The analyze job handles empty sessions
-		# gracefully — it will mark the session Ready with a "no traffic
+		# gracefully it will mark the session Ready with a "no traffic
 		# was recorded" summary.
 		try:
 			frappe.enqueue(
@@ -414,7 +414,7 @@ def _sweep_stuck_analyzing():
 	"""Find Analyzing rows older than STALE_ANALYZING_MINUTES and mark Failed.
 
 	A genuinely long analyze (heavy EXPLAIN burst + AI suggestions, up to ~25min)
-	can cross the threshold WITHOUT bumping ``modified`` — the liveness heartbeat
+	can cross the threshold WITHOUT bumping ``modified``: the liveness heartbeat
 	is Redis-only (no risky mid-analyze DB commit). So before failing a row, skip
 	it if it still holds the live single-flight flag: that flag is heartbeated
 	throughout analyze, so its presence proves the run is progressing, not wedged.
@@ -452,7 +452,7 @@ def _sweep_stale_stopping():
 
 	``Stopping`` is meant to last only the instant between ``api._mark_stopping``
 	and ``analyze.run`` setting ``Analyzing``. Lingering there means the analyze
-	job never ran — no worker on the ``long`` queue, a queue backlog, or a
+	job never ran no worker on the ``long`` queue, a queue backlog, or a
 	worker OOM-killed mid-analyze that left a zombie job. Re-enqueue so the
 	session self-heals once a worker is available (analyze is idempotent and
 	handles empty sessions). We bump ``modified`` (re-affirming the status) so a
@@ -525,7 +525,7 @@ def _sweep_stale_phase2_runs():
 					"status": "Failed",
 					"warnings_json": frappe.as_json([
 						"Phase 2 run expired before any line data was captured "
-						"(no flow re-run within the window) — auto-stopped by "
+						"(no flow re-run within the window) auto-stopped by "
 						"janitor. To retry: click \"Run Line-Profile Pass\", "
 						"re-run your flow, then \"Stop Phase 2 Run\".",
 					]),

--- a/optimus/line_profile/analyzer.py
+++ b/optimus/line_profile/analyzer.py
@@ -9,10 +9,10 @@ per-line timings) into report-friendly findings + per-function aggregate.
 Two functions, mirroring the phase-1 ``analyze.run`` ↔ ``analyzers/*``
 split:
 
-- ``analyze(results_json)`` is the **pure** classifier — testable in
+- ``analyze(results_json)`` is the **pure** classifier testable in
   isolation, no Frappe / Redis access.
 - ``run_analyze(session_uuid, run_uuid)`` is the **impure** RQ entry
-  point — pulls samples from Redis, calls aggregate_samples, calls
+  point pulls samples from Redis, calls aggregate_samples, calls
   analyze, persists to the Optimus Phase Two Run row, propagates findings
   to the parent Session, triggers re-render, publishes realtime events.
 """
@@ -70,7 +70,7 @@ def _classify_hot_line(line_ms: float, total_ms: float) -> str | None:
 	"""Return 'High', 'Medium', or None for a candidate hot line.
 
 	The line must concentrate enough fraction AND have enough absolute time
-	to be worth flagging — a single line that's 100% of a 30ms function
+	to be worth flagging a single line that's 100% of a 30ms function
 	isn't actionable noise, but 60% of a 300ms function is.
 	"""
 	if total_ms <= 0:
@@ -87,7 +87,7 @@ def _classify_hot_line(line_ms: float, total_ms: float) -> str | None:
 def _function_invoked(fn: dict) -> bool:
 	"""A function is 'invoked' if at least one line has hits > 0 OR
 	total_ms > 0. line_profiler may report empty stats (no lines), or the
-	full line list with hits=0 — both mean the picked function was never
+	full line list with hits=0 both mean the picked function was never
 	executed during the recording."""
 	lines = fn.get("lines") or []
 	if not lines:
@@ -100,7 +100,7 @@ def _strip_line_comment(content: str) -> str:
 
 	Naively tracks single/double-quoted string state so a ``#`` inside a
 	literal doesn't get treated as a comment boundary. Triple-quoted
-	strings aren't recognised — line_profiler's per-line ``content``
+	strings aren't recognised line_profiler's per-line ``content``
 	carries one source line, so multi-line literals shouldn't appear
 	here in practice. A miss only costs a false negative (regex sees
 	the commented call and we don't suppress); never drops a real leaf.
@@ -136,7 +136,7 @@ def _detect_pass_through_callee(
 	(e.g. ``a(b(c()))``), the **last** one in the iteration order is
 	returned. The caller resolves chains by walking the per-function
 	classifications transitively, so picking any one of the present
-	qualnames suffices to anchor the chain — the leaf is found by
+	qualnames suffices to anchor the chain the leaf is found by
 	following ``passthrough_to`` until ``None``.
 	"""
 	stripped = _strip_line_comment(content or "")
@@ -224,13 +224,13 @@ def _hot_line_finding(fn: dict, line: dict, severity: str) -> dict:
 		# dotted_path stays in the description + technical_detail below.
 		"title": (
 			f"{_qualname_of(fn)}:{lineno} consumed {total_ms:.0f}ms "
-			f"({hits} hits) — single hottest line"
+			f"({hits} hits) single hottest line"
 		),
 		"customer_description": (
 			f"The line **{dotted_path}:{lineno}** is the dominant time sink in "
 			f"this function ({total_ms:.0f}ms across {hits} executions). "
 			"Optimizing it directly will move the needle on the function's "
-			"total cost — line-level timing makes the fix targetable."
+			"total cost line-level timing makes the fix targetable."
 		),
 		"technical_detail_json": json.dumps({
 			"dotted_path": dotted_path,
@@ -290,13 +290,13 @@ def _build_call_chain(
 	the end).
 
 	Empty chain (length 0) is returned when the leaf has no upstream
-	pass-through caller — i.e. it's a standalone function with no
+	pass-through caller i.e. it's a standalone function with no
 	wrapper finding to merge into. Single-step "chain" makes no sense
 	to render either, so we return [] in that case.
 
 	When the leaf has multiple callers (two functions whose hot lines
 	both call into this leaf), the chain follows the **hottest** caller
-	at each step — measured by the caller's function-total ``total_ms``.
+	at each step measured by the caller's function-total ``total_ms``.
 	"""
 	seen: set[str] = {leaf_qualname}
 	chain_qualnames: list[str] = [leaf_qualname]
@@ -405,10 +405,10 @@ def analyze(
 	Output:
 	  - findings: ``Hot Line`` (High/Medium) per **leaf** function whose
 	    hot line is the real cost driver. Functions whose hot line is
-	    just a call into another instrumented function are suppressed —
+	    just a call into another instrumented function are suppressed
 	    their position is preserved as a breadcrumb on the deeper finding.
 	    ``Function Not Invoked`` (Low) per pick that recorded nothing.
-	  - aggregate: ``{phase2_functions: [per-function summary, ...]}`` —
+	  - aggregate: ``{phase2_functions: [per-function summary, ...]}``:
 	    each summary carries top-5 lines by ``total_ms``.
 	  - warnings: human-readable strings for the report's warnings panel.
 	"""
@@ -478,7 +478,7 @@ def analyze(
 			uninvoked_paths.append(c["fn"].get("dotted_path") or qualname)
 			continue
 		if c["passthrough_to"]:
-			# Suppress — defer to the deeper leaf's finding. The chain is
+			# Suppress defer to the deeper leaf's finding. The chain is
 			# rebuilt when we visit that leaf below.
 			continue
 		fn = c["fn"]
@@ -492,7 +492,7 @@ def analyze(
 		if chain:
 			_attach_call_chain(finding, chain)
 		else:
-			# No upstream pass-through caller — try the phase-1 fallback
+			# No upstream pass-through caller try the phase-1 fallback
 			# hint for the rarer case where this finding's hot line is
 			# itself a call into uninstrumented code.
 			hint = _compute_phase1_hint(fn, hottest, call_trees)
@@ -515,7 +515,7 @@ def analyze(
 
 
 # ---------------------------------------------------------------------------
-# Orchestrator (impure — frappe required)
+# Orchestrator (impure frappe required)
 # ---------------------------------------------------------------------------
 
 
@@ -536,7 +536,7 @@ def run_analyze(session_uuid: str, run_uuid: str) -> None:
 	re-raise so RQ logs it.
 	"""
 	if not _FRAPPE_AVAILABLE:
-		raise RuntimeError("frappe not importable — run under bench")
+		raise RuntimeError("frappe not importable run under bench")
 
 	from optimus.line_profile import capture
 
@@ -549,7 +549,7 @@ def run_analyze(session_uuid: str, run_uuid: str) -> None:
 	parent_docname = run_row.parent
 	# Resolve the session owner so realtime events reach their Desk tab. This runs
 	# in an RQ worker with no browser socket, so publish_realtime needs an EXPLICIT
-	# user (a None target won't reach the form) — same as phase-1's
+	# user (a None target won't reach the form) same as phase-1's
 	# _publish_session_event. Without this the form never auto-updates the run row.
 	try:
 		owner = frappe.db.get_value("Optimus Session", parent_docname, "user")
@@ -589,12 +589,12 @@ def run_analyze(session_uuid: str, run_uuid: str) -> None:
 				if isinstance(tree, dict):
 					call_trees.append(tree)
 		except Exception:
-			# Loading phase-1 trees is best-effort — without them we
+			# Loading phase-1 trees is best-effort without them we
 			# fall back to regex-only pass-through detection.
 			call_trees = []
 		result = analyze(results_json, call_trees=call_trees or None)
 		# Observe, don't spoil: if the overhead watchdog cut tracing short to
-		# protect the user's flow, the line data is partial — say so (read the
+		# protect the user's flow, the line data is partial say so (read the
 		# flag before cleanup_run clears it below).
 		if capture.budget_was_hit(run_uuid):
 			result.warnings.append(
@@ -613,7 +613,7 @@ def run_analyze(session_uuid: str, run_uuid: str) -> None:
 		# path (which expects session_uuid, not docname).
 		_regenerate_parent_reports(session_uuid)
 
-		# Done — drop ephemeral Redis state.
+		# Done drop ephemeral Redis state.
 		capture.cleanup_run(run_uuid)
 
 		_publish("phase_2_run_ready", {
@@ -693,7 +693,7 @@ def _persist_run(
 	for finding in result.findings:
 		# Optimus Finding.title is a Data(140) field. Phase-2 findings are
 		# appended directly here (bypassing analyze._truncate_finding_titles),
-		# so clamp defensively — a long title must not trip Frappe's truncation
+		# so clamp defensively a long title must not trip Frappe's truncation
 		# warning while stopping phase 2. Full context lives in the description /
 		# technical_detail_json.
 		_title = finding.get("title") or ""
@@ -727,7 +727,7 @@ def _mark_run_failed(parent_docname: str, run_uuid: str, error: str, tb: str) ->
 		parent.save(ignore_permissions=True)
 		safe_commit()
 	except Exception:
-		# Truly best-effort — don't mask the original exception.
+		# Truly best-effort don't mask the original exception.
 		try:
 			frappe.db.rollback()
 		except Exception:

--- a/optimus/line_profile/capture.py
+++ b/optimus/line_profile/capture.py
@@ -5,11 +5,11 @@
 
 Two layers, both in this module:
 
-1. **Pure** — ``aggregate_samples(samples, picks)`` merges per-request
+1. **Pure**: ``aggregate_samples(samples, picks)`` merges per-request
    line_profiler stats into the analyzer's input shape. Tested in
    isolation.
 
-2. **Impure** — ``start_line_profile_pass`` / ``stop_line_profile_pass``
+2. **Impure**: ``start_line_profile_pass`` / ``stop_line_profile_pass``
    own the Redis-backed run lifecycle; ``is_active`` is the hot-path
    predicate for hooks; ``make_profiler``, ``serialize_stats`` and
    ``flush_samples`` form the per-request enable/disable cycle;
@@ -32,7 +32,7 @@ from optimus import redis_keys as _redis_keys
 from optimus.line_profile import diff
 
 # ---------------------------------------------------------------------------
-# Optional dependencies — guarded so the pure layer loads everywhere
+# Optional dependencies guarded so the pure layer loads everywhere
 # ---------------------------------------------------------------------------
 
 try:
@@ -58,14 +58,14 @@ def is_line_profiler_available() -> bool:
 def _require_frappe() -> None:
 	if not _FRAPPE_AVAILABLE:
 		raise RuntimeError(
-			"frappe must be importable for this operation — run under bench."
+			"frappe must be importable for this operation run under bench."
 		)
 
 
 def _require_line_profiler() -> None:
 	if not _LP_AVAILABLE:
 		raise RuntimeError(
-			"line_profiler is not installed — run "
+			"line_profiler is not installed run "
 			"`bench pip install line_profiler` to enable phase 2."
 		)
 
@@ -78,7 +78,7 @@ def _require_line_profiler() -> None:
 # budget_hit keys are now built via ``optimus.redis_keys`` (the v0.12.0
 # centralized source-of-truth). The local ``_active_key`` /
 # ``_picks_key`` / ``_source_key`` / ``_samples_key`` /
-# ``_budget_hit_key`` helpers below have been retired — call sites use
+# ``_budget_hit_key`` helpers below have been retired call sites use
 # ``_redis_keys.lp_active(user)`` etc. directly. Key strings are
 # byte-identical to the pre-v0.12.20 local helpers, so on-disk Redis
 # values from older bench versions resolve unchanged.
@@ -96,7 +96,7 @@ _resolved_fns_by_run: dict[str, list] = {}
 
 
 # ---------------------------------------------------------------------------
-# Pick resolution helper (lighter than picker.resolve_freeform — just
+# Pick resolution helper (lighter than picker.resolve_freeform just
 # returns the function object, used by the worker cache)
 # ---------------------------------------------------------------------------
 
@@ -105,7 +105,7 @@ def _resolve_attr(dotted_path: str):
 	"""Resolve a dotted path to its underlying function object.
 
 	Mirrors ``picker.resolve_freeform`` but returns just the callable. None
-	on any resolution failure — caller decides the surfacing.
+	on any resolution failure caller decides the surfacing.
 	"""
 	parts = dotted_path.split(".")
 	module = None
@@ -116,9 +116,9 @@ def _resolve_attr(dotted_path: str):
 			module_parts = i
 			break
 		except (ImportError, TypeError, ValueError):
-			# Mirror picker._resolve_freeform_exact: a malformed prefix —
+			# Mirror picker._resolve_freeform_exact: a malformed prefix
 			# a relative "...pkg" name (TypeError) or an empty name
-			# (ValueError) — is just "not importable". Honour this
+			# (ValueError) is just "not importable". Honour this
 			# function's documented "None on any resolution failure"
 			# contract instead of letting it escape as a 500.
 			continue
@@ -151,11 +151,11 @@ def aggregate_samples(samples: list[list[dict]], picks: list[dict]) -> list[dict
 	"""Merge per-request line_profiler samples into the analyzer's input shape.
 
 	Inputs:
-	  samples — list of per-request batches. Each batch is a list of line
+	  samples list of per-request batches. Each batch is a list of line
 	            records: ``{file, qualname, lineno, hits, total_us}``.
 	            One batch per HTTP request or background job that ran with
 	            phase-2 instrumentation active.
-	  picks   — one entry per picked function with the source-line data
+	  picks one entry per picked function with the source-line data
 	            captured at start time:
 	            ``{dotted_path, qualname, file, first_lineno, source_lines: [{lineno, content}]}``.
 
@@ -165,7 +165,7 @@ def aggregate_samples(samples: list[list[dict]], picks: list[dict]) -> list[dict
 
 	Samples that don't match any pick (stale code, renamed function, hot-
 	reload weirdness) are silently dropped. Lines in the sample that no
-	longer exist in the picked function's source are likewise dropped —
+	longer exist in the picked function's source are likewise dropped
 	the source-of-truth is the source captured at start time.
 	"""
 	# Build a lookup: (file, qualname, lineno) → cumulative {hits, total_us}
@@ -214,7 +214,7 @@ def aggregate_samples(samples: list[list[dict]], picks: list[dict]) -> list[dict
 
 
 # ---------------------------------------------------------------------------
-# Lifecycle (impure — frappe + Redis required)
+# Lifecycle (impure frappe + Redis required)
 # ---------------------------------------------------------------------------
 
 
@@ -296,7 +296,7 @@ def stop_line_profile_pass(run_uuid: str, user: str) -> None:
 
 	Also clears ``frappe.local._lp_active`` so the same web request that
 	called stop doesn't see a stale cached flag from earlier in the
-	request — the enqueue patch in __init__.py reads this to decide
+	request the enqueue patch in __init__.py reads this to decide
 	whether to propagate ``_lp_session_id`` into job kwargs.
 	"""
 	_require_frappe()
@@ -314,7 +314,7 @@ def stop_line_profile_pass(run_uuid: str, user: str) -> None:
 def is_active(user: str) -> str | None:
 	"""Return the active phase-2 run_uuid for the user, or None.
 
-	Hot-path predicate from the phase-2 request hook — must be cheap. The
+	Hot-path predicate from the phase-2 request hook must be cheap. The
 	value is cached on ``frappe.local._lp_active`` for the request lifetime
 	to avoid repeated Redis hits inside one request.
 	"""
@@ -368,13 +368,13 @@ def _get_or_resolve_picks(run_uuid: str) -> list:
 # its own thread-local ``_lp_profiler``. Under a multi-threaded (gunicorn
 # ``gthread``) worker, two requests can profile concurrently and co-own tool 2.
 # The forcible ``release_monitoring_tool`` (free_tool_id) and the before-hook's
-# orphan self-heal therefore must NOT key on the calling thread's local — freeing
+# orphan self-heal therefore must NOT key on the calling thread's local freeing
 # tool 2 while a sibling thread is still enabled desyncs line_profiler's shared
 # manager (the tool-2 leak class that froze production). This counter is the
 # process-wide truth: reclaim / force-free only when it reads 0.
 #
 # A thread killed mid-flight (without running its after-hook) would leak its
-# increment — but a gunicorn timeout recycles the whole worker, resetting this
+# increment but a gunicorn timeout recycles the whole worker, resetting this
 # global, so that path self-corrects on the next request.
 _active_profiler_lock = threading.Lock()
 _active_profiler_count = 0
@@ -429,7 +429,7 @@ def release_monitoring_tool() -> None:
 
 
 def disengage_monitoring() -> None:
-	"""Stop line-trace overhead *without* unseating line_profiler — zero tool 2's
+	"""Stop line-trace overhead *without* unseating line_profiler zero tool 2's
 	events but leave the tool registered.
 
 	This is the watchdog's disengage (vs ``release_monitoring_tool``'s full free).
@@ -458,7 +458,7 @@ def disengage_monitoring() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Overhead budget — observe without spoiling the flow
+# Overhead budget observe without spoiling the flow
 # ---------------------------------------------------------------------------
 # line_profiler does deterministic per-line tracing, so instrumenting a hot
 # loop multiplies its runtime and would freeze the user's request. A watchdog
@@ -499,7 +499,7 @@ def clear_budget_hit(run_uuid: str) -> None:
 def _disengage_run(run_uuid: str) -> None:
 	"""Watchdog callback: stop line tracing so the request finishes at its
 	natural speed, and flag the run as budget-truncated. Runs on a timer thread,
-	so it uses ``disengage_monitoring`` (zero events) — NOT ``release_monitoring_tool``
+	so it uses ``disengage_monitoring`` (zero events) NOT ``release_monitoring_tool``
 	(free the tool): freeing tool 2 out from under the request thread's still-active
 	profiler desyncs line_profiler's manager and orphans it (see
 	``disengage_monitoring``). The request thread's own ``disable_by_count`` does
@@ -528,7 +528,7 @@ def start_overhead_watchdog(run_uuid: str, budget_seconds):
 def make_profiler(run_uuid: str):
 	"""Build a fresh ``LineProfiler`` with the run's picks attached. Returns
 	None if line_profiler is unavailable, the run has no resolvable picks,
-	or any other defensive failure — phase 2 then becomes a no-op for this
+	or any other defensive failure phase 2 then becomes a no-op for this
 	request rather than breaking the host flow."""
 	if not _LP_AVAILABLE:
 		return None
@@ -660,7 +660,7 @@ def cleanup_run(run_uuid: str) -> None:
 		try:
 			frappe.cache.delete_value(key_fn(run_uuid))
 		except Exception:
-			# Best-effort — janitor will retry. Don't break analyze on
+			# Best-effort janitor will retry. Don't break analyze on
 			# Redis hiccups.
 			pass
 	_resolved_fns_by_run.pop(run_uuid, None)

--- a/optimus/line_profile/diff.py
+++ b/optimus/line_profile/diff.py
@@ -15,7 +15,7 @@ import hashlib
 def content_hash(source_text: str) -> str:
 	"""Return a sha256 hex digest of the line's stripped source text.
 
-	Whitespace-only edits don't change the hash — leading/trailing
+	Whitespace-only edits don't change the hash leading/trailing
 	whitespace is stripped before hashing, so re-indenting (or trimming
 	a trailing space) keeps the content-identity stable.
 	"""
@@ -42,7 +42,7 @@ def align_function(run_a_lines: list[dict], run_b_lines: list[dict]) -> list[dic
 	rows in ``run_a`` lineno order trailing.
 	"""
 	# Index run_a by content hash so we can look up while walking run_b.
-	# Each hash maps to a list (a line could appear multiple times — a
+	# Each hash maps to a list (a line could appear multiple times a
 	# repeated empty line, for example), so we pop from each list to mark
 	# consumed entries.
 	a_index: dict[str, list[dict]] = {}

--- a/optimus/line_profile/hooks.py
+++ b/optimus/line_profile/hooks.py
@@ -5,7 +5,7 @@
 
 Registered in ``optimus/hooks.py`` alongside the phase-1 callbacks
 in ``hooks_callbacks.py``. Phase-1 and phase-2 are mutually exclusive for
-a single user — they read separate Redis flags
+a single user they read separate Redis flags
 (``profiler:active:<user>`` vs ``profiler:lp:active:<user>``) and the API
 layer rejects starting one while the other is active.
 
@@ -68,7 +68,7 @@ def before_request_line_profile(*args, **kwargs) -> None:
 		if not run_uuid:
 			return
 
-		# Skip the profiler's own endpoints — same logic phase-1 uses to
+		# Skip the profiler's own endpoints same logic phase-1 uses to
 		# avoid recording its own admin API calls.
 		if hooks_callbacks._should_skip_request():
 			return
@@ -84,7 +84,7 @@ def before_request_line_profile(*args, **kwargs) -> None:
 		# worker a sibling thread mid-profile legitimately owns tool 2, and
 		# reclaiming it would desync that thread (the tool-2 leak class). The
 		# thread-local check stays as a cheap first gate. Log when the reclaim
-		# actually fires — silent reclaim masked the leak class in production.
+		# actually fires silent reclaim masked the leak class in production.
 		if (
 			capture.active_profiler_count() == 0
 			and getattr(frappe.local, "_lp_profiler", None) is None
@@ -175,7 +175,7 @@ def before_job_line_profile(method=None, kwargs=None, **rest) -> None:
 	dict *unconditionally*, even if we end up not instrumenting (run
 	already stopped, line_profiler unavailable, user is Guest, etc.).
 	The kwargs dict is the same one Frappe's ``execute_job`` will splat
-	into the user's method via ``method(**kwargs)`` — leaving our
+	into the user's method via ``method(**kwargs)``: leaving our
 	marker in there crashes the method with an unexpected-keyword-
 	argument error.
 
@@ -183,7 +183,7 @@ def before_job_line_profile(method=None, kwargs=None, **rest) -> None:
 	Frappe's hook dispatcher passes ``method`` + ``kwargs`` as named
 	parameters.
 	"""
-	# Always pop our marker first — before any control-flow that might
+	# Always pop our marker first before any control-flow that might
 	# return early. The mutation propagates because ``kwargs`` is a
 	# reference to the dict execute_job will use.
 	if isinstance(kwargs, dict):
@@ -211,7 +211,7 @@ def before_job_line_profile(method=None, kwargs=None, **rest) -> None:
 		# Self-heal a tool 2 orphaned by a previously-killed job (see
 		# before_request_line_profile). RQ workers run one job at a time, so
 		# the process-wide count is 0 between jobs and this is equivalent to the
-		# old thread-local gate — but we share the same count mechanism for
+		# old thread-local gate but we share the same count mechanism for
 		# consistency and strict safety. Log when the reclaim actually fires.
 		if (
 			capture.active_profiler_count() == 0

--- a/optimus/line_profile/picker.py
+++ b/optimus/line_profile/picker.py
@@ -6,18 +6,18 @@ resolve free-form dotted paths typed by the customer.
 
 The picker has two responsibilities:
 
-1. **Curated list** — walk the pyinstrument call trees attached to phase-1
+1. **Curated list**: walk the pyinstrument call trees attached to phase-1
    actions, aggregate Python frames by dotted path, and return the top-N
    candidates with cumulative_ms + hit_count + app + framework-membership
    metadata. The form UI uses this for its multi-select.
 
-2. **Free-form resolution** — given a dotted path the customer typed
+2. **Free-form resolution**: given a dotted path the customer typed
    (``my_app.tasks.heavy_job``), import the module, walk attribute access,
    and validate eligibility for ``line_profiler``. C-extensions / builtins
    lack ``__code__`` and cannot be line-profiled; lambdas and Server
    Scripts (filename starts with ``<``) are similarly out-of-scope.
 
-This module is **pure** — no Frappe DB / Redis access. The API endpoint
+This module is **pure**: no Frappe DB / Redis access. The API endpoint
 (``api.py``) loads the parsed call trees from the Optimus Session and
 passes them to ``_build_candidates_from_trees``.
 """
@@ -29,11 +29,11 @@ from optimus.analyzers.call_tree import _is_pure_helper_frame, _top_level_app
 
 CANDIDATE_CAP = 30
 # v0.7.x (P2): non-framework frames at/above this cumulative-ms are "recommended"
-# — the picker pre-ticks them so the real hot paths are one click to line-profile.
+# the picker pre-ticks them so the real hot paths are one click to line-profile.
 # Matches the auto_expand_min_ms default so "worth expanding" == "worth ticking".
 RECOMMEND_MIN_MS = 50.0
 # v0.13: surface hot frames from the top-N hottest action trees, not just the
-# single hottest — a flow often has several slow actions worth line-profiling
+# single hottest a flow often has several slow actions worth line-profiling
 # (e.g. multiple slow background jobs). A per-tree budget keeps one giant tree
 # (a long bg job) from filling the whole list and starving the others.
 _MAX_TREES = 8
@@ -61,7 +61,7 @@ def _is_synthetic_frame(function: str) -> bool:
 def filter_out_ignored_apps(candidates, ignored_apps):
 	"""Drop candidates whose owning ``app`` is on the Ignored Apps list.
 
-	Returns ``(kept, dropped_count)``. Pure — the caller resolves the ignored
+	Returns ``(kept, dropped_count)``. Pure the caller resolves the ignored
 	set (``settings.get_ignored_apps``) and passes it in, so the manual picker
 	(``api.get_phase2_candidates``) and auto-arm (``analyze._auto_arm_phase2``)
 	share ONE matching rule and can't silently drift.
@@ -87,7 +87,7 @@ def _derive_module_path(filename: str) -> str:
 	stdlib paths, etc.).
 
 	The filename usually comes from pyinstrument's ``file_path_short``,
-	which is ``os.path.relpath(file, <a sys.path entry>)`` — on some
+	which is ``os.path.relpath(file, <a sys.path entry>)``: on some
 	benches that yields leading ``../`` segments. Those are relative-path
 	artifacts, NOT module components: left in, ``".".join`` turns ``..``
 	into a leading dot (``"...pkg"``), and the curated pick then tries to
@@ -103,7 +103,7 @@ def _derive_module_path(filename: str) -> str:
 	]
 	if not parts:
 		return ""
-	# Strip leading "apps" (or "/apps") — Frappe convention. Subsequent
+	# Strip leading "apps" (or "/apps") Frappe convention. Subsequent
 	# duplicate (`apps/<app>/<app>/`) is the package-name double we want
 	# to collapse.
 	if "apps" in parts:
@@ -171,7 +171,7 @@ def _walk_tree(node: dict, hits: dict) -> None:
 	if (
 		kind == "python"
 		and not _is_synthetic_frame(function)
-		# Drop framework plumbing/wrapper frames — every request goes
+		# Drop framework plumbing/wrapper frames every request goes
 		# through frappe.app.application, frappe.handler.handle,
 		# frappe.utils.typing_validations.wrapper, frappe.recorder.record_sql,
 		# frappe.model.document.save / fn / runner / composer, etc. These
@@ -214,7 +214,7 @@ def _build_tree_indented_candidates(trees: list[dict]) -> list[dict]:
 	DFS pre-order means a parent always lands in the list before its children;
 	children at each level are explored hottest-first.
 
-	Was: only the single hottest tree — which hid the hot frames of every other
+	Was: only the single hottest tree which hid the hot frames of every other
 	slow action (a flow with several slow bg jobs only surfaced one). Now the
 	top ``_MAX_TREES`` trees above ``_MIN_TREE_MS`` are each walked with a
 	per-tree budget (so one giant tree doesn't fill the list), capped overall at
@@ -242,12 +242,12 @@ def _build_tree_indented_candidates(trees: list[dict]) -> list[dict]:
 		kind = node.get("kind", "python")
 		# v0.13: bucket the frame by its owning app the SAME way the donut /
 		# leaderboard do (``_top_level_app``). Frames that bucket to
-		# ``[other]`` — Python stdlib (``importlib/__init__.py``), third-party
-		# site-packages, synthetic ``<...>`` frames — are NOT the customer's
+		# ``[other]``: Python stdlib (``importlib/__init__.py``), third-party
+		# site-packages, synthetic ``<...>`` frames are NOT the customer's
 		# code (nor a Frappe framework app) and can't be usefully
 		# line-profiled, so they must never appear in the picker. (The real
 		# cost of a hot ``importlib.import_module`` is module loading, fixed by
-		# lazy-importing in the user's own frame — which DOES surface.)
+		# lazy-importing in the user's own frame which DOES surface.)
 		bucket = _top_level_app(function, filename)
 		is_real = (
 			kind == "python"
@@ -262,7 +262,7 @@ def _build_tree_indented_candidates(trees: list[dict]) -> list[dict]:
 			dotted = _build_dotted_path(filename, function)
 			if dotted and dotted in seen:
 				# Same function already offered (a hot function often roots more
-				# than one action tree) — don't list it twice. Walk its children
+				# than one action tree) don't list it twice. Walk its children
 				# at THIS depth so unique descendants still surface, then stop.
 				for child in sorted(
 					node.get("children") or [],
@@ -287,7 +287,7 @@ def _build_tree_indented_candidates(trees: list[dict]) -> list[dict]:
 				"hit_count": int(node.get("hit_count") or 1),
 				"is_framework": is_framework,
 				"depth": my_depth,
-				# v0.7.x (P2): pre-tick the real hot paths — user code above the
+				# v0.7.x (P2): pre-tick the real hot paths user code above the
 				# time threshold (the frames that become self-time findings).
 				"recommended": (not is_framework) and cml >= RECOMMEND_MIN_MS,
 			})
@@ -334,7 +334,7 @@ def _build_candidates_from_trees(trees: list[dict], findings: list[dict]) -> lis
 
 	Each output candidate carries:
 	  - ``dotted_path`` derived from filename + function name (best effort
-	    — class methods may need a freeform correction at pick time)
+	    class methods may need a freeform correction at pick time)
 	  - ``qualname`` the bare function name as captured (e.g. ``validate``)
 	  - ``file`` / ``lineno`` the captured source location
 	  - ``app`` extracted from filename's ``apps/<app>/`` prefix
@@ -436,8 +436,8 @@ def expand_hot_chain(
 	  • there is no Python child remaining,
 	  • or the chain has reached ``max_depth`` (when > 0).
 
-	v0.13.x: ``max_depth = 0`` means unlimited — walks to the leaf in
-	the hot-chain direction. ``min_ms = 0`` means no minimum — every
+	v0.13.x: ``max_depth = 0`` means unlimited walks to the leaf in
+	the hot-chain direction. ``min_ms = 0`` means no minimum every
 	measurable child is eligible. The Strict Sensitivity Profile uses
 	both as 0 so the operator gets the deepest possible auto-expansion.
 
@@ -509,7 +509,7 @@ def deepest_instrumented_descendant(
 	instrumented functions: when auto_expand instrumented A and C but
 	NOT the intermediate B (B was below ``min_ms`` or out of
 	``max_depth``), regex on A's hot line content sees ``B(...)`` and
-	finds no match in the instrumented set — but the phase-1 call tree
+	finds no match in the instrumented set but the phase-1 call tree
 	records A → B → C, so this helper walks down from A and reports C
 	as the deepest instrumented descendant.
 	"""
@@ -580,8 +580,8 @@ def resolve_freeform(dotted_path: str) -> dict:
 	The picker derives the *collapsed* single-prefix form
 	(``apps/<app>/<app>/x.py`` → ``<app>.x``), which is correct for
 	editable-installed apps (``import erpnext`` is the inner package). But
-	some apps are importable only with the doubled prefix — ``<app>.<app>.x``
-	— e.g. where ``import <app>`` yields the OUTER ``apps/<app>/`` dir. Try
+	some apps are importable only with the doubled prefix ``<app>.<app>.x``
+	e.g. where ``import <app>`` yields the OUTER ``apps/<app>/`` dir. Try
 	the path as given, then retry once with the app name doubled, and only
 	then surface the original (single-prefix) error.
 	"""
@@ -613,7 +613,7 @@ def _resolve_freeform_exact(dotted_path: str) -> dict:
 	parts = dotted_path.split(".")
 	if len(parts) < 2:
 		raise PickerError(
-			f"'{dotted_path}' looks like a top-level module — need at least "
+			f"'{dotted_path}' looks like a top-level module need at least "
 			"module.function (e.g. 'my_app.tasks.heavy_job')"
 		)
 
@@ -630,10 +630,10 @@ def _resolve_freeform_exact(dotted_path: str) -> dict:
 		except (ImportError, TypeError, ValueError) as exc:
 			# A non-importable prefix just means "try a shorter one". Besides
 			# ImportError (module not found), importlib raises TypeError for a
-			# relative name — a stored/curated dotted_path with a leading
+			# relative name a stored/curated dotted_path with a leading
 			# "..." makes ".".join(parts[:i]) start with a dot ("...pkg"),
 			# which importlib treats as a relative import requiring a package
-			# — and ValueError for an empty name. Treat all three as "this
+			# and ValueError for an empty name. Treat all three as "this
 			# prefix doesn't import" so a malformed path degrades to the clean
 			# PickerError below (which the caller handles) rather than
 			# escaping as a 500.
@@ -648,7 +648,7 @@ def _resolve_freeform_exact(dotted_path: str) -> dict:
 
 	if module_parts == len(parts):
 		raise PickerError(
-			f"'{dotted_path}' resolved to a module, not a function — "
+			f"'{dotted_path}' resolved to a module, not a function "
 			"include the function name (e.g. 'json.dumps' rather than 'json')"
 		)
 
@@ -670,7 +670,7 @@ def _resolve_freeform_exact(dotted_path: str) -> dict:
 		except AttributeError:
 			# Try class-method search ONLY for the very next attribute on
 			# a fresh module, and only when there's exactly one matching
-			# class — anything else is too ambiguous to pick automatically
+			# class anything else is too ambiguous to pick automatically
 			# and the user should use the freeform textbox to disambiguate.
 			if idx == 0 and len(remaining) == 1:
 				import inspect as _inspect

--- a/optimus/optimus/doctype/optimus_action/optimus_action.py
+++ b/optimus/optimus/doctype/optimus_action/optimus_action.py
@@ -5,5 +5,5 @@ from frappe.model.document import Document
 
 
 class OptimusAction(Document):
-	# Child table — no logic in Phase 0.
+	# Child table no logic in Phase 0.
 	pass

--- a/optimus/optimus/doctype/optimus_background_job/optimus_background_job.py
+++ b/optimus/optimus/doctype/optimus_background_job/optimus_background_job.py
@@ -5,7 +5,7 @@ from frappe.model.document import Document
 
 
 class OptimusBackgroundJob(Document):
-	# Child table on Optimus Session — one row per RQ job the recorded flow
+	# Child table on Optimus Session one row per RQ job the recorded flow
 	# enqueued, with its terminal status. Populated by analyze.run from the
 	# per-session job-meta hash (see optimus.session + optimus.analyze).
 	pass

--- a/optimus/optimus/doctype/optimus_finding/optimus_finding.json
+++ b/optimus/optimus/doctype/optimus_finding/optimus_finding.json
@@ -75,7 +75,7 @@
    "read_only": 1
   },
   {
-   "description": "JSON: AI-generated fix suggestion for this finding — {suggestion (markdown), model, provider, generated_at}. Populated on demand via the 'Suggest a fix (AI)' action; empty until then.",
+   "description": "JSON: AI-generated fix suggestion for this finding {suggestion (markdown), model, provider, generated_at}. Populated on demand via the 'Suggest a fix (AI)' action; empty until then.",
    "fieldname": "llm_fix_json",
    "fieldtype": "Long Text",
    "label": "AI Fix Suggestion (JSON)",

--- a/optimus/optimus/doctype/optimus_finding/optimus_finding.py
+++ b/optimus/optimus/doctype/optimus_finding/optimus_finding.py
@@ -5,5 +5,5 @@ from frappe.model.document import Document
 
 
 class OptimusFinding(Document):
-	# Child table — no logic in Phase 0.
+	# Child table no logic in Phase 0.
 	pass

--- a/optimus/optimus/doctype/optimus_phase_two_run/optimus_phase_two_run.json
+++ b/optimus/optimus/doctype/optimus_phase_two_run/optimus_phase_two_run.json
@@ -61,7 +61,7 @@
    "read_only": 1
   },
   {
-   "description": "JSON: aggregated per-function per-line timings — analyzer input + render source.",
+   "description": "JSON: aggregated per-function per-line timings analyzer input + render source.",
    "fieldname": "results_json",
    "fieldtype": "Long Text",
    "label": "Results (JSON)",

--- a/optimus/optimus/doctype/optimus_phase_two_run/optimus_phase_two_run.py
+++ b/optimus/optimus/doctype/optimus_phase_two_run/optimus_phase_two_run.py
@@ -5,6 +5,6 @@ from frappe.model.document import Document
 
 
 class OptimusPhaseTwoRun(Document):
-	# Child table on Optimus Session — orchestration logic lives in
+	# Child table on Optimus Session orchestration logic lives in
 	# optimus.line_profile.capture and .analyzer.
 	pass

--- a/optimus/optimus/doctype/optimus_session/optimus_session.js
+++ b/optimus/optimus/doctype/optimus_session/optimus_session.js
@@ -49,7 +49,7 @@ function render_ai_buttons(frm) {
 // Show a live headline on the form while analyze is running (the floating
 // widget shows the same progress, but if you're sitting on the Profiler
 // Session form you shouldn't have to stare at a static "Analyzing" status
-// — especially when AI fix suggestions are being generated, which can take
+// especially when AI fix suggestions are being generated, which can take
 // a while). Cleared + reloaded when the session reaches Ready / Failed.
 function subscribe_session_progress(frm) {
 	if (frm.is_new()) return;
@@ -65,7 +65,7 @@ function subscribe_session_progress(frm) {
 		frm.dashboard.set_headline(
 			'<span class="text-muted">' +
 				'<i class="fa fa-spinner fa-spin" style="margin-right:6px;"></i>' +
-				(pct !== null ? __("Preparing report — {0}% · {1}", [pct, desc]) : desc) +
+				(pct !== null ? __("Preparing report {0}% · {1}", [pct, desc]) : desc) +
 				"</span>"
 		);
 	});
@@ -101,12 +101,12 @@ function subscribe_session_progress(frm) {
 	});
 }
 
-// Single AI button: "Refresh AI suggestions" — replaces five legacy
+// Single AI button: "Refresh AI suggestions" replaces five legacy
 // buttons (Suggest a fix / Generate AI fixes / Re-evaluate AI fixes /
 // Humanize Steps / Suggest an index). One server endpoint runs all
 // three AI operations server-side and re-renders the report once at
 // the end. The per-section toggles still gate which operations run
-// inside the endpoint — a toggle-off section is skipped silently.
+// inside the endpoint a toggle-off section is skipped silently.
 function render_ai_refill_button(frm) {
 	if (frm.is_new()) return;
 	if (frm.doc.status !== "Ready") return;
@@ -118,7 +118,7 @@ function render_ai_refill_button(frm) {
 					"Refresh every AI-generated section of the report? " +
 						"This re-runs fix suggestions on findings, the " +
 						"humanized Steps to Reproduce, and index advice " +
-						"for tables with a candidate — then re-renders " +
+						"for tables with a candidate then re-renders " +
 						"the report once. Calls the configured LLM for " +
 						"each, so it can take a bit. If it doesn't " +
 						"finish in one pass, run it again."
@@ -154,13 +154,13 @@ function _refill_ai_call(frm) {
 			frappe.show_alert({ message: msg, indicator: indicator });
 			if (failed) {
 				frappe.show_alert({
-					message: __("{0} call(s) failed — old suggestions kept (see Error Log).", [failed]),
+					message: __("{0} call(s) failed old suggestions kept (see Error Log).", [failed]),
 					indicator: "red",
 				});
 			}
 			if (skipped) {
 				frappe.show_alert({
-					message: __("{0} skipped (time budget) — run it again for the rest.", [skipped]),
+					message: __("{0} skipped (time budget) run it again for the rest.", [skipped]),
 					indicator: "orange",
 				});
 			}
@@ -168,7 +168,7 @@ function _refill_ai_call(frm) {
 		},
 		error: () => {
 			frappe.show_alert({
-				message: __("The AI refresh request failed — see the error popup for details."),
+				message: __("The AI refresh request failed see the error popup for details."),
 				indicator: "red",
 			});
 		},
@@ -187,7 +187,7 @@ function render_phase2_button(frm) {
 	if (frm.doc.status !== "Ready") return;
 
 	// If there's an in-flight Recording row, surface Stop as the primary
-	// affordance — that's what the user is looking for after they've
+	// affordance that's what the user is looking for after they've
 	// reproduced their flow.
 	var recording = (frm.doc.phase_2_runs || []).find(function (r) {
 		return r.status === "Recording";
@@ -205,7 +205,7 @@ function render_phase2_button(frm) {
 					callback: function () {
 						frappe.show_alert({
 							message: __(
-								"Phase 2 stopped. Analyzing now — the report " +
+								"Phase 2 stopped. Analyzing now the report " +
 								"section will refresh when ready."
 							),
 							indicator: "blue",
@@ -223,11 +223,11 @@ function render_phase2_button(frm) {
 
 		// v0.7.x: a Recording pass does nothing until the flow re-executes and
 		// the pass is stopped. Auto-arm (and the picker) leave users staring at
-		// a Stop button with no context — spell out the two steps.
+		// a Stop button with no context spell out the two steps.
 		frm.set_intro(
 			__(
 				"🔬 Line profiling is armed. Re-run your flow now so the hot " +
-				"path(s) execute again, then click \"Stop Phase 2 Run\" above — " +
+				"path(s) execute again, then click \"Stop Phase 2 Run\" above " +
 				"the report will then pinpoint the exact hot line(s). " +
 				"(Profiling has to re-execute your code; it can't replay the " +
 				"original run.)"
@@ -241,7 +241,7 @@ function render_phase2_button(frm) {
 
 	// Surface a Retry button for any Phase 2 Run row stuck in Analyzing
 	// or Failed. The most common cause of stuck Analyzing is a dev site
-	// running without `bench start` — no RQ worker picks up the long
+	// running without `bench start`: no RQ worker picks up the long
 	// queue. retry_phase2_analyze runs inline so the click resolves
 	// directly to Ready or Failed.
 	var stuck_runs = (frm.doc.phase_2_runs || []).filter(function (row) {
@@ -251,7 +251,7 @@ function render_phase2_button(frm) {
 	// v0.6.x: when there are 2+ stuck runs, surface a SINGLE "Retry all
 	// stuck Phase-2 runs" button that fires ONE batched server call
 	// (addresses Lens-audit "frappe.call(...) inside a loop"). The
-	// per-run buttons below stay — they let the operator retry one
+	// per-run buttons below stay they let the operator retry one
 	// specific run when only one is misbehaving.
 	if (stuck_runs.length >= 2) {
 		frm.add_custom_button(
@@ -267,7 +267,7 @@ function render_phase2_button(frm) {
 						var t = msg.tallies || {};
 						frappe.show_alert({
 							message: __(
-								"Batch retry finished — " +
+								"Batch retry finished " +
 								(t.Ready || 0) + " Ready · " +
 								(t.Failed || 0) + " Failed" +
 								((t.Analyzing || 0) ? " · " + t.Analyzing + " still Analyzing" : "")
@@ -295,7 +295,7 @@ function render_phase2_button(frm) {
 						var msg = (r && r.message) || {};
 						frappe.show_alert({
 							message: __(
-								"Retry finished — status: " +
+								"Retry finished status: " +
 								(msg.status || "unknown") +
 								(msg.error ? " · " + msg.error : "")
 							),
@@ -315,7 +315,7 @@ function render_phase2_button(frm) {
 
 	// Recovery hatch: force-clear a stuck phase-2 active flag if a
 	// previous run never reached Stop (worker crash, tab close, etc.).
-	// Idempotent — safe to click when nothing is stuck.
+	// Idempotent safe to click when nothing is stuck.
 	frm.add_custom_button(__("Force Stop Stuck Run"), function () {
 		frappe.confirm(
 			__(
@@ -330,7 +330,7 @@ function render_phase2_button(frm) {
 						var msg = r && r.message ? r.message : {};
 						frappe.show_alert({
 							message: __(
-								"Phase 2 cleared — flag was " +
+								"Phase 2 cleared flag was " +
 								(msg.cleared_active_flag ? "set" : "already clear") +
 								"; " +
 								(msg.rows_marked_failed || 0) +
@@ -493,7 +493,7 @@ function show_phase2_dialog(frm, data) {
 
 	// When there are no user-app frames at all (vanilla ERPNext or a
 	// site without custom apps), the framework list IS the primary
-	// list — the customer is profiling erpnext / frappe code. Promote
+	// list the customer is profiling erpnext / frappe code. Promote
 	// it to default-expanded so the dialog shows usable candidates
 	// instead of an empty primary section.
 	var no_user_app = primary.length === 0 && framework.length > 0;
@@ -568,7 +568,7 @@ function show_phase2_dialog(frm, data) {
 				: __(
 					"+ " +
 					framework.length +
-					" framework frames (frappe / erpnext) — actionable for " +
+					" framework frames (frappe / erpnext) actionable for " +
 					"customizations or framework-level fixes"
 				),
 			collapsible: !no_user_app,
@@ -615,7 +615,7 @@ function show_phase2_dialog(frm, data) {
 			"following the hottest user-code child until it hits an ORM " +
 			"call or framework wrapper. The run instruments the entire " +
 			"chain so you see exactly which descendant line is the time " +
-			"sink — no need to re-pick and re-record level by level."
+			"sink no need to re-pick and re-record level by level."
 		),
 	});
 
@@ -677,7 +677,7 @@ function start_phase2(frm, picks, auto_expand) {
 			var expansions = r.message.expansions || [];
 
 			var msg = __(
-				"Phase 2 recording started — instrumenting " +
+				"Phase 2 recording started instrumenting " +
 				instrumented +
 				" function" + (instrumented === 1 ? "" : "s") +
 				". Reproduce your flow now, then click Stop on the floating widget."
@@ -694,12 +694,12 @@ function start_phase2(frm, picks, auto_expand) {
 			}
 			frappe.show_alert({ message: msg, indicator: "blue" });
 			frm.dashboard.add_indicator(
-				__("Phase 2 recording — run " + run_uuid.slice(0, 8) + "..."),
+				__("Phase 2 recording run " + run_uuid.slice(0, 8) + "..."),
 				"blue"
 			);
 		},
 		error: function (xhr) {
-			// Frappe surfaces validation errors through frappe.throw — they
+			// Frappe surfaces validation errors through frappe.throw they
 			// already render as a modal; we just re-enable the button.
 		},
 	});
@@ -770,7 +770,7 @@ function render_retry_button(frm) {
 // from the stored session data without re-running the analyzer. Shown
 // on Ready / Failed sessions. Typical use: the report template was
 // upgraded (e.g. noise filters or exec summary added) and the admin
-// wants existing sessions to reflect the new layout — or the original
+// wants existing sessions to reflect the new layout or the original
 // render crashed and a fix was deployed.
 function render_regenerate_report_button(frm) {
 	if (frm.is_new()) return;
@@ -783,7 +783,7 @@ function render_regenerate_report_button(frm) {
 				"Re-render the HTML report from stored session data. This "
 				+ "does NOT re-run the analyzer. Note: if \"Suggest AI fixes "
 				+ "in the report by default\" is enabled, this also asks the "
-				+ "LLM for fixes for any findings that don't have one yet — "
+				+ "LLM for fixes for any findings that don't have one yet "
 				+ "which can take a while."
 			),
 			() => {
@@ -832,7 +832,7 @@ function render_regenerate_report_button(frm) {
 // Parent-level, NON-status hint that an additive phase-2 line-profile drill-down
 // is still computing. The session's own `status` intentionally stays "Ready" (the
 // phase-1 report is rendered and available, and a session can have many phase-2
-// passes) — this just resolves the "parent Ready but a Phase 2 run says Analyzing"
+// passes) this just resolves the "parent Ready but a Phase 2 run says Analyzing"
 // confusion without flapping the real status. Driven by the already-loaded child
 // rows, so no extra round-trip; cleared automatically on the next refresh once the
 // run finishes (the phase_2_run_ready realtime event reloads the form).
@@ -929,7 +929,7 @@ function render_drain_progress(frm) {
 	};
 	const tick = () => {
 		// Stop polling if the user navigated away from this form (no clean
-		// per-form unload hook in Frappe — cur_frm is the active form).
+		// per-form unload hook in Frappe cur_frm is the active form).
 		if (window.cur_frm !== frm) {
 			stop();
 			return;
@@ -946,7 +946,7 @@ function render_drain_progress(frm) {
 					return;
 				}
 				const n = d.pending != null ? d.pending : 0;
-				// One self-managed banner updated in place — set_intro /
+				// One self-managed banner updated in place set_intro /
 				// set_headline both APPEND a dismissible .form-message in this
 				// Frappe version, so polling them stacked a new bar each tick.
 				_drain_banner(
@@ -970,7 +970,7 @@ function render_download_buttons(frm) {
 	if (frm.doc.status !== "Ready") return;
 
 	// v0.6.0 Round 7: safe-mode reporting removed. Single admin-scoped
-	// report — the raw HTML plus a lazy-generated PDF. Server-side
+	// report the raw HTML plus a lazy-generated PDF. Server-side
 	// permission gating still applies (Optimus User role + per-File
 	// permission hook).
 	if (frm.doc.raw_report_file) {
@@ -985,7 +985,7 @@ function render_download_buttons(frm) {
 						// Programmatic <a download="..."> click forces
 						// the browser to save the file rather than navigate
 						// to it. window.open serves the HTML inline because
-						// the file's Content-Type is text/html — that's the
+						// the file's Content-Type is text/html that's the
 						// "Open Report" flow below; this button needs a
 						// real save-to-disk.
 						const link = document.createElement("a");
@@ -1012,7 +1012,7 @@ function render_download_buttons(frm) {
 						// Content-Disposition: attachment, which triggers a
 						// download dialog instead of rendering inline. Fetch
 						// the content, wrap it in a blob URL with the right
-						// MIME type, and window.open that — blob URLs are
+						// MIME type, and window.open that blob URLs are
 						// not governed by the original response's
 						// Content-Disposition, so the browser renders the
 						// HTML inline. Works because the report HTML is

--- a/optimus/optimus/doctype/optimus_session/optimus_session.json
+++ b/optimus/optimus/doctype/optimus_session/optimus_session.json
@@ -117,7 +117,7 @@
   },
   {
    "default": "0",
-   "description": "Cumulative LLM tokens billed for this session — analyze auto-suggest plus every Refresh / on-demand AI run. Matches the Aerele usage ledger; only ever increases.",
+   "description": "Cumulative LLM tokens billed for this session analyze auto-suggest plus every Refresh / on-demand AI run. Matches the Aerele usage ledger; only ever increases.",
    "fieldname": "ai_tokens_spent",
    "fieldtype": "Long Int",
    "label": "AI Tokens Spent",
@@ -191,7 +191,7 @@
    "label": "Analyze Duration (ms)",
    "precision": "2",
    "read_only": 1,
-   "description": "How long the analyze pipeline took — useful for tracking profiler health."
+   "description": "How long the analyze pipeline took useful for tracking profiler health."
   },
   {
    "fieldname": "summary_section",
@@ -245,7 +245,7 @@
    "label": "Reports"
   },
   {
-   "description": "Full data — admin-scoped via Frappe File permissions.",
+   "description": "Full data admin-scoped via Frappe File permissions.",
    "fieldname": "raw_report_file",
    "fieldtype": "Attach",
    "label": "Report",
@@ -319,7 +319,7 @@
    "hidden": 1,
    "label": "v0.5.0 Aggregates (JSON)",
    "read_only": 1,
-   "description": "v0.5.0+: JSON dict holding infra_pressure and frontend_timings aggregates — infra_timeline, infra_summary, frontend_xhr_matched, frontend_vitals_by_page, frontend_orphans, frontend_summary. Consumed by the Server Resource and Frontend panels in the report template."
+   "description": "v0.5.0+: JSON dict holding infra_pressure and frontend_timings aggregates infra_timeline, infra_summary, frontend_xhr_matched, frontend_vitals_by_page, frontend_orphans, frontend_summary. Consumed by the Server Resource and Frontend panels in the report template."
   },
   {
    "fieldname": "analyzer_warnings",

--- a/optimus/optimus/doctype/optimus_session/optimus_session.py
+++ b/optimus/optimus/doctype/optimus_session/optimus_session.py
@@ -5,7 +5,7 @@ from frappe.model.document import Document
 
 
 class OptimusSession(Document):
-	# Phase 0 — scaffold only.
+	# Phase 0 scaffold only.
 	# Lifecycle methods (validate, on_update, on_trash) will be added in
 	# Phase 1 alongside the session API and Redis state tracking.
 	pass

--- a/optimus/optimus/doctype/optimus_settings/optimus_settings.js
+++ b/optimus/optimus/doctype/optimus_settings/optimus_settings.js
@@ -2,7 +2,7 @@
 // For license information, please see license.txt
 
 // Fill the `app_name` Autocomplete on BOTH the Tracked Apps and Ignored Apps
-// child tables with the bench's installed apps — both share the field on the
+// child tables with the bench's installed apps both share the field on the
 // `Optimus Tracked App` child doctype, so both must be filled.
 //
 // Why on refresh: the Autocomplete options live on the grid docfield,
@@ -10,12 +10,12 @@
 // on refresh survives reloads and "refresh" Ctrl-S cycles.
 
 // The full set of fields the Sensitivity Profile governs. Kept in sync with
-// optimus.settings._SENSITIVITY_KEYS — the preset numbers themselves are NOT
+// optimus.settings._SENSITIVITY_KEYS the preset numbers themselves are NOT
 // duplicated here; they're fetched at runtime from
 // optimus.api.get_config_profiles (single source of truth in settings.py).
 // Fields missing from this list are silently NOT updated by the JS preset-
 // write, even though the backend would still apply the preset at config-
-// resolve time — they'd appear locked under a non-Custom profile but show
+// resolve time they'd appear locked under a non-Custom profile but show
 // stale values. So this MUST match _SENSITIVITY_KEYS exactly.
 const OPTIMUS_SENSITIVITY_FIELDS = [
 	// General → Session retention
@@ -27,7 +27,7 @@ const OPTIMUS_SENSITIVITY_FIELDS = [
 	// Display filters
 	"min_action_duration_ms",
 	"large_duration_threshold_ms",
-	// Analyzer thresholds (detection — the original nine)
+	// Analyzer thresholds (detection the original nine)
 	"redundant_doc_threshold",
 	"redundant_cache_threshold",
 	"redundant_perm_threshold",
@@ -56,7 +56,7 @@ frappe.ui.form.on("Optimus Settings", {
 
 		// The API Key is a secret token, not a human-chosen password, so the
 		// password-strength meter is meaningless for it. It also POSTs the
-		// value to `test_password_strength` (zxcvbn) on every keystroke — and
+		// value to `test_password_strength` (zxcvbn) on every keystroke and
 		// for a long key zxcvbn returns a `guesses` integer larger than 64
 		// bits, which the server's orjson serializer can't encode → a 500
 		// "<!doctype" HTML page the form can't parse. Turning the check off
@@ -75,8 +75,8 @@ frappe.ui.form.on("Optimus Settings", {
 				// Options are a newline-separated string (Frappe splits on \n).
 				const options = r.message.join("\n");
 				// New rows rebuild their docfield from frappe.meta, so set the
-				// base child-doctype meta too — both docfield_map AND
-				// docfield_list — or a freshly-added row's dropdown is blank on
+				// base child-doctype meta too both docfield_map AND
+				// docfield_list or a freshly-added row's dropdown is blank on
 				// older Frappe (e.g. 15.98).
 				try {
 					const child_dt = "Optimus Tracked App";
@@ -91,7 +91,7 @@ frappe.ui.form.on("Optimus Settings", {
 						}
 					});
 				} catch (e) {
-					// meta not ready — per-grid update below covers existing rows.
+					// meta not ready per-grid update below covers existing rows.
 				}
 				// Fill each grid that's present.
 				["tracked_apps", "ignored_apps"].forEach((fieldname) => {
@@ -108,12 +108,12 @@ frappe.ui.form.on("Optimus Settings", {
 			},
 		});
 
-		// "Test AI connection" — only when the feature is on. Saves the
+		// "Test AI connection" only when the feature is on. Saves the
 		// operator a profiling round-trip just to find out the key/model
 		// are wrong.
 		// Also re-evaluate the "Test AI connection" button visibility
 		// when the operator toggles ai_enabled (see the ai_enabled
-		// handler below — it re-runs refresh() so this conditional
+		// handler below it re-runs refresh() so this conditional
 		// fires again).
 		if (frm.doc.ai_enabled) {
 			frm.add_custom_button(__("Test AI connection"), () => {
@@ -156,7 +156,7 @@ frappe.ui.form.on("Optimus Settings", {
 	config_profile(frm) {
 		// Sensitivity Profile changed. Under a named preset (Strict /
 		// Recommended / Relaxed) the threshold fields are read-only and the
-		// preset drives analysis at read time — but we ALSO fill the fields
+		// preset drives analysis at read time but we ALSO fill the fields
 		// with the preset numbers so the operator can see what they're getting
 		// (and so they become the starting point if they later pick Custom).
 		// On Custom we just unlock the fields and leave their current values.
@@ -212,7 +212,7 @@ frappe.ui.form.on("Optimus Settings", {
 	},
 
 	ai_provider(frm) {
-		// Base URL only applies to the "OpenAI-compatible" provider — the
+		// Base URL only applies to the "OpenAI-compatible" provider the
 		// hosted providers (Anthropic / OpenAI / Kimi) use their built-in
 		// default endpoint. Re-evaluate depends_on so Base URL hides/shows
 		// immediately when the provider changes, without a save + reload.

--- a/optimus/optimus/doctype/optimus_settings/optimus_settings.json
+++ b/optimus/optimus/doctype/optimus_settings/optimus_settings.json
@@ -113,7 +113,7 @@
   },
   {
    "default": "30",
-   "description": "Optimus Session records older than this are eligible for automatic deletion by the daily housekeeping job. Set to 0 to keep forever (the daily sweep becomes a no-op). Reference values — Strict: 1  ·  Recommended: 30  ·  Relaxed: 7.",
+   "description": "Optimus Session records older than this are eligible for automatic deletion by the daily housekeeping job. Set to 0 to keep forever (the daily sweep becomes a no-op). Reference values: Strict: 1  ·  Recommended: 30  ·  Relaxed: 7.",
    "fieldname": "session_retention_days",
    "fieldtype": "Int",
    "label": "Session Retention (days)",
@@ -128,7 +128,7 @@
   {
    "fieldname": "apps_description_tracked",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\"><b>Tracked Apps</b> is an <i>allowlist</i> — when populated, only those apps' findings are actionable; everything else routes to <i>Framework-level observations</i>. Leave it empty to keep the default (frappe / erpnext / hrms / lms / helpdesk / insights / crm / builder / wiki / drive / payments and pip libs are treated as framework code).</p><p class=\"text-muted small\" style=\"color:#b91c1c\"><b>Do not add frappe or erpnext to Tracked Apps.</b> Doing so flips them to \"user code\" and floods your actionable findings with framework noise — the opposite of what most users want. If you want them gone, add them to <b>Ignored Apps</b> (right) instead.</p>"
+   "options": "<p class=\"text-muted small\"><b>Tracked Apps</b> is an <i>allowlist</i> when populated, only those apps' findings are actionable; everything else routes to <i>Framework-level observations</i>. Leave it empty to keep the default (frappe / erpnext / hrms / lms / helpdesk / insights / crm / builder / wiki / drive / payments and pip libs are treated as framework code).</p><p class=\"text-muted small\" style=\"color:#b91c1c\"><b>Do not add frappe or erpnext to Tracked Apps.</b> Doing so flips them to \"user code\" and floods your actionable findings with framework noise the opposite of what most users want. If you want them gone, add them to <b>Ignored Apps</b> (right) instead.</p>"
   },
   {
    "fieldname": "tracked_apps",
@@ -143,7 +143,7 @@
   {
    "fieldname": "apps_description_ignored",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\"><b>Ignored Apps</b> is an <i>exclusion list</i> — findings whose blame app falls in this list are <b>dropped from the report entirely</b> (both the \"Findings — what to fix\" and \"Framework-level observations\" sections). Use it for apps you can't (or won't) patch. <b>Default on fresh install:</b> every Frappe-organization-maintained app is seeded — <code>frappe</code>, <code>erpnext</code>, <code>hrms</code>, <code>lms</code>, <code>helpdesk</code>, <code>insights</code>, <code>crm</code>, <code>builder</code>, <code>wiki</code>, <code>drive</code>, <code>payments</code> — so a typical custom-app developer doesn't see Frappe-org noise on day one. Remove the rows you actively contribute to (ERPNext core, HRMS, etc.). The \"Issues found\" stat card shows the kept count plus a \"N findings hidden\" note, so the total stays honest.</p>"
+   "options": "<p class=\"text-muted small\"><b>Ignored Apps</b> is an <i>exclusion list</i> findings whose blame app falls in this list are <b>dropped from the report entirely</b> (both the \"Findings what to fix\" and \"Framework-level observations\" sections). Use it for apps you can't (or won't) patch. <b>Default on fresh install:</b> every Frappe-organization-maintained app is seeded <code>frappe</code>, <code>erpnext</code>, <code>hrms</code>, <code>lms</code>, <code>helpdesk</code>, <code>insights</code>, <code>crm</code>, <code>builder</code>, <code>wiki</code>, <code>drive</code>, <code>payments</code> so a typical custom-app developer doesn't see Frappe-org noise on day one. Remove the rows you actively contribute to (ERPNext core, HRMS, etc.). The \"Issues found\" stat card shows the kept count plus a \"N findings hidden\" note, so the total stays honest.</p>"
   },
   {
    "fieldname": "ignored_apps",
@@ -159,7 +159,7 @@
   {
    "fieldname": "skip_description",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\">Patterns and users to exclude from instrumentation. Matches against request path / job kwargs / session user. The profiler's own admin endpoints are always skipped — these settings extend the built-in skip list.</p>"
+   "options": "<p class=\"text-muted small\">Patterns and users to exclude from instrumentation. Matches against request path / job kwargs / session user. The profiler's own admin endpoints are always skipped these settings extend the built-in skip list.</p>"
   },
   {
    "description": "One pattern per line. URL paths starting with any of these prefixes are NOT profiled, even when an active session exists. Useful for healthcheck endpoints, polling APIs, etc. Lines starting with # are treated as comments. Example: /api/method/ping",
@@ -185,7 +185,7 @@
   {
    "fieldname": "redaction_description",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\">Optimus redacts <b>sensitive values at capture time</b> — passwords, API keys, tokens, CSRF, cookies, and authorization headers never reach Redis or the persisted report. Defaults cover 12 canonical patterns. Add domain-specific names below (one per line) to extend redaction; defaults are <b>never removed</b>. Substring match, case-insensitive. Lines starting with <code>#</code> are comments.</p>"
+   "options": "<p class=\"text-muted small\">Optimus redacts <b>sensitive values at capture time</b> passwords, API keys, tokens, CSRF, cookies, and authorization headers never reach Redis or the persisted report. Defaults cover 12 canonical patterns. Add domain-specific names below (one per line) to extend redaction; defaults are <b>never removed</b>. Substring match, case-insensitive. Lines starting with <code>#</code> are comments.</p>"
   },
   {
    "fieldname": "sensitive_sql_columns",
@@ -211,11 +211,11 @@
   {
    "fieldname": "capacity_description",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\">Long-running flows (bulk inserts, complex Submit chains) can exceed the per-recording query cap during analyze-time enrichment — each query needs an <code>EXPLAIN</code> round-trip, so very high counts would exceed RQ's job timeout. When capped, the report covers the first N queries and the rest are truncated; a red banner at the top of the report surfaces the truncation so you know the analysis is partial.</p><p class=\"text-muted small\"><b>Default: 2000</b> — comfortable for most flows. Raise to 5000 or 10000 for flows that legitimately touch more rows (e.g. Manufacturing Plan Submit creating 100+ child orders). Analyze-time cost scales roughly linearly with this value.</p>"
+   "options": "<p class=\"text-muted small\">Long-running flows (bulk inserts, complex Submit chains) can exceed the per-recording query cap during analyze-time enrichment each query needs an <code>EXPLAIN</code> round-trip, so very high counts would exceed RQ's job timeout. When capped, the report covers the first N queries and the rest are truncated; a red banner at the top of the report surfaces the truncation so you know the analysis is partial.</p><p class=\"text-muted small\"><b>Default: 2000</b> comfortable for most flows. Raise to 5000 or 10000 for flows that legitimately touch more rows (e.g. Manufacturing Plan Submit creating 100+ child orders). Analyze-time cost scales roughly linearly with this value.</p>"
   },
   {
    "default": "2000",
-   "description": "Max queries per recording that get enriched (sqlparse format + EXPLAIN + normalization). Anything beyond this is truncated with a warning. Keep reasonable — each query costs one EXPLAIN round-trip. Set to 0 for no cap (enrich every query — analyze time scales linearly with query volume, so reserve this for forensic deep-dives). Reference values — Strict: 0  ·  Recommended: 2000  ·  Relaxed: 1000.",
+   "description": "Max queries per recording that get enriched (sqlparse format + EXPLAIN + normalization). Anything beyond this is truncated with a warning. Keep reasonable each query costs one EXPLAIN round-trip. Set to 0 for no cap (enrich every query analyze time scales linearly with query volume, so reserve this for forensic deep-dives). Reference values: Strict: 0  ·  Recommended: 2000  ·  Relaxed: 1000.",
    "fieldname": "max_queries_per_recording",
    "fieldtype": "Int",
    "label": "Max Queries per Recording",
@@ -224,7 +224,7 @@
   },
   {
    "default": "1.0",
-   "description": "pyinstrument statistical-sampler interval in milliseconds. Lower = finer call-tree resolution but higher overhead. 1ms is the recommended default; raise to 5-10ms for prod-like profiling. Cannot be lower than 0.1ms. Reference values — Strict: 0.5  ·  Recommended: 1.0  ·  Relaxed: 5.0.",
+   "description": "pyinstrument statistical-sampler interval in milliseconds. Lower = finer call-tree resolution but higher overhead. 1ms is the recommended default; raise to 5-10ms for prod-like profiling. Cannot be lower than 0.1ms. Reference values: Strict: 0.5  ·  Recommended: 1.0  ·  Relaxed: 5.0.",
    "fieldname": "pyinstrument_sampler_interval_ms",
    "fieldtype": "Float",
    "label": "Sampler Interval (ms)",
@@ -237,14 +237,14 @@
   },
   {
    "default": "1",
-   "description": "When checked, the \"Time spent per database table\" section in the report drops Frappe schema/meta tables (tabDocType, tabDocField, tabSingles, tabPatch Log, tabWorkspace, tabRole, tabDocType Link/Action/State, …), framework-internal tables (tabHas Role, tabDefaultValue, tabUser Social Login, tabUser Role Profile, tabBlock Module, tabUser Email), and information_schema.* — touched by every request via framework machinery, not user-actionable. A small \"(N tables hidden)\" note replaces them. Other sections (top-queries leaderboard, per-action drill-down, full recordings) are unaffected. Uncheck to see them all.",
+   "description": "When checked, the \"Time spent per database table\" section in the report drops Frappe schema/meta tables (tabDocType, tabDocField, tabSingles, tabPatch Log, tabWorkspace, tabRole, tabDocType Link/Action/State, …), framework-internal tables (tabHas Role, tabDefaultValue, tabUser Social Login, tabUser Role Profile, tabBlock Module, tabUser Email), and information_schema.* touched by every request via framework machinery, not user-actionable. A small \"(N tables hidden)\" note replaces them. Other sections (top-queries leaderboard, per-action drill-down, full recordings) are unaffected. Uncheck to see them all.",
    "fieldname": "hide_framework_tables",
    "fieldtype": "Check",
    "label": "Hide framework / internal database tables in the breakdown"
   },
   {
    "default": "300",
-   "description": "How long (seconds, capped at 300) the analyze job watches the background jobs the profiled flow enqueued, waiting for each to reach a terminal state (completed / failed / timeout) before generating the report. Every enqueued job is listed in the report's \"Background jobs\" section with its status; a job still running when this window elapses is shown as \"Running\" (click Retry Analyze once it finishes to capture its data). 0 = don't wait. On a single-worker bench the analyze job yields the worker between checks so those jobs can actually run; if the scheduler is disabled / no worker is available, the wait is skipped. Reference values — Strict: 300  ·  Recommended: 300  ·  Relaxed: 60.",
+   "description": "How long (seconds, capped at 300) the analyze job watches the background jobs the profiled flow enqueued, waiting for each to reach a terminal state (completed / failed / timeout) before generating the report. Every enqueued job is listed in the report's \"Background jobs\" section with its status; a job still running when this window elapses is shown as \"Running\" (click Retry Analyze once it finishes to capture its data). 0 = don't wait. On a single-worker bench the analyze job yields the worker between checks so those jobs can actually run; if the scheduler is disabled / no worker is available, the wait is skipped. Reference values: Strict: 300  ·  Recommended: 300  ·  Relaxed: 60.",
    "fieldname": "background_job_wait_seconds",
    "fieldtype": "Int",
    "label": "Wait for Background Jobs (seconds)",
@@ -259,11 +259,11 @@
   {
    "fieldname": "display_filters_description",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\">These thresholds affect how Optimus <i>renders</i> the report — they don't change what's captured or analyzed.</p>"
+   "options": "<p class=\"text-muted small\">These thresholds affect how Optimus <i>renders</i> the report they don't change what's captured or analyzed.</p>"
   },
   {
    "default": "0",
-   "description": "Drop actions shorter than this many milliseconds from the per-action breakdown in reports. 0 = show everything. Useful for declutter when a flow generates many sub-millisecond background polls. Reference values — Strict: 1  ·  Recommended: 0  ·  Relaxed: 50.",
+   "description": "Drop actions shorter than this many milliseconds from the per-action breakdown in reports. 0 = show everything. Useful for declutter when a flow generates many sub-millisecond background polls. Reference values: Strict: 1  ·  Recommended: 0  ·  Relaxed: 50.",
    "fieldname": "min_action_duration_ms",
    "fieldtype": "Float",
    "label": "Min Action Duration to Show (ms)",
@@ -276,7 +276,7 @@
   },
   {
    "default": "1000",
-   "description": "Render any duration above this threshold (in milliseconds) as seconds — e.g. with the default of 1000, 5234ms displays as 5.23s but 800ms stays as 800ms. Set to a very large value (e.g. 99999999) to effectively disable. Reference values — Strict: 500  ·  Recommended: 1000  ·  Relaxed: 99999999.",
+   "description": "Render any duration above this threshold (in milliseconds) as seconds e.g. with the default of 1000, 5234ms displays as 5.23s but 800ms stays as 800ms. Set to a very large value (e.g. 99999999) to effectively disable. Reference values: Strict: 500  ·  Recommended: 1000  ·  Relaxed: 99999999.",
    "fieldname": "large_duration_threshold_ms",
    "fieldtype": "Float",
    "label": "Render durations in seconds above (ms)",
@@ -296,7 +296,7 @@
   {
    "fieldname": "sensitivity_description",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\">Pick a preset to set every tunable threshold across Optimus in one move — analyzer thresholds (the original nine), capture knobs (max queries / sampler interval / background-job wait), retention, display filters, Phase-2 defaults, and the AI auto-suggest cap. <b>Strict</b> catches more (more findings, more noise) and keeps data longer; <b>Relaxed</b> catches less and prunes faster; <b>Recommended</b> is the shipped default and automatically tracks future tuning. Choose <b>Custom</b> to edit the individual fields yourself — they stay locked under the named presets.</p>"
+   "options": "<p class=\"text-muted small\">Pick a preset to set every tunable threshold across Optimus in one move analyzer thresholds (the original nine), capture knobs (max queries / sampler interval / background-job wait), retention, display filters, Phase-2 defaults, and the AI auto-suggest cap. <b>Strict</b> catches more (more findings, more noise) and keeps data longer; <b>Relaxed</b> catches less and prunes faster; <b>Recommended</b> is the shipped default and automatically tracks future tuning. Choose <b>Custom</b> to edit the individual fields yourself they stay locked under the named presets.</p>"
   },
   {
    "default": "Recommended",
@@ -318,7 +318,7 @@
   },
   {
    "default": "5",
-   "description": "Minimum get_doc calls for the same (doctype, name) from the same callsite before a Redundant Call finding is emitted. Reference values — Strict: 3  ·  Recommended: 5  ·  Relaxed: 10.",
+   "description": "Minimum get_doc calls for the same (doctype, name) from the same callsite before a Redundant Call finding is emitted. Reference values: Strict: 3  ·  Recommended: 5  ·  Relaxed: 10.",
    "fieldname": "redundant_doc_threshold",
    "fieldtype": "Int",
    "label": "Redundant get_doc Threshold",
@@ -327,7 +327,7 @@
   },
   {
    "default": "50",
-   "description": "Minimum cache lookups for the same key from the same callsite before a Redundant Call finding is emitted. Cache lookups aren't individually timed, so low-count loops are indistinguishable from framework background noise — 50 matches the high-severity threshold and cuts 0ms noise. Reference values — Strict: 20  ·  Recommended: 50  ·  Relaxed: 100.",
+   "description": "Minimum cache lookups for the same key from the same callsite before a Redundant Call finding is emitted. Cache lookups aren't individually timed, so low-count loops are indistinguishable from framework background noise 50 matches the high-severity threshold and cuts 0ms noise. Reference values: Strict: 20  ·  Recommended: 50  ·  Relaxed: 100.",
    "fieldname": "redundant_cache_threshold",
    "fieldtype": "Int",
    "label": "Redundant Cache Lookup Threshold",
@@ -340,7 +340,7 @@
   },
   {
    "default": "10",
-   "description": "Minimum has_permission calls for the same (doctype, name, ptype) from the same callsite before a Redundant Call finding is emitted. Reference values — Strict: 5  ·  Recommended: 10  ·  Relaxed: 25.",
+   "description": "Minimum has_permission calls for the same (doctype, name, ptype) from the same callsite before a Redundant Call finding is emitted. Reference values: Strict: 5  ·  Recommended: 10  ·  Relaxed: 25.",
    "fieldname": "redundant_perm_threshold",
    "fieldtype": "Int",
    "label": "Redundant Permission Check Threshold",
@@ -349,7 +349,7 @@
   },
   {
    "default": "10",
-   "description": "Minimum identical queries from the same callsite before an N+1 Query finding is emitted. Reference values — Strict: 5  ·  Recommended: 10  ·  Relaxed: 25.",
+   "description": "Minimum identical queries from the same callsite before an N+1 Query finding is emitted. Reference values: Strict: 5  ·  Recommended: 10  ·  Relaxed: 25.",
    "fieldname": "n_plus_one_min_occurrences",
    "fieldtype": "Int",
    "label": "N+1 Minimum Occurrences",
@@ -368,7 +368,7 @@
   },
   {
    "default": "200",
-   "description": "Single SQL query duration above this is flagged as a Slow Query finding. Default 200ms — anything below is usually within acceptable per-query budget. Reference values — Strict: 100  ·  Recommended: 200  ·  Relaxed: 500.",
+   "description": "Single SQL query duration above this is flagged as a Slow Query finding. Default 200ms anything below is usually within acceptable per-query budget. Reference values: Strict: 100  ·  Recommended: 200  ·  Relaxed: 500.",
    "fieldname": "slow_query_threshold_ms",
    "fieldtype": "Float",
    "label": "Slow Query Threshold (ms)",
@@ -377,7 +377,7 @@
   },
   {
    "default": "25",
-   "description": "Slow Hot Path threshold as a percentage of the action's wall time. A subtree consuming >= this % AND >= the min-ms below qualifies. Default 25% with 200ms minimum. Reference values — Strict: 15  ·  Recommended: 25  ·  Relaxed: 40.",
+   "description": "Slow Hot Path threshold as a percentage of the action's wall time. A subtree consuming >= this % AND >= the min-ms below qualifies. Default 25% with 200ms minimum. Reference values: Strict: 15  ·  Recommended: 25  ·  Relaxed: 40.",
    "fieldname": "slow_hot_path_pct_threshold",
    "fieldtype": "Float",
    "label": "Slow Hot Path Threshold (% of action wall time)",
@@ -386,7 +386,7 @@
   },
   {
    "default": "200",
-   "description": "Slow Hot Path minimum absolute time. A subtree needs both >= the % above AND >= this many ms to qualify. Reference values — Strict: 100  ·  Recommended: 200  ·  Relaxed: 500.",
+   "description": "Slow Hot Path minimum absolute time. A subtree needs both >= the % above AND >= this many ms to qualify. Reference values: Strict: 100  ·  Recommended: 200  ·  Relaxed: 500.",
    "fieldname": "slow_hot_path_min_ms",
    "fieldtype": "Float",
    "label": "Slow Hot Path Minimum (ms)",
@@ -399,7 +399,7 @@
   },
   {
    "default": "50",
-   "description": "Phase 2 Hot Line: a single line consuming this %% of the function's total time AND >= the min-ms below is flagged High severity. Default 50% / 100ms. Reference values — Strict: 35  ·  Recommended: 50  ·  Relaxed: 70.",
+   "description": "Phase 2 Hot Line: a single line consuming this %% of the function's total time AND >= the min-ms below is flagged High severity. Default 50% / 100ms. Reference values: Strict: 35  ·  Recommended: 50  ·  Relaxed: 70.",
    "fieldname": "hot_line_high_pct",
    "fieldtype": "Float",
    "label": "Hot Line High Severity (% of function time)",
@@ -408,7 +408,7 @@
   },
   {
    "default": "100",
-   "description": "Phase 2 Hot Line minimum absolute time for High severity. Reference values — Strict: 50  ·  Recommended: 100  ·  Relaxed: 250.",
+   "description": "Phase 2 Hot Line minimum absolute time for High severity. Reference values: Strict: 50  ·  Recommended: 100  ·  Relaxed: 250.",
    "fieldname": "hot_line_high_min_ms",
    "fieldtype": "Float",
    "label": "Hot Line High Severity Min (ms)",
@@ -427,7 +427,7 @@
   },
   {
    "default": "10",
-   "description": "Cap on how many phase-2 runs can be retained per Optimus Session. When exceeded, the oldest run's full results are archived to a private File and only the row metadata is kept in the DocType. Set to 0 for no cap (every run keeps full results — watch DocType size on heavy users). Reference values — Strict: 0  ·  Recommended: 10  ·  Relaxed: 5.",
+   "description": "Cap on how many phase-2 runs can be retained per Optimus Session. When exceeded, the oldest run's full results are archived to a private File and only the row metadata is kept in the DocType. Set to 0 for no cap (every run keeps full results watch DocType size on heavy users). Reference values: Strict: 0  ·  Recommended: 10  ·  Relaxed: 5.",
    "fieldname": "phase2_max_runs_per_session",
    "fieldtype": "Int",
    "label": "Phase 2: Max Runs per Session",
@@ -447,7 +447,7 @@
   },
   {
    "default": "10",
-   "description": "Maximum levels deep that auto-expand will follow into the call tree from a curated pick. Set to 0 for unlimited depth (walks to the leaf — pairs naturally with auto-expand min-ms 0 for the deepest possible instrumentation). Reference values — Strict: 0  ·  Recommended: 10  ·  Relaxed: 5.",
+   "description": "Maximum levels deep that auto-expand will follow into the call tree from a curated pick. Set to 0 for unlimited depth (walks to the leaf pairs naturally with auto-expand min-ms 0 for the deepest possible instrumentation). Reference values: Strict: 0  ·  Recommended: 10  ·  Relaxed: 5.",
    "fieldname": "auto_expand_max_depth",
    "fieldtype": "Int",
    "label": "Auto-Expand: Max Depth",
@@ -456,7 +456,7 @@
   },
   {
    "default": "50",
-   "description": "Auto-expand stops descending when the next-hottest child consumes less than this many milliseconds. Lower = follow deeper into smaller hot spots; higher = stop earlier and instrument fewer functions. Set to 0 to follow into every measurable child (no minimum). Reference values — Strict: 10  ·  Recommended: 50  ·  Relaxed: 100.",
+   "description": "Auto-expand stops descending when the next-hottest child consumes less than this many milliseconds. Lower = follow deeper into smaller hot spots; higher = stop earlier and instrument fewer functions. Set to 0 to follow into every measurable child (no minimum). Reference values: Strict: 10  ·  Recommended: 50  ·  Relaxed: 100.",
    "fieldname": "auto_expand_min_ms",
    "fieldtype": "Float",
    "label": "Auto-Expand: Minimum Child Time (ms)",
@@ -476,7 +476,7 @@
   {
    "fieldname": "ai_description",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\">When enabled, a <b>Suggest a fix (AI)</b> button appears on the Optimus Session form. Clicking it sends the selected finding's context — finding type, callsite, a window of surrounding <b>source code</b>, the normalized SQL and EXPLAIN row — to the configured LLM and stores the returned fix on the finding (it also shows up in the regenerated HTML report). <b>This sends code and queries to your chosen provider.</b> Point <code>Base URL</code> at a local model (Ollama / LM Studio / vLLM) to keep everything on-box. <a href=\"https://github.com/Aerele-RnD/optimus/blob/main/docs/AI-FIXING.md\" target=\"_blank\">Read the full data-flow documentation</a> — what's sent, what isn't, and step-by-step local-LLM recipes.</p>"
+   "options": "<p class=\"text-muted small\">When enabled, a <b>Suggest a fix (AI)</b> button appears on the Optimus Session form. Clicking it sends the selected finding's context finding type, callsite, a window of surrounding <b>source code</b>, the normalized SQL and EXPLAIN row to the configured LLM and stores the returned fix on the finding (it also shows up in the regenerated HTML report). <b>This sends code and queries to your chosen provider.</b> Point <code>Base URL</code> at a local model (Ollama / LM Studio / vLLM) to keep everything on-box. <a href=\"https://github.com/Aerele-RnD/optimus/blob/main/docs/AI-FIXING.md\" target=\"_blank\">Read the full data-flow documentation</a> what's sent, what isn't, and step-by-step local-LLM recipes.</p>"
   },
   {
    "default": "0",
@@ -488,7 +488,7 @@
   {
    "default": "Anthropic",
    "depends_on": "eval:doc.ai_enabled",
-   "description": "Wire format / hosted defaults. \"OpenAI-compatible\" requires a Base URL and Model — use it for Ollama, LM Studio, vLLM, OpenRouter, Together, Groq, etc.",
+   "description": "Wire format / hosted defaults. \"OpenAI-compatible\" requires a Base URL and Model use it for Ollama, LM Studio, vLLM, OpenRouter, Together, Groq, etc.",
    "fieldname": "ai_provider",
    "fieldtype": "Select",
    "label": "Provider",
@@ -496,7 +496,7 @@
   },
   {
    "depends_on": "eval:doc.ai_enabled && doc.ai_provider == 'OpenAI-compatible'",
-   "description": "The OpenAI-compatible endpoint base (include /v1) — e.g. http://localhost:11434/v1 (Ollama), http://localhost:1234/v1 (LM Studio), https://openrouter.ai/api/v1. Hosted providers (Anthropic, OpenAI, Kimi) use their built-in default, so this is hidden for them.",
+   "description": "The OpenAI-compatible endpoint base (include /v1) e.g. http://localhost:11434/v1 (Ollama), http://localhost:1234/v1 (LM Studio), https://openrouter.ai/api/v1. Hosted providers (Anthropic, OpenAI, Kimi) use their built-in default, so this is hidden for them.",
    "fieldname": "ai_base_url",
    "fieldtype": "Data",
    "label": "Base URL"
@@ -521,7 +521,7 @@
   },
   {
    "depends_on": "eval:doc.ai_enabled",
-   "description": "Pick which sections of the report may use the LLM. Turning one off is a hard disable — that section is never auto-generated, its buttons on the Optimus Session form are hidden, the API refuses, and re-rendered reports omit it.",
+   "description": "Pick which sections of the report may use the LLM. Turning one off is a hard disable that section is never auto-generated, its buttons on the Optimus Session form are hidden, the API refuses, and re-rendered reports omit it.",
    "fieldname": "ai_sections_break",
    "fieldtype": "Section Break",
    "label": "Use the LLM for"
@@ -529,7 +529,7 @@
   {
    "default": "1",
    "depends_on": "eval:doc.ai_enabled",
-   "description": "When off: no AI-suggested fix on findings — not auto-generated during analyze, the \"Suggest a fix (AI)\" / \"Generate AI fixes\" / \"Re-evaluate AI fixes\" buttons are hidden, the API refuses, and re-rendered reports omit the AI-fix block.",
+   "description": "When off: no AI-suggested fix on findings not auto-generated during analyze, the \"Suggest a fix (AI)\" / \"Generate AI fixes\" / \"Re-evaluate AI fixes\" buttons are hidden, the API refuses, and re-rendered reports omit the AI-fix block.",
    "fieldname": "ai_suggest_findings",
    "fieldtype": "Check",
    "label": "Fix suggestions on findings"
@@ -537,7 +537,7 @@
   {
    "default": "1",
    "depends_on": "eval:doc.ai_enabled",
-   "description": "When off: no \"Index advice (AI)\" block in the \"Time spent per database table\" section — not auto-generated, the \"Suggest an index (AI)\" button is hidden, the API refuses, and re-rendered reports omit it.",
+   "description": "When off: no \"Index advice (AI)\" block in the \"Time spent per database table\" section not auto-generated, the \"Suggest an index (AI)\" button is hidden, the API refuses, and re-rendered reports omit it.",
    "fieldname": "ai_suggest_indexes",
    "fieldtype": "Check",
    "label": "Index recommendations (DB-tables breakdown)"
@@ -564,7 +564,7 @@
   {
    "default": "0",
    "depends_on": "eval:doc.ai_enabled",
-   "description": "When checked, the analyze pipeline asks the LLM for a fix for each eligible finding automatically, so suggestions are already in the report — no need to click \"Suggest a fix (AI)\" per finding. Costs LLM tokens (and a little extra analyze time) on every session that's analyzed; keep it off unless you want suggestions baked in by default.",
+   "description": "When checked, the analyze pipeline asks the LLM for a fix for each eligible finding automatically, so suggestions are already in the report no need to click \"Suggest a fix (AI)\" per finding. Costs LLM tokens (and a little extra analyze time) on every session that's analyzed; keep it off unless you want suggestions baked in by default.",
    "fieldname": "ai_auto_suggest",
    "fieldtype": "Check",
    "label": "Suggest AI fixes in the report by default"
@@ -577,7 +577,7 @@
   {
    "default": "5",
    "depends_on": "eval:doc.ai_enabled && doc.ai_auto_suggest",
-   "description": "Cap on how many findings get an automatic suggestion per session — the highest-severity, highest-impact ones first. 0 = every eligible finding (can be slow + costly on big sessions). Reference values — Strict: 0  ·  Recommended: 5  ·  Relaxed: 3.",
+   "description": "Cap on how many findings get an automatic suggestion per session the highest-severity, highest-impact ones first. 0 = every eligible finding (can be slow + costly on big sessions). Reference values: Strict: 0  ·  Recommended: 5  ·  Relaxed: 3.",
    "fieldname": "ai_auto_suggest_max",
    "read_only_depends_on": "eval:doc.config_profile != \"Custom\"",
    "fieldtype": "Int",
@@ -594,11 +594,11 @@
    "depends_on": "eval:doc.ai_enabled",
    "fieldname": "ai_privacy_description",
    "fieldtype": "HTML",
-   "options": "<p class=\"text-muted small\">Per-type opt-out and the local-LLM timeout. The exclusion list is the only way (short of disabling AI entirely) to keep a specific finding category from ever being built into a payload — useful when a particular type embeds business logic you don't want shared with a hosted provider. The timeout knob exists for local LLMs: hosted providers usually answer in seconds, but a cold-start ollama / vLLM run can take well over a minute on first call.</p>"
+   "options": "<p class=\"text-muted small\">Per-type opt-out and the local-LLM timeout. The exclusion list is the only way (short of disabling AI entirely) to keep a specific finding category from ever being built into a payload useful when a particular type embeds business logic you don't want shared with a hosted provider. The timeout knob exists for local LLMs: hosted providers usually answer in seconds, but a cold-start ollama / vLLM run can take well over a minute on first call.</p>"
   },
   {
    "depends_on": "eval:doc.ai_enabled",
-   "description": "One finding type per line — those types are skipped in both auto-suggest and on-demand (the payload is never built). Exact-match, case-sensitive. Lines starting with '#' are comments. Use the canonical names: Filesort, Framework N+1, Full Table Scan, Hot Line, Low Filter Ratio, Missing Index, N+1 Query, Redundant Call, Slow Query, Temporary Table.",
+   "description": "One finding type per line those types are skipped in both auto-suggest and on-demand (the payload is never built). Exact-match, case-sensitive. Lines starting with '#' are comments. Use the canonical names: Filesort, Framework N+1, Full Table Scan, Hot Line, Low Filter Ratio, Missing Index, N+1 Query, Redundant Call, Slow Query, Temporary Table.",
    "fieldname": "ai_excluded_finding_types",
    "fieldtype": "Small Text",
    "label": "Excluded finding types"

--- a/optimus/optimus/doctype/optimus_settings/optimus_settings.py
+++ b/optimus/optimus/doctype/optimus_settings/optimus_settings.py
@@ -9,7 +9,7 @@ class OptimusSettings(Document):
 	"""Site-wide configuration for Optimus.
 
 	A Single DocType. The cached reader in ``optimus.settings``
-	is what analyzers and hooks actually call — this controller only
+	is what analyzers and hooks actually call this controller only
 	handles validation + cache invalidation when an admin saves.
 	"""
 
@@ -27,7 +27,7 @@ class OptimusSettings(Document):
 
 		frappe.cache.delete_value(redis_keys.settings_cache())
 
-	# Numeric floors per field — a value below the floor would either
+	# Numeric floors per field a value below the floor would either
 	# break the analyzer at runtime (negative interval, zero retention)
 	# or render a useless report (sub-microsecond thresholds). Floors
 	# of 0 mean "0 is OK as a 'no filter' / 'always flag' sentinel".
@@ -68,7 +68,7 @@ class OptimusSettings(Document):
 		"""Floor each numeric setting at a safe minimum so a typo
 		(e.g. ``-1`` for a sampler interval, ``0`` for session
 		retention) doesn't break the analyzer at runtime. Silently
-		clamps — the operator sees the corrected value on the form
+		clamps the operator sees the corrected value on the form
 		after save."""
 		for fieldname, floor in self._NUMERIC_FLOORS.items():
 			current = self.get(fieldname)
@@ -82,7 +82,7 @@ class OptimusSettings(Document):
 					# behaviour for non-child-table scalar fields.
 					setattr(self, fieldname, floor)
 			except (TypeError, ValueError):
-				# Non-numeric input — let Frappe's field-type validation
+				# Non-numeric input let Frappe's field-type validation
 				# handle it; nothing useful for us to do here.
 				continue
 
@@ -112,13 +112,13 @@ class OptimusSettings(Document):
 		Apps.
 
 		Most users misread "Tracked Apps" as "apps to monitor" and
-		add frappe + erpnext — which has the OPPOSITE effect of what
+		add frappe + erpnext which has the OPPOSITE effect of what
 		they want: it flips the classifier into inclusion mode where
 		framework code becomes "user code", and their actionable
 		findings list gets flooded with framework noise.
 
 		We don't HARD-block the save (ERPNext contributors may
-		legitimately want framework findings as actionable) — just
+		legitimately want framework findings as actionable) just
 		flash a clear warning so the common misconfiguration surfaces
 		itself.
 		"""
@@ -137,7 +137,7 @@ class OptimusSettings(Document):
 		msg = (
 			"<b>Heads up:</b> you added "
 			+ ", ".join(f"<code>{a}</code>" for a in offenders)
-			+ " to Tracked Apps. These are framework/first-party apps — "
+			+ " to Tracked Apps. These are framework/first-party apps "
 			"adding them here flips the filter into <i>inclusion mode</i>, "
 			"so their findings will now show up as <b>actionable</b> "
 			"instead of in the collapsed Framework observations section. "
@@ -149,14 +149,14 @@ class OptimusSettings(Document):
 		)
 		frappe.msgprint(
 			msg,
-			title="Tracked Apps — possible misconfiguration",
+			title="Tracked Apps possible misconfiguration",
 			indicator="orange",
 		)
 
 	def _warn_on_incomplete_ai_config(self):
 		"""Non-blocking warning when AI fix suggestions are enabled but
 		the config is incomplete (no model, or no API key for a provider
-		that needs one). The feature stays enabled — the operator just
+		that needs one). The feature stays enabled the operator just
 		sees a clear hint instead of a cryptic error on first use."""
 		if not self.get("ai_enabled"):
 			return
@@ -179,8 +179,8 @@ class OptimusSettings(Document):
 		frappe.msgprint(
 			"AI Fix Suggestions are enabled but " + ", ".join(missing)
 			+ (" is" if len(missing) == 1 else " are")
-			+ " not set — the <b>Suggest a fix (AI)</b> button will report a "
+			+ " not set the <b>Suggest a fix (AI)</b> button will report a "
 			"configuration error until you fill these in.",
-			title="AI Fix Suggestions — incomplete config",
+			title="AI Fix Suggestions incomplete config",
 			indicator="orange",
 		)

--- a/optimus/patches/v0_2_0/remove_version_tracking.py
+++ b/optimus/patches/v0_2_0/remove_version_tracking.py
@@ -12,7 +12,7 @@ Round 2 fix sets track_changes=0 in the DocType JSON. This patch runs
 on bench migrate to delete existing tabVersion rows for Profiler
 Session so the cleanup is complete.
 
-Safe to run multiple times (the DELETE is idempotent — any new rows
+Safe to run multiple times (the DELETE is idempotent any new rows
 created between migrations are also cleaned up).
 """
 

--- a/optimus/patches/v0_5_0/upgrade_notes_to_text_editor.py
+++ b/optimus/patches/v0_5_0/upgrade_notes_to_text_editor.py
@@ -5,7 +5,7 @@
 
 The existing `notes` field was plain Text. v0.5.0 upgrades it to
 Text Editor so users can include rich formatting (lists, links,
-code blocks) in their "Steps to Reproduce" context — rendered at
+code blocks) in their "Steps to Reproduce" context rendered at
 the top of the report above findings.
 
 Fresh installs pick this up from the updated doctype JSON automatically.
@@ -13,7 +13,7 @@ This patch reloads the doctype definition so existing installs see the
 new fieldtype and label without needing a manual bench migrate --rebuild.
 
 Existing note values carry over unchanged: plain-text content is valid
-Text Editor input, so no data migration is needed — the DB column
+Text Editor input, so no data migration is needed the DB column
 stays, only the metadata changes.
 """
 

--- a/optimus/patches/v0_5_2/bump_cache_threshold_default.py
+++ b/optimus/patches/v0_5_2/bump_cache_threshold_default.py
@@ -14,7 +14,7 @@ This patch runs on migrate. It's conservative:
 
 1. Only runs if the Optimus Settings Single exists (fresh installs
    pick up the new default from JSON; nothing to patch).
-2. Only bumps the value from **exactly 10** — the prior default.
+2. Only bumps the value from **exactly 10**: the prior default.
    Any other value (user-tuned 5, 20, 100, etc.) is left alone so we
    never silently overwrite a deliberate configuration choice.
 3. Invalidates the settings cache so the next request sees the new
@@ -37,7 +37,7 @@ def execute():
 	except Exception:
 		return
 
-	# Only flip the exact old default — respect any deliberate tuning.
+	# Only flip the exact old default respect any deliberate tuning.
 	try:
 		current_int = int(current) if current is not None else None
 	except (TypeError, ValueError):

--- a/optimus/patches/v0_6_0/add_ai_fix_fields.py
+++ b/optimus/patches/v0_6_0/add_ai_fix_fields.py
@@ -11,7 +11,7 @@ Additive only:
 ``bench migrate`` already auto-adds the columns from the updated .json files;
 this patch just reloads the two DocTypes so that happens deterministically
 during the patch run (matching the pattern of the other ``add_*_fields``
-patches in this app). Idempotent — safe to re-run.
+patches in this app). Idempotent safe to re-run.
 """
 
 import frappe

--- a/optimus/patches/v0_6_0/drop_comparison_fields.py
+++ b/optimus/patches/v0_6_0/drop_comparison_fields.py
@@ -32,7 +32,7 @@ def execute():
 	# Best-effort: clear baseline-pinning cache keys. These were stored as
 	# `profiler:baseline:<label>` -> docname. Redis SCAN-style deletion
 	# isn't available through frappe.cache's portable API, so we just drop
-	# the keys we can derive from existing session titles — anything else
+	# the keys we can derive from existing session titles anything else
 	# expires on its own (cache, not durable state).
 	try:
 		titles = frappe.get_all("Optimus Session", pluck="title") or []

--- a/optimus/patches/v0_6_0/drop_safe_report_fields.py
+++ b/optimus/patches/v0_6_0/drop_safe_report_fields.py
@@ -60,7 +60,7 @@ def execute():
 						"File", name, force=True, ignore_permissions=True,
 					)
 				except Exception:
-					# Individual file deletion failures are non-fatal —
+					# Individual file deletion failures are non-fatal
 					# log and move on so a single broken row doesn't
 					# block the rest of the migration.
 					frappe.log_error(

--- a/optimus/patches/v0_6_0/rename_phase_two_doctype.py
+++ b/optimus/patches/v0_6_0/rename_phase_two_doctype.py
@@ -15,11 +15,11 @@ Two Run`` as part of the broader DocType rename.
 Idempotent + defensive:
 
 1. No-op when the old DocType is already gone (fresh installs already
-   ship with the new name in JSON — Frappe creates the new DocType
+   ship with the new name in JSON Frappe creates the new DocType
    directly).
 2. No-op when the new name already exists alongside the old (someone
    ran a partial migration). In that case the renamed table would
-   conflict — bail out and let the operator resolve it manually.
+   conflict bail out and let the operator resolve it manually.
 3. Uses ``frappe.rename_doc("DocType", old, new)`` which handles:
      - renaming the row in ``tabDocType``,
      - renaming the underlying SQL table (``tabProfiler Phase 2 Run``
@@ -30,7 +30,7 @@ Idempotent + defensive:
 4. Clears the settings cache as a safety net for any stale references.
 
 Trade-off acknowledged in ``AUDIT_BASELINE.md``: the in-code field name
-on the parent (``phase_2_runs``) stays snake_case — the audit's
+on the parent (``phase_2_runs``) stays snake_case the audit's
 Title-Case rule applies only to DocType names, not field names.
 """
 
@@ -55,7 +55,7 @@ def execute():
 		return
 	if new_exists:
 		frappe.logger().warning(
-			"optimus: skipping Phase-Two DocType rename — both "
+			"optimus: skipping Phase-Two DocType rename both "
 			f"{OLD_NAME!r} AND {NEW_NAME!r} exist. Resolve manually before "
 			"re-running migrate (e.g. `bench --site <s> delete-doc DocType "
 			f"'{NEW_NAME}'` if the empty one is the duplicate)."
@@ -75,7 +75,7 @@ def execute():
 	except Exception:
 		pass
 
-	# Drop our own settings cache too — paranoid but cheap. Both the legacy
+	# Drop our own settings cache too paranoid but cheap. Both the legacy
 	# (``profiler_settings_cached``) and the v0.7.0-renamed
 	# (``optimus_settings_cached``) keys are cleared since either could
 	# be lingering depending on which version the site is upgrading from.

--- a/optimus/patches/v0_6_0/set_hide_framework_tables_default.py
+++ b/optimus/patches/v0_6_0/set_hide_framework_tables_default.py
@@ -7,7 +7,7 @@ Settings rows that have the field stored as 0 / None.
 Background: the field shipped without a JSON ``default: "1"``, so the
 Single's persisted value initialized to 0 for every install. The
 ``_DEFAULTS`` dict + dataclass default of True only kicked in when the
-DocType row was missing entirely — once the field exists in storage,
+DocType row was missing entirely once the field exists in storage,
 the persisted 0 wins. Users who never explicitly touched the checkbox
 were left with the filter off, even though the docs and the
 description text both say the feature is "default on". A user
@@ -17,10 +17,10 @@ and every framework / internal table was visible.
 This patch is a one-time correction:
 
 1. Only runs if the Optimus Settings Single exists (fresh installs
-   pick up the new JSON default via ``"default": "1"`` — no patch
+   pick up the new JSON default via ``"default": "1"``: no patch
    needed).
 2. Only flips values that are currently 0 / None / empty / unset to 1.
-   Any non-falsy stored value is left alone — if a deployment had
+   Any non-falsy stored value is left alone if a deployment had
    somehow set it to 1 already, the patch is a no-op.
 3. Trade-off: if an admin DELIBERATELY unchecked the box and saved
    (stored 0), the patch flips that 0 → 1. We can't distinguish

--- a/optimus/patches/v0_9_0/add_ai_privacy_fields.py
+++ b/optimus/patches/v0_9_0/add_ai_privacy_fields.py
@@ -10,7 +10,7 @@ Additive only:
 ``bench migrate`` already auto-adds the new fields from the updated
 ``optimus_settings.json``; this patch reloads the DocType deterministically
 during the patch run (matching the pattern of the other ``add_*_fields``
-patches in this app). Idempotent — safe to re-run.
+patches in this app). Idempotent safe to re-run.
 
 Closes Critical Risk #2 of the v0.7.x architecture review (no per-type
 opt-out, no configurable timeout for local LLMs). See docs/AI-FIXING.md

--- a/optimus/pdf_export.py
+++ b/optimus/pdf_export.py
@@ -5,7 +5,7 @@
 
 Generated on first request via frappe.utils.pdf.get_pdf (wkhtmltopdf),
 cached to a private File attachment on the Optimus Session. Subsequent
-requests serve from cache. Analyze pipeline is never touched — keeping
+requests serve from cache. Analyze pipeline is never touched keeping
 PDF generation outside the analyze budget.
 """
 
@@ -16,7 +16,7 @@ import frappe
 from optimus import safe_commit
 
 # v0.5.2 round 4: wkhtmltopdf uses old QtWebKit which doesn't reliably
-# render collapsed <details> content even under @media print — the
+# render collapsed <details> content even under @media print the
 # Observations subsection and Analyzer notes section end up invisible
 # in the PDF. We pre-process the HTML to force `open` on every
 # <details> before handing it to wkhtmltopdf, so PDF reports contain
@@ -67,7 +67,7 @@ def clear_cached_pdf(session_uuid: str) -> None:
 	try:
 		# v0.6.x: was get_doc(...).name; switched to a single get_value to
 		# skip loading the full File doc (and its child tables) just to read
-		# one scalar — addresses Lens audit "get_doc used only for reading
+		# one scalar addresses Lens audit "get_doc used only for reading
 		# fields" at this site.
 		file_name = frappe.db.get_value("File", {"file_url": current_url}, "name")
 		if file_name:
@@ -90,7 +90,7 @@ def _load_session(session_uuid: str):
 def _load_raw_html(doc) -> str:
 	if not doc.raw_report_file:
 		frappe.throw("This session has no report to convert.")
-	# audit: ok (get_doc kept — .get_content() is a doc-instance method
+	# audit: ok (get_doc kept .get_content() is a doc-instance method
 	# that streams the attached bytes; db.get_value can only return field
 	# values, not file content. Lens flagged this as "get_doc used only
 	# for reading fields" but it isn't reading a field, it's reading the
@@ -103,7 +103,7 @@ def _expand_collapsible_sections(html: str) -> str:
 	"""Add the ``open`` attribute to every <details> element so the
 	PDF renderer shows their content.
 
-	Idempotent — <details open> and <details ... open> are left alone.
+	Idempotent <details open> and <details ... open> are left alone.
 	Exposed as module-level for unit-testing.
 	"""
 	def _inject_open(match: re.Match) -> str:
@@ -121,12 +121,12 @@ def _expand_collapsible_sections(html: str) -> str:
 def _html_to_pdf(html: str) -> bytes:
 	"""Run HTML through wkhtmltopdf via frappe.utils.pdf.get_pdf.
 
-	Options tuned for the report's CSS — A4, conservative margins,
+	Options tuned for the report's CSS A4, conservative margins,
 	UTF-8, print-media-type so any @media print rules in the report are
 	honored (e.g. the SVG donut fallback).
 
 	Pre-processes the HTML to force-open all <details> blocks so the
-	Observations subsection and Analyzer notes render in the PDF —
+	Observations subsection and Analyzer notes render in the PDF
 	wkhtmltopdf's QtWebKit doesn't reliably expand collapsed <details>
 	via @media print alone.
 	"""

--- a/optimus/permissions.py
+++ b/optimus/permissions.py
@@ -6,7 +6,7 @@
 Currently exposes one gate: a `has_permission` for the File DocType that
 double-checks downloads of the profiler report. The UI hides the
 "Download Report" button from non-admin/non-owner users, but a malicious
-user who guessed the file URL could try to fetch it directly — this
+user who guessed the file URL could try to fetch it directly this
 gate makes that fail.
 
 v0.6.0 Round 7: safe-mode reports were removed. The single remaining
@@ -25,7 +25,7 @@ def file_has_permission(doc, ptype=None, user=None):
 
 	Allows access to:
 	  - Anyone who passes the underlying parent permission check (handled
-	    by Frappe's built-in private file logic — Optimus User with
+	    by Frappe's built-in private file logic Optimus User with
 	    if_owner=1, System Manager always)
 	  - Plus an additional check for the report files specifically: only
 	    System Manager OR the recording user, even if some other role

--- a/optimus/public/css/floating_widget.css
+++ b/optimus/public/css/floating_widget.css
@@ -1,4 +1,4 @@
-/* Optimus — Floating start/stop widget
+/* Optimus Floating start/stop widget
  *
  * Injected into Desk via app_include_css in hooks.py.
  * Lives in the bottom-right corner of every Desk page.

--- a/optimus/public/js/floating_widget.js
+++ b/optimus/public/js/floating_widget.js
@@ -1,4 +1,4 @@
-// Optimus — Floating start/stop widget
+// Optimus Floating start/stop widget
 //
 // Injected into every Desk page via app_include_js in hooks.py.
 // Renders a small floating button bottom-right that lets a user with the
@@ -103,14 +103,14 @@
 		// (before_request / before_job short-circuit), so showing it
 		// misleads the user into thinking they can still record.
 		// `frappe.boot.optimus_enabled` is populated by boot_session
-		// and defaults to True on error — matching the settings
+		// and defaults to True on error matching the settings
 		// module's fail-open posture.
 		const bootEnabled = (
 			frappe.boot && frappe.boot.optimus_enabled
 		);
 		if (bootEnabled === false) {
 			_diag(
-				"[optimus] profiler is disabled in settings — "
+				"[optimus] profiler is disabled in settings "
 				+ "widget will not mount"
 			);
 			return;
@@ -120,7 +120,7 @@
 		// server-side `_require_profiler_user()` check in api.py is the
 		// real permission gate; this client-side check is just a hint
 		// and was causing race-condition bugs because `frappe.user_roles`
-		// may not be populated when this script runs (see desk.js:329 —
+		// may not be populated when this script runs (see desk.js:329
 		// set_globals runs after Desk class construction). We err on the
 		// side of always mounting; users without the role will see a
 		// permission error if they actually click Start.
@@ -202,7 +202,7 @@
 	}
 
 	function subscribeVisibility() {
-		// v0.5.1: no more polling — but we still want to refresh state
+		// v0.5.1: no more polling but we still want to refresh state
 		// ONCE when the tab becomes visible again, to catch TTL-based
 		// auto-stop that happens silently (Redis active-pointer expired
 		// while the tab was hidden) and any realtime events the Socket
@@ -231,7 +231,7 @@
 		// Expose the build ID so a hovering user / dev-tools inspector
 		// can confirm which JS is actually running without opening
 		// the console.
-		widget.title = "Optimus — build " + WIDGET_BUILD_ID;
+		widget.title = "Optimus build " + WIDGET_BUILD_ID;
 		widget.setAttribute("data-build-id", WIDGET_BUILD_ID);
 		widget.innerHTML = `
 			<span class="fp-dot"></span>
@@ -247,7 +247,7 @@
 			"position: fixed",
 			"right: 20px",
 			"bottom: 20px",
-			"z-index: 2147483647",  /* max int32 — above everything */
+			"z-index: 2147483647",  /* max int32 above everything */
 			"display: block !important",
 			"visibility: visible !important",
 			"opacity: 1 !important",
@@ -275,7 +275,7 @@
 
 	function refreshStatus() {
 		// If we're locally in a transient state (stopping/analyzing/ready),
-		// don't override it with status() — server may not have reflected
+		// don't override it with status() server may not have reflected
 		// our local action yet.
 		if (currentState.display === "stopping" || currentState.display === "analyzing") {
 			return;
@@ -286,7 +286,7 @@
 				// v0.5.0 pass-4 fix: re-check the display state inside
 				// the callback. The guard at the top of refreshStatus
 				// only prevents NEW polls from firing during transient
-				// states — it doesn't help an in-flight poll whose
+				// states it doesn't help an in-flight poll whose
 				// frappe.call was already dispatched before the user
 				// clicked Stop. Without this check, a late-arriving
 				// status response would overwrite the "stopping"
@@ -318,7 +318,7 @@
 					}
 				} else {
 					if (currentState.display === "recording") {
-						// We thought we were recording but server says no — auto-stop
+						// We thought we were recording but server says no auto-stop
 						// fired or someone called stop from elsewhere. Reset.
 						currentState.display = "inactive";
 						currentState.active = false;
@@ -341,7 +341,7 @@
 		} else if (currentState.display === "recording") {
 			// v0.6.0: phase-2 recording uses a different stop API and a
 			// different active-flag in Redis. Route the click accordingly
-			// — confirmAndStop calls api.stop which only knows about
+			// confirmAndStop calls api.stop which only knows about
 			// phase-1's flag and would no-op silently for phase 2.
 			if (currentState.phase2 && currentState.run_uuid) {
 				stopPhase2();
@@ -371,7 +371,7 @@
 			callback: () => {
 				frappe.show_alert({
 					message: __(
-						"Phase 2 stopped — analyzing now. Open the session " +
+						"Phase 2 stopped analyzing now. Open the session " +
 						"to see the line-level report when it's ready."
 					),
 					indicator: "blue",
@@ -387,7 +387,7 @@
 	/**
 	 * Derive a contextual default for the Session label field from
 	 * the current Frappe Desk route. Used by openStartDialog() so the
-	 * user can click Start without typing — the most common "what am
+	 * user can click Start without typing the most common "what am
 	 * I profiling" answer is already on screen.
 	 *
 	 * Route shapes handled (Frappe v16):
@@ -419,13 +419,13 @@
 				switch (head) {
 					case "Form":
 						return doctype && leaf
-							? `${doctype} — ${leaf}`
+							? `${doctype} ${leaf}`
 							: doctype || "Form";
 					case "List":
 						if (!doctype) return "List";
 						if (sub === "Kanban") {
 							return leaf
-								? `${doctype} kanban — ${leaf}`
+								? `${doctype} kanban ${leaf}`
 								: `${doctype} kanban`;
 						}
 						if (sub === "Report") return `${doctype} report`;
@@ -436,15 +436,15 @@
 					case "Tree":
 						return doctype ? `${doctype} tree` : "Tree";
 					case "query-report":
-						return doctype ? `Report — ${doctype}` : "Report";
+						return doctype ? `Report ${doctype}` : "Report";
 					case "dashboard-view":
-						return doctype ? `Dashboard — ${doctype}` : "Dashboard";
+						return doctype ? `Dashboard ${doctype}` : "Dashboard";
 					case "modules":
 					case "desk":
 					case "app":
 						return "Profiling session";
 					default:
-						if (head && doctype) return `${head} — ${doctype}`;
+						if (head && doctype) return `${head} ${doctype}`;
 						if (head) return String(head);
 						return "Profiling session";
 				}
@@ -484,7 +484,7 @@
 					length: 140,
 					default: getDefaultSessionLabel(),
 					description:
-						"Give this session a name you'll recognize later — e.g. 'Sales Invoice flow with 50 items'. (up to 140 characters)",
+						"Give this session a name you'll recognize later e.g. 'Sales Invoice flow with 50 items'. (up to 140 characters)",
 				},
 				{
 					fieldname: "warning_html",
@@ -492,7 +492,7 @@
 					options: `
 						<div style="background: #fffbeb; border: 1px solid #fbbf24; border-radius: 4px; padding: 10px 12px; margin-top: 10px; font-size: 0.85rem; color: #92400e;">
 							<strong>Note:</strong> Recording adds ~1.5–2× wall-clock overhead per request while it's running.
-							Only your traffic will be captured — other users on this site are not affected.
+							Only your traffic will be captured other users on this site are not affected.
 							The session auto-stops after 10 minutes.
 						</div>
 					`,
@@ -533,10 +533,10 @@
 							});
 						} else {
 							// Server returned 200 but no session_uuid in the
-							// response — unexpected. Surface something so
+							// response unexpected. Surface something so
 							// the user knows the click didn't land.
 							frappe.show_alert({
-								message: __("Profiler start returned no session — check Error Log"),
+								message: __("Profiler start returned no session check Error Log"),
 								indicator: "orange",
 							});
 						}
@@ -547,7 +547,7 @@
 						// this error branch, a failed start (permission
 						// denied, server exception, concurrent session,
 						// etc.) would leave the user staring at a
-						// silent inactive pill after the dialog closes —
+						// silent inactive pill after the dialog closes
 						// the exact 'widget not working as expected'
 						// failure mode they'd see if their account
 						// lacked the Optimus User role.
@@ -559,8 +559,8 @@
 						// already been hidden at this point so we can't
 						// keep the user on it for another try.
 						const msg = (r && r._server_messages)
-							? "Profiler start failed — see the Frappe error alert above"
-							: "Profiler start failed — check your role and try again";
+							? "Profiler start failed see the Frappe error alert above"
+							: "Profiler start failed check your role and try again";
 						frappe.show_alert({
 							message: __(msg),
 							indicator: "red",
@@ -573,13 +573,13 @@
 	}
 
 	function confirmAndStop() {
-		// No confirmation modal — keep it one-click. Just fire stop().
+		// No confirmation modal keep it one-click. Just fire stop().
 		// Update currentState.display BEFORE the API call so refreshStatus()'s
-		// transient-state guard (line ~241) kicks in — otherwise the 5s poll
+		// transient-state guard (line ~241) kicks in otherwise the 5s poll
 		// can race the stop API and flip the widget back to "Recording".
 		//
 		// v0.5.0: also flush any buffered frontend metrics before the stop
-		// API fires, so analyze can join them to recordings. Best-effort —
+		// API fires, so analyze can join them to recordings. Best-effort
 		// a failed flush never blocks stop.
 		_diag("[optimus] confirmAndStop: click received");
 		setDisplay("stopping", "Stopping…", "");
@@ -590,7 +590,7 @@
 			if (window.optimus_frontend && window.optimus_frontend.flush) {
 				window.optimus_frontend.flush({ sync: false });
 			}
-		} catch (e) { /* noop — frontend module missing or flush failed */ }
+		} catch (e) { /* noop frontend module missing or flush failed */ }
 
 		frappe.call({
 			method: "optimus.api.stop",
@@ -603,7 +603,7 @@
 				// when the session has already been cleared (auto-stop,
 				// janitor sweep, or a retried click after a network blip
 				// on the first stop). Previously we fell into the else
-				// branch and transitioned to "Analyzing…" — wrong, because
+				// branch and transitioned to "Analyzing…" wrong, because
 				// there's nothing analyzing. The widget would hang on
 				// Analyzing… forever because no realtime event would ever
 				// fire for a session that no longer exists server-side.
@@ -616,7 +616,7 @@
 					}
 					setDisplay("inactive", "Profiler", "");
 					frappe.show_alert({
-						message: __("No active session — widget reset"),
+						message: __("No active session widget reset"),
 						indicator: "gray",
 					});
 					return;
@@ -626,7 +626,7 @@
 					// v0.5.0: scheduler was disabled and analyze ran
 					// synchronously inside the stop request. The session
 					// is already finalized (Ready or Failed) by the time
-					// we get here — branch on data.status so a failed
+					// we get here branch on data.status so a failed
 					// inline analyze doesn't show "Report ready" to the
 					// user. In both branches we transition to "ready"
 					// state so the user can click the pill and land on
@@ -636,7 +636,7 @@
 					if (data.status === "Failed") {
 						setDisplay("ready", "Analyze failed", "click to view");
 						frappe.show_alert({
-							message: __("Profiler analyze failed — click the pill to see details"),
+							message: __("Profiler analyze failed click the pill to see details"),
 							indicator: "red",
 						});
 					} else {
@@ -650,14 +650,14 @@
 					setDisplay("analyzing", "Analyzing…", "");
 					currentState.display = "analyzing";
 					frappe.show_alert({
-						message: __("Profiler stopped — analyzing session…"),
+						message: __("Profiler stopped analyzing session…"),
 						indicator: "orange",
 					});
 				}
 			},
 			error: (r) => {
 				// Stop failed at the network or server level. Don't
-				// unconditionally revert to Recording — we don't actually
+				// unconditionally revert to Recording we don't actually
 				// know whether the stop succeeded on the server. It's
 				// possible the session was already cleared (auto-stop,
 				// janitor sweep) and the 'error' is a 400 / 500 we
@@ -672,13 +672,13 @@
 					callback: (sr) => {
 						const sdata = (sr && sr.message) || {};
 						if (sdata.active) {
-							// Session is still live server-side — retry is
+							// Session is still live server-side retry is
 							// meaningful.
 							currentState.display = "recording";
 							setDisplay("recording", "Recording", computeElapsed());
 							startElapsedTimer();
 							frappe.show_alert({
-								message: __("Failed to stop profiler — try again"),
+								message: __("Failed to stop profiler try again"),
 								indicator: "red",
 							});
 						} else {
@@ -706,7 +706,7 @@
 						setDisplay("recording", "Recording", computeElapsed());
 						startElapsedTimer();
 						frappe.show_alert({
-							message: __("Network error — please retry"),
+							message: __("Network error please retry"),
 							indicator: "red",
 						});
 					},
@@ -719,11 +719,11 @@
 		// v0.5.1: realtime is now the PRIMARY state-transition channel
 		// (polling is gone). Server emits:
 		//
-		//   optimus_session_stopping   — user clicked Stop on another tab
-		//   optimus_session_analyzing  — analyze.run started
-		//   optimus_progress           — percent + description during analyze
-		//   optimus_session_ready      — analyze finished, report available
-		//   optimus_session_failed     — analyze crashed
+		//   optimus_session_stopping user clicked Stop on another tab
+		//   optimus_session_analyzing analyze.run started
+		//   optimus_progress percent + description during analyze
+		//   optimus_session_ready analyze finished, report available
+		//   optimus_session_failed analyze crashed
 		//
 		// The widget rehydrates state from these events so a session
 		// driven from tab A is visible in tabs B, C, D without any tab
@@ -768,7 +768,7 @@
 			currentState.docname = data.docname || currentState.docname;
 			setDisplay("ready", "Analyze failed", "click to view");
 			frappe.show_alert({
-				message: __("Profiler analyze failed — check Error Log"),
+				message: __("Profiler analyze failed check Error Log"),
 				indicator: "red",
 			});
 		});
@@ -796,7 +796,7 @@
 		// state-machine slots as phase-1 (recording → analyzing → ready),
 		// but the labels are prefixed with "Phase 2" so the user knows
 		// which mode is running. Phase 2 is started/stopped from the
-		// Optimus Session form, not the floating widget — clicking the
+		// Optimus Session form, not the floating widget clicking the
 		// widget while Phase 2 is recording still means "stop" via the
 		// existing Stop API path (api.stop_line_profile_pass), which the
 		// form's history list reflects after refresh.

--- a/optimus/public/js/optimus_frontend.js
+++ b/optimus/public/js/optimus_frontend.js
@@ -1,7 +1,7 @@
 // Copyright (c) 2026, Optimus contributors
 // For license information, please see license.txt
 //
-// Optimus — browser-side metrics shim (v0.5.0)
+// Optimus browser-side metrics shim (v0.5.0)
 //
 // Wraps window.fetch + XMLHttpRequest.prototype to capture XHR timings,
 // and uses PerformanceObserver to capture Web Vitals (FCP, LCP, CLS,
@@ -101,7 +101,7 @@
 	// responseText.length is a UTF-16 code unit count, which undercounts
 	// multi-byte characters (emoji, non-ASCII text). TextEncoder gives
 	// us the real wire byte count. For large responses this is O(n)
-	// with an allocation — acceptable because it only runs when
+	// with an allocation acceptable because it only runs when
 	// Content-Length is missing (the common case on modern servers
 	// already sets the header).
 	// -----------------------------------------------------------------
@@ -141,7 +141,7 @@
 			var start = performance.now();
 			xhr.addEventListener("loadend", function () {
 				try {
-					// Gate on active session — without this, Chromium
+					// Gate on active session without this, Chromium
 					// browsers log "Refused to get unsafe header
 					// 'X-Optimus-Recording-Id'" on every API response
 					// because Frappe stamps Access-Control-Allow-Origin
@@ -209,7 +209,7 @@
 			});
 		}
 	} catch (e) {
-		// Older browsers without PerformanceObserver — degrade silently.
+		// Older browsers without PerformanceObserver degrade silently.
 	}
 
 	// -----------------------------------------------------------------
@@ -278,7 +278,7 @@
 				method: "optimus.api.submit_frontend_metrics",
 				args: { payload: body },
 			});
-		} catch (e) { /* last-ditch — nothing more we can do */ }
+		} catch (e) { /* last-ditch nothing more we can do */ }
 	}
 
 	// Watchdog flush: runs every 60s but ONLY does work when there's an

--- a/optimus/redaction.py
+++ b/optimus/redaction.py
@@ -1,16 +1,16 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Sensitive-data redaction — pure functions, no Frappe imports.
+"""Sensitive-data redaction pure functions, no Frappe imports.
 
 Two responsibilities:
 
-  * :func:`redact_sensitive` — walks a dict / list and replaces values
+  * :func:`redact_sensitive`: walks a dict / list and replaces values
     under keys whose name contains a sensitive substring
     (``password``, ``api_key``, ``token``, …) with ``"<REDACTED:keyname>"``.
     Used for ``form_dict``, ``headers``, and any nested envelope.
 
-  * :func:`redact_sql_literals` — replaces literal RHS values in
+  * :func:`redact_sql_literals`: replaces literal RHS values in
     ``<sensitive_column> = '...'`` SQL comparisons with ``'<REDACTED>'``.
     Best-effort regex; misses UPDATE SET clauses and obscure shapes,
     but covers the >95% case (``WHERE password = 'admin123'`` is the
@@ -24,13 +24,13 @@ backed up their DB exfiltrated data they didn't realize they had.
 
 v0.7.x+ the recorder-patch path in ``optimus/__init__.py`` calls these
 at CAPTURE time so raw values never enter Redis. The renderer still
-calls them as defense-in-depth (catches anything the patch didn't —
+calls them as defense-in-depth (catches anything the patch didn't
 e.g. older sessions written under the previous contract).
 
 Settings-driven extension: every function accepts an ``extra_keys`` /
 ``extra_columns`` tuple so customers can add domain-specific patterns
 (``recovery_code``, ``otp_seed``, ``bank_account``, …) via Optimus
-Settings without forking. Extension is ADDITIVE — there's no API to
+Settings without forking. Extension is ADDITIVE there's no API to
 remove a default pattern; a config typo can't accidentally disable
 redaction of a known-sensitive key.
 
@@ -48,7 +48,7 @@ from functools import lru_cache
 # values 1:1 so the relocation is behavior-preserving; the test suite
 # locks them in.
 # NOTE: key matching is SUBSTRING (case-insensitive), so very short tokens are
-# avoided — e.g. ``sid`` is intentionally NOT here (it would match "consider",
+# avoided e.g. ``sid`` is intentionally NOT here (it would match "consider",
 # "inside", …); the Frappe session id rides in the ``Cookie`` header, already
 # covered. SQL-column matching below is word-boundary, so it's safe from that.
 DEFAULT_SENSITIVE_KEYS: tuple[str, ...] = (
@@ -87,7 +87,7 @@ def redact_sensitive(payload, *, extra_keys: tuple[str, ...] = ()):
 	under sensitive keys replaced by ``"<REDACTED:keyname>"``. Non-
 	container scalars pass through unchanged.
 
-	Pure — never mutates the input.
+	Pure never mutates the input.
 	"""
 	if isinstance(payload, dict):
 		out = {}
@@ -110,12 +110,12 @@ def _sql_literal_regex(columns: tuple[str, ...]) -> re.Pattern:
 
 	Caching keeps the patched-recorder hot path fast even when an
 	``extra_columns`` tuple is passed (each unique extras-tuple compiles
-	once per process). The cache size is intentionally small — most
+	once per process). The cache size is intentionally small most
 	deployments have ONE extras list (from Optimus Settings) so the
 	cache holds the default pattern + at most one per setting variant.
 	"""
 	# RHS literal alternatives, tried left-to-right: double-quoted, single-quoted,
-	# parenthesised IN-list, then a BARE token (unquoted number/hex/identifier) —
+	# parenthesised IN-list, then a BARE token (unquoted number/hex/identifier)
 	# the last catches ``WHERE password = 123`` / ``= 0xDEAD`` / ``= admin`` which
 	# the quoted-only pattern leaked verbatim.
 	return re.compile(
@@ -131,7 +131,7 @@ def redact_sql_literals(sql_str: str, *, extra_columns: tuple[str, ...] = ()) ->
 
 	Best-effort regex pass:
 
-	  * Quick exit when no sensitive substring appears (the 95% path —
+	  * Quick exit when no sensitive substring appears (the 95% path
 	    avoids the regex cost on every benign query).
 	  * Regex replacement on ``column (=|LIKE|IN) literal`` where
 	    ``literal`` is single-quoted, double-quoted, or parenthesised.
@@ -159,7 +159,7 @@ def redact_call_queries(calls, *, extra_columns: tuple[str, ...] = ()) -> None:
 	"""Apply :func:`redact_sql_literals` over a recording's ``calls``
 	list in place. Touches ``query`` + ``normalized_query`` fields.
 
-	Mutates input — different shape from the dict/list redactor because
+	Mutates input different shape from the dict/list redactor because
 	calls lists are large and copying is wasteful when the caller
 	already owns the recording dict.
 	"""

--- a/optimus/redis_keys.py
+++ b/optimus/redis_keys.py
@@ -3,9 +3,9 @@
 
 """Single source of truth for every Redis key Optimus writes.
 
-Pre-v0.12.0 the keys were partially centralized — :mod:`optimus.session`
+Pre-v0.12.0 the keys were partially centralized :mod:`optimus.session`
 and :mod:`optimus.line_profile.capture` already had private helpers
-(``_active_key``, ``_meta_key``, etc.) — but five other modules
+(``_active_key``, ``_meta_key``, etc.) but five other modules
 (:mod:`optimus.api`, :mod:`optimus.hooks_callbacks`, :mod:`optimus.analyze`,
 :mod:`optimus.settings`, :mod:`optimus.janitor`) built keys via inline
 f-strings, scattering the schema across the codebase and making future
@@ -31,17 +31,17 @@ to detect. The v0.12.0 baseline is ``1``.
 
 **Namespace conventions:**
 
-* ``profiler:`` prefix — every per-session / per-user / per-recording
+* ``profiler:`` prefix every per-session / per-user / per-recording
   key. Predates the v0.7.0 rename from ``frappe_profiler``; kept for
   backward compatibility with in-flight benches.
-* ``optimus:`` prefix — app-level state that's not bound to a session
+* ``optimus:`` prefix app-level state that's not bound to a session
   (``schema_version``, ``analyze:inflight``, ``retention_backlog``).
-* ``optimus_settings_cached`` — legacy single key (no prefix) for the
+* ``optimus_settings_cached``: legacy single key (no prefix) for the
   cached :class:`OptimusConfig` snapshot. Pre-dates the prefix
   convention; the cost of renaming would be a one-shot cache miss for
   every running bench, so we leave it.
 
-This module imports nothing from Frappe — every function is a pure
+This module imports nothing from Frappe every function is a pure
 string-building helper. Safe to call from any code path Optimus runs.
 """
 
@@ -50,11 +50,11 @@ from __future__ import annotations
 # v0.12.0: foundation release for Redis schema versioning. Bumping this
 # constant signals to ``redis_schema.unwrap_value`` that any persisted
 # value missing or carrying a different ``_v`` field is from a different
-# era — the unwrapper either migrates it (when a migration path exists)
+# era the unwrapper either migrates it (when a migration path exists)
 # or returns the caller's default.
 SCHEMA_VERSION = 1
 
-# Namespace prefixes — documented here, not used in the builders below
+# Namespace prefixes documented here, not used in the builders below
 # (the f-strings already encode them inline). Useful for the audit test
 # and for grep-discovery of the namespace surface.
 KEY_PREFIX = "profiler:"
@@ -80,7 +80,7 @@ def session_meta(session_uuid: str) -> str:
 	"""Session metadata hash. Value: a Frappe-pickled dict
 	(``session_uuid``, ``docname``, ``user``, ``label``, ``started_at``,
 	``capture_python_tree``, optional ``cap_warning``, optional
-	``draining_until``). No TTL — explicitly deleted by
+	``draining_until``). No TTL explicitly deleted by
 	``delete_session_state`` on analyze completion."""
 	return f"profiler:session:{session_uuid}:meta"
 
@@ -88,7 +88,7 @@ def session_meta(session_uuid: str) -> str:
 def session_recordings(session_uuid: str) -> str:
 	"""Set of recording UUIDs belonging to a session. Members are raw
 	UUID strings; SADD via :func:`optimus.session.register_recording`.
-	No TTL — deleted by ``delete_session_state``."""
+	No TTL deleted by ``delete_session_state``."""
 	return f"profiler:session:{session_uuid}:recordings"
 
 
@@ -96,7 +96,7 @@ def session_pending_jobs(session_uuid: str) -> str:
 	"""Set of RQ job IDs the session's flow enqueued and analyze is
 	still waiting on. Members SADD'd by
 	:func:`optimus.session.register_pending_job`, SREM'd by
-	:func:`clear_pending_job`. No TTL — deleted by
+	:func:`clear_pending_job`. No TTL deleted by
 	``delete_session_state``."""
 	return f"profiler:session:{session_uuid}:pending_jobs"
 
@@ -106,7 +106,7 @@ def session_jobs(session_uuid: str) -> str:
 	Fields are job IDs; values are JSON-encoded dicts written by the
 	``_MERGE_JOB_META_LUA`` Lua script via :func:`_raw_redis` (NOT
 	Frappe's pickle-wrapped ``hset``). See REDIS-SCHEMA.md "Dual-encoding
-	hazard" for details. No TTL — deleted by ``delete_session_state``."""
+	hazard" for details. No TTL deleted by ``delete_session_state``."""
 	return f"profiler:session:{session_uuid}:jobs"
 
 
@@ -163,11 +163,11 @@ def frontend_vitals(session_uuid: str) -> str:
 
 
 def frontend_legacy(session_uuid: str) -> str:
-	"""Pre-v0.5.1 combined frontend dict — a single key holding both XHR
+	"""Pre-v0.5.1 combined frontend dict a single key holding both XHR
 	and vitals data merged via GET-modify-SET. No code path writes this
 	any more; only :func:`optimus.session.delete_session_state` reads it
 	(as a defensive cleanup target for in-flight benches that still
-	carry the legacy shape). No TTL on legacy writes — that's exactly
+	carry the legacy shape). No TTL on legacy writes that's exactly
 	the upgrade-leak this PR documents."""
 	return f"profiler:frontend:{session_uuid}"
 
@@ -188,7 +188,7 @@ def lp_active(user: str) -> str:
 def lp_picks(run_uuid: str) -> str:
 	"""Hash of the run's picked functions. Keys are dotted-function
 	paths; values are Frappe-pickled metadata dicts (budget, source
-	file, etc.). No TTL — deleted by
+	file, etc.). No TTL deleted by
 	:func:`optimus.line_profile.capture.cleanup_run`."""
 	return f"profiler:lp:{run_uuid}:picks"
 
@@ -196,14 +196,14 @@ def lp_picks(run_uuid: str) -> str:
 def lp_source(run_uuid: str) -> str:
 	"""Hash of per-function source lines captured at picks time. Keys
 	are dotted-function paths; values are
-	``list[{lineno, content}]``. No TTL — cleaned by ``cleanup_run``."""
+	``list[{lineno, content}]``. No TTL cleaned by ``cleanup_run``."""
 	return f"profiler:lp:{run_uuid}:source"
 
 
 def lp_samples(run_uuid: str) -> str:
 	"""List of per-line samples flushed from each request/job under the
 	active Phase-2 pass. Each entry is a dict
-	(``lineno``, ``count``, ``wall_ms``, ``function``). No TTL — cleaned
+	(``lineno``, ``count``, ``wall_ms``, ``function``). No TTL cleaned
 	by ``cleanup_run``."""
 	return f"profiler:lp:{run_uuid}:samples"
 
@@ -224,7 +224,7 @@ def onboarding_seen(user: str) -> str:
 	"""Per-user "dismissed the onboarding toast" marker. Value: any
 	truthy string. TTL: 90 days (matches the
 	``session_retention_days`` default; documented in REDIS-SCHEMA.md
-	§ "TTL discipline"). Pre-v0.12.0 had NO TTL — keys accumulated
+	§ "TTL discipline"). Pre-v0.12.0 had NO TTL keys accumulated
 	indefinitely; this release fixes the leak."""
 	return f"profiler:onboarding_seen:{user}"
 
@@ -232,7 +232,7 @@ def onboarding_seen(user: str) -> str:
 def explain_cache(cache_key: str) -> str:
 	"""Cache of ``EXPLAIN`` enrichment results, keyed by the analyzer's
 	hash of the normalized query. Persists across sessions so identical
-	queries don't re-EXPLAIN. No explicit TTL — survives indefinitely
+	queries don't re-EXPLAIN. No explicit TTL survives indefinitely
 	(this is a pure read-through cache and the value is small)."""
 	return f"profiler:explain:{cache_key}"
 
@@ -245,7 +245,7 @@ def analyze_inflight() -> str:
 
 
 def retention_backlog() -> str:
-	"""Janitor backlog counter — written when the daily sweep hits its
+	"""Janitor backlog counter written when the daily sweep hits its
 	per-run cap and can't finish in one tick. Read by the operator
 	dashboard / Optimus Settings to surface "the bench is producing
 	sessions faster than retention can delete them"."""
@@ -255,7 +255,7 @@ def retention_backlog() -> str:
 def settings_cache() -> str:
 	"""Cached :class:`OptimusConfig` snapshot. Invalidated by the
 	Optimus Settings DocType's ``on_update`` hook. Pre-dates the
-	``optimus:`` prefix convention — renaming would force a one-shot
+	``optimus:`` prefix convention renaming would force a one-shot
 	cache miss for every running bench on upgrade, so the legacy name
 	stays."""
 	return "optimus_settings_cached"
@@ -266,13 +266,13 @@ def schema_version() -> str:
 	current :data:`SCHEMA_VERSION`). Written at app import by
 	:func:`optimus.redis_schema.write_schema_sentinel`; read by
 	:func:`optimus.redis_schema.read_schema_sentinel`. A version mismatch
-	at boot signals an upgrade — a future PR can drive proactive
+	at boot signals an upgrade a future PR can drive proactive
 	migration off this signal."""
 	return "optimus:schema_version"
 
 
 # ---------------------------------------------------------------------------
-# KEY_PATTERNS — used by the audit test + REDIS-SCHEMA.md drift check
+# KEY_PATTERNS used by the audit test + REDIS-SCHEMA.md drift check
 # ---------------------------------------------------------------------------
 #
 # Every key pattern Optimus writes, in the canonical placeholder form.
@@ -284,7 +284,7 @@ def schema_version() -> str:
 #      docs/REDIS-SCHEMA.md. Drift in either direction fails CI.
 #
 # Order matches the function definitions above (for readability + diff
-# stability when adding new keys — append, don't reorder).
+# stability when adding new keys append, don't reorder).
 KEY_PATTERNS: tuple[str, ...] = (
 	"profiler:active:<user>",
 	"profiler:session:<session_uuid>:meta",

--- a/optimus/redis_schema.py
+++ b/optimus/redis_schema.py
@@ -14,7 +14,7 @@ values from older releases.
 **The contract for future schema changes:**
 
 1. Bump :data:`SCHEMA_VERSION` (in this module AND in
-   :data:`optimus.redis_keys.SCHEMA_VERSION` — they must stay in sync).
+   :data:`optimus.redis_keys.SCHEMA_VERSION`: they must stay in sync).
 2. On the WRITE side, wrap the new-shape payload via :func:`wrap_value`
    before passing to ``frappe.cache.set_value`` / ``hset`` / etc.
 3. On the READ side, unwrap via :func:`unwrap_value`. The helper
@@ -40,7 +40,7 @@ values from older releases.
   release can add a janitor pass that enumerates ``profiler:*`` keys
   and migrates / purges those with mismatched versions.
 
-This module imports nothing from Frappe at module top — the helpers
+This module imports nothing from Frappe at module top the helpers
 lazy-import inside their functions so pure-pytest tests can exercise
 the envelope logic without a bench. The sentinel-write path requires
 Frappe (it writes to ``frappe.cache``) but degrades silently when
@@ -65,7 +65,7 @@ _ENVELOPE_PAYLOAD_FIELD = "data"
 
 
 # ---------------------------------------------------------------------------
-# Envelope helpers — opt-in for new schema-change code paths
+# Envelope helpers opt-in for new schema-change code paths
 # ---------------------------------------------------------------------------
 
 
@@ -76,7 +76,7 @@ def wrap_value(payload: Any, *, version: int = SCHEMA_VERSION) -> dict:
 
 	The wrapper is the explicit signal that THIS value's shape is
 	version-controlled. Callers writing legacy un-wrapped values are
-	unaffected — they continue to write the bare payload and readers
+	unaffected they continue to write the bare payload and readers
 	detect the legacy shape by absence of the ``_v`` key.
 	"""
 	return {_ENVELOPE_VERSION_FIELD: int(version), _ENVELOPE_PAYLOAD_FIELD: payload}
@@ -104,7 +104,7 @@ def unwrap_value(
 		return default, None
 	# Require BOTH envelope fields. ``wrap_value`` always writes both, so a dict
 	# carrying only ``_v`` (a legacy payload that happens to use that key) is NOT
-	# an envelope — treating it as one would discard its real value.
+	# an envelope treating it as one would discard its real value.
 	if (
 		isinstance(value, dict)
 		and _ENVELOPE_VERSION_FIELD in value
@@ -116,7 +116,7 @@ def unwrap_value(
 			observed = 0
 		if observed == int(expected):
 			return value.get(_ENVELOPE_PAYLOAD_FIELD), observed
-		# Drift — return the caller's default so the host code path can
+		# Drift return the caller's default so the host code path can
 		# degrade gracefully. We DON'T try to migrate inline; that would
 		# couple this helper to every value shape's migration rules. A
 		# future PR can ship the migration.
@@ -127,13 +127,13 @@ def unwrap_value(
 
 
 # ---------------------------------------------------------------------------
-# Sentinel key — written at app import, read by future migration paths
+# Sentinel key written at app import, read by future migration paths
 # ---------------------------------------------------------------------------
 
 
 def write_schema_sentinel() -> None:
 	"""Write the current :data:`SCHEMA_VERSION` to the sentinel key (see
-	:func:`optimus.redis_keys.schema_version`). Idempotent — overwrites
+	:func:`optimus.redis_keys.schema_version`). Idempotent overwrites
 	whatever was there. Best-effort; a Redis hiccup at app-import must
 	never break app load (the same discipline as
 	:func:`optimus._startup_probe_tool2`).
@@ -153,7 +153,7 @@ def write_schema_sentinel() -> None:
 			SCHEMA_VERSION,
 		)
 	except Exception:
-		# Sentinel-write failure is non-fatal — app continues to function;
+		# Sentinel-write failure is non-fatal app continues to function;
 		# the next worker boot retries.
 		pass
 

--- a/optimus/renderer/README.md
+++ b/optimus/renderer/README.md
@@ -1,4 +1,4 @@
-# `optimus.renderer` — package layout & extraction recipe
+# `optimus.renderer`: package layout & extraction recipe
 
 `optimus.renderer` turns a fully-analyzed `Optimus Session` row into the
 self-contained safe-report HTML. v0.10.0+ it's a **package** that
@@ -19,7 +19,7 @@ change"; new contributors faced a steep on-ramp; the safe-report layer
 is exactly where a dev shop using Optimus would want to extend, and it
 was the hardest place to extend safely.
 
-The package split does **not** rewrite logic — it relocates self-contained
+The package split does **not** rewrite logic it relocates self-contained
 clusters into named modules. The output HTML stays byte-equivalent (and
 the structural-snapshot test below enforces that across every
 extraction).
@@ -34,27 +34,27 @@ optimus/renderer/
                            # was 4,958 before the v0.10.0 extractions)
   README.md                # this file
   source.py                # source-file I/O + _BoundedFileCache (LRU)
-                           # — _path_within_bench, _resolve_source_path,
+                           # _path_within_bench, _resolve_source_path,
                            #    _read_source_snippet, _read_source_window
   syntax.py                # Pygments highlighting + diff-block wrapper
-                           # — _ensure_pygments, _highlight_*, _highlight_diff_html
+                           # _ensure_pygments, _highlight_*, _highlight_diff_html
   time_format.py           # duration + datetime formatting
-                           # — _format_duration_ms, _format_datetime_display,
+                           # _format_duration_ms, _format_datetime_display,
                            #    _get_server_timezone
   visualization.py         # donut chart + hot-frames + frame-name redaction
-                           # — build_donut_data, build_donut_svg,
+                           # build_donut_data, build_donut_svg,
                            #    build_hot_frames_table, redact_frame_name
   call_tree_renderer.py    # call-tree panel (nested <details> tree)
-                           # — _render_call_tree_panel, _render_call_tree_node,
+                           # _render_call_tree_panel, _render_call_tree_node,
                            #    _ct_is_user_frame, _ct_is_sql_leaf,
                            #    _ct_is_other_frame
   doc_event_renderer.py    # doc-event lifecycle binding + per-DocType
-                           # breakdown — _extract_target_doc,
+                           # breakdown _extract_target_doc,
                            #    _attach_action_context,
                            #    _build_doc_event_breakdown,
                            #    _doctype_from_controller_path, ...
   line_drilldown.py        # Phase-2 Line-Level Drilldown panel +
-                           # per-function tables —
+                           # per-function tables
                            #    _build_line_drilldown_callsite_index
                            #    (semi-public; analyze.py calls it),
                            #    _make_line_drilldown_lookup,
@@ -93,7 +93,7 @@ optimus/renderer/
 All eight submodules are imported back into `_internal.py` under their
 original names so legacy call sites resolve unchanged. The package's
 `__init__.py` walks `dir(_internal)` and re-exports every non-dunder name
-— including underscore-prefixed internals — so external callers
+including underscore-prefixed internals so external callers
 (`analyze.py`, `api.py`, the test suite) see exactly the surface they saw
 pre-split.
 
@@ -137,7 +137,7 @@ against a checked-in golden at `optimus/tests/fixtures/renderer_structure.json`:
 * the per-tag count across the whole document (gross DOM-shape sanity)
 
 The pre-v0.10.0 test suite locked **content** ("the string '50× hits'
-appears in the HTML") but never **structure** — a refactor that renamed
+appears in the HTML") but never **structure**: a refactor that renamed
 `<div class="finding-card">` to `<section class="finding">` would have
 passed every existing test and silently broken the (frozen) template's
 CSS. The snapshot closes that gap.
@@ -161,7 +161,7 @@ counts moved.
 
 Per the user's standing constraint
 ([[feedback_report_template_frozen]]),
-`optimus/templates/report.html` is frozen — don't restyle markup, CSS,
+`optimus/templates/report.html` is frozen don't restyle markup, CSS,
 labels, section IDs, or class names without an explicit user request.
 Per [[feedback_safe_report_self_contained]], the rendered HTML must stay
 fully offline-safe (no `<script>` tags, no CDN / remote `src=` /
@@ -173,9 +173,9 @@ guarantees are locked by tests:
 
 ## Public-API stability
 
-The package's contract — the names that external callers
+The package's contract the names that external callers
 (`analyze.py`, `api.py`, the test suite, third-party forks) MUST keep
-finding — is enumerated and locked by:
+finding is enumerated and locked by:
 
 `test_renderer_structure_snapshot.py::TestPublicAPIPreserved`
 
@@ -198,9 +198,9 @@ Remaining two:
 |---|---|---|---|
 | ✓ `call_tree_renderer` (done in v0.12.8) | 240 | Weak | `_render_call_tree_panel`, `_render_call_tree_node`, `_ct_is_user_frame`, `_ct_is_sql_leaf`, `_ct_is_other_frame`. Self-contained tree rendering. |
 | ✓ `doc_event_renderer` (done in v0.12.10) | 376 | Moderate | `_extract_target_doc`, `_attach_action_context`, `_build_doc_event_breakdown`, plus 6 helpers + constants. Self-contained at module-import time despite "Moderate" coupling at analyze-time. |
-| ✓ `line_drilldown` (done in v0.12.12) | 416 (scoped) | Internal | `_render_line_drilldown_panel`, `_build_line_drilldown_callsite_index`, `_make_line_drilldown_lookup`, `_phase2_invoked`, `_render_phase2_function_table`, `_render_phase2_diff_table` + 3 back-compat aliases. Semi-public — `analyze.py` calls `_build_line_drilldown_callsite_index` via the package shim. Smaller than the README's 840-LOC estimate because `_find_call_line_in_function_body` (AST-walking helper) + `_retarget_phase1_callsites_to_drilldown_leaf` + `_root_cause_key` / `_group_findings_by_root_cause` stay with the still-pending finding_enrichment cluster. |
+| ✓ `line_drilldown` (done in v0.12.12) | 416 (scoped) | Internal | `_render_line_drilldown_panel`, `_build_line_drilldown_callsite_index`, `_make_line_drilldown_lookup`, `_phase2_invoked`, `_render_phase2_function_table`, `_render_phase2_diff_table` + 3 back-compat aliases. Semi-public `analyze.py` calls `_build_line_drilldown_callsite_index` via the package shim. Smaller than the README's 840-LOC estimate because `_find_call_line_in_function_body` (AST-walking helper) + `_retarget_phase1_callsites_to_drilldown_leaf` + `_root_cause_key` / `_group_findings_by_root_cause` stay with the still-pending finding_enrichment cluster. |
 | ✓ `finding_enrichment` (done in v0.12.16 + v0.12.19 + v0.12.26) | ~700 LOC total, now fully extracted | HIGH (resolved via v0.12.23's `source_resolution.py` prep) | Phase 1 (v0.12.16): `_root_cause_key`, `_group_findings_by_root_cause`, `_normalize_callsite` + `_GROUPING_SEVERITY_RANK`. Phase 2 (v0.12.19): `_find_node_in_tree`, `_walk_drilldown_chain`, `_attach_drilldown_chains`. Phase 3 (v0.12.26): `_finding_to_dict` (~200 LOC), `_attach_representative_callsites`, `_expand_self_time_snippets`, `_retarget_phase1_callsites_to_drilldown_leaf`, `_find_call_line_in_function_body`, `_markdown_to_safe_html`, `_read_function_body_snippet`, `_SQL_REDFLAG_FINDING_TYPES`. |
-| `render()` orchestrator | 812 | Core | The big function itself. Could be split into per-phase helpers within `_internal.py`, but a per-module split isn't natural — it's an orchestrator, not a section. Keep integrated. |
+| `render()` orchestrator | 812 | Core | The big function itself. Could be split into per-phase helpers within `_internal.py`, but a per-module split isn't natural it's an orchestrator, not a section. Keep integrated. |
 
 Each follow-up PR uses the recipe above. The structural snapshot is the
 shared safety net; the public-API tests are the contract harness.

--- a/optimus/renderer/__init__.py
+++ b/optimus/renderer/__init__.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Optimus renderer — turns a fully-analyzed ``Optimus Session`` row into
+"""Optimus renderer turns a fully-analyzed ``Optimus Session`` row into
 the self-contained safe-report HTML.
 
 v0.10.0+ this module is a **package** that aggregates per-concern
@@ -12,7 +12,7 @@ the remaining cluster roadmap, and the structural-snapshot canary that
 protects the template contract across follow-up PRs.
 
 The public API (what ``analyze.py`` / ``api.py`` / the test suite import)
-stays exactly as it was — every existing ``from optimus.renderer import X``
+stays exactly as it was every existing ``from optimus.renderer import X``
 and ``optimus.renderer.X`` resolution continues to work. The wildcard
 re-export from ``_internal`` covers names this module hasn't started
 tracking explicitly; the explicit re-exports below are the names that
@@ -22,7 +22,7 @@ matter enough to lock with a unit test
 
 from __future__ import annotations
 
-# Re-export EVERY symbol from the legacy monolithic module — including
+# Re-export EVERY symbol from the legacy monolithic module including
 # underscore-prefixed internals like ``_OTHER_APP_LABEL``,
 # ``_find_node_in_tree``, ``_build_executive_summary`` etc. that test files
 # (and a few cross-module callers) import directly. ``from X import *``
@@ -37,7 +37,7 @@ from optimus.renderer import _internal as _renderer_internal
 
 for _name in dir(_renderer_internal):
 	if _name.startswith("__") and _name.endswith("__"):
-		# Skip dunders — they're either Python-internal (``__name__``,
+		# Skip dunders they're either Python-internal (``__name__``,
 		# ``__file__``) or module re-imports we don't want shadowing
 		# this package's own dunders.
 		continue

--- a/optimus/renderer/_internal.py
+++ b/optimus/renderer/_internal.py
@@ -26,12 +26,12 @@ from optimus.analyzers.base import SEVERITY_ORDER
 
 # Sensitive-data redaction lives in ``optimus/redaction.py`` (pure
 # functions, no Frappe imports) so the recorder-patch path in
-# ``optimus/__init__.py`` can run them at CAPTURE time — before raw
+# ``optimus/__init__.py`` can run them at CAPTURE time before raw
 # values reach Redis or the persisted DocType JSON. The renderer calls
 # them as defense-in-depth (catches older sessions written under the
 # pre-patch contract, plus any code path where the patch didn't fire).
 # Settings-driven extras: ``OptimusConfig.sensitive_sql_columns`` /
-# ``sensitive_form_keys`` (additive — never replaces the defaults).
+# ``sensitive_form_keys`` (additive never replaces the defaults).
 from optimus.redaction import redact_call_queries as _redact_call_queries_base
 from optimus.redaction import redact_sensitive as _redact_sensitive_base
 from optimus.redaction import redact_sql_literals as _redact_sql_literals_base
@@ -52,7 +52,7 @@ from optimus.renderer.syntax import (
 
 def _settings_extras() -> tuple[tuple[str, ...], tuple[str, ...]]:
 	"""Read the live ``sensitive_form_keys`` / ``sensitive_sql_columns``
-	extras from Optimus Settings. Best-effort — falls back to empty
+	extras from Optimus Settings. Best-effort falls back to empty
 	tuples on any error so a settings hiccup never breaks rendering
 	(the defaults inside ``optimus.redaction`` still apply)."""
 	try:
@@ -76,7 +76,7 @@ def _redact_sensitive(payload):
 
 
 def _redact_sql_literals(sql_str: str) -> str:
-	"""Backward-compatible wrapper. Same as ``_redact_sensitive`` —
+	"""Backward-compatible wrapper. Same as ``_redact_sensitive``:
 	reads settings + delegates."""
 	_, extra_cols = _settings_extras()
 	return _redact_sql_literals_base(sql_str, extra_columns=extra_cols)
@@ -197,7 +197,7 @@ from optimus.renderer.time_format import (
 # v0.10.0+: donut chart + hot-frames table + frame-name redaction moved to
 # optimus/renderer/visualization.py. All four are PUBLIC (passed into the
 # template context as helpers) so the package __init__.py also re-exports
-# them — the imports here keep the symbols available at this module's
+# them the imports here keep the symbols available at this module's
 # namespace for callers that resolve via ``optimus.renderer._internal.X``.
 from optimus.renderer.visualization import (
 	_DONUT_COLORS,
@@ -256,7 +256,7 @@ def render(
 	    session_doc: The Optimus Session DocType row (loaded via
 	        frappe.get_doc). Provides totals, summary_html, and the
 	        actions/findings child rows.
-	    recordings: The in-memory recordings list. Required — provides
+	    recordings: The in-memory recordings list. Required provides
 	        raw SQL, headers, form_dict, and full stack traces for the
 	        per-action drill-down.
 	    generated_at: ISO timestamp of when this report was generated;
@@ -300,7 +300,7 @@ def render(
 				_redact_call_queries(rec_copy["calls"])
 			recordings_by_uuid[uid] = rec_copy
 
-	# `idx` = the action's original position — matches a finding's `action_ref`
+	# `idx` = the action's original position matches a finding's `action_ref`
 	# (which is the action index as a string) so the Background-jobs section
 	# can tally findings per job even after the min-duration filter below.
 	actions = [
@@ -339,16 +339,16 @@ def render(
 		_finding_to_dict(f, _finding_file_cache)
 		for f in (session_doc.findings or [])
 	]
-	# v0.6.x: SQL "red flag" findings carry no callsite — derive a
+	# v0.6.x: SQL "red flag" findings carry no callsite derive a
 	# representative one (the hottest user-app frame that ran the offending
 	# query) from the recordings so their smoking-gun block can render too.
 	_attach_representative_callsites(all_findings, recordings or [], file_cache=_finding_file_cache)
 	# v0.7.x: drop findings whose callsite has no file:line. They have
-	# no actionable anchor for the reader — pre-v0.7 they bucketed as
+	# no actionable anchor for the reader pre-v0.7 they bucketed as
 	# "Other (no callsite)" and the user explicitly opted to suppress
 	# that bucket. Filtered AFTER ``_attach_representative_callsites``
 	# so SQL red-flag findings that DID get a representative callsite
-	# survive. The filter is global — these findings also disappear
+	# survive. The filter is global these findings also disappear
 	# from the Executive Summary, severity counts, and observations
 	# so there's no phantom-row inconsistency between sections.
 	def _has_renderable_callsite(f):
@@ -358,7 +358,7 @@ def render(
 
 	all_findings = [f for f in all_findings if _has_renderable_callsite(f)]
 	# v0.7.x: "X was picked but never invoked during phase 2" is non-actionable
-	# noise — it just means the replay didn't exercise that pick. The Line-Level
+	# noise it just means the replay didn't exercise that pick. The Line-Level
 	# Drilldown already notes uninvoked picks in one concise line. Drop these
 	# globally at render so existing reports declutter on regenerate too (the
 	# analyzer no longer emits them for new runs); global so they also leave the
@@ -399,7 +399,7 @@ def render(
 			for _k in ("diagnosis_html", "patch_html", "rationale_html", "verify_html", "description_html", "code_html", "why_html"):
 				if _k in _lf:
 					_lf[_k] = _strip_em(_lf[_k])
-	# v0.6.x: "Ignored Apps" — drop findings whose blame app is in the
+	# v0.6.x: "Ignored Apps" drop findings whose blame app is in the
 	# admin's exclusion list, BEFORE anything downstream sees the list
 	# (doc-event breakdown, background-jobs tally, exec summary, severity
 	# counts, the actionable/observational split, bucketing). The "Issues
@@ -429,7 +429,7 @@ def render(
 	# v0.7.x J.11: enrich finding callsite function names with the DocType
 	# suffix for display. Runs AFTER _build_doc_event_breakdown because
 	# that function parses ``callsite.function`` against the lifecycle
-	# event vocabulary (``validate``, ``on_submit``, ...) — suffixing
+	# event vocabulary (``validate``, ``on_submit``, ...) suffixing
 	# before classification would break the match.
 	for _f in (all_findings or []):
 		if not isinstance(_f, dict):
@@ -447,7 +447,7 @@ def render(
 			if _cs_fn and " (" not in _cs_fn:
 				_cs["function"] = f"{_cs_fn} ({_dt})"
 
-	# v0.6.0: the "RQ Jobs" section — the captured background-job
+	# v0.6.0: the "RQ Jobs" section the captured background-job
 	# recordings, surfaced on their own (they also stay in the per-action
 	# table). Derived from the persisted action rows; uses all findings
 	# (actionable + observational) for the per-job findings tally.
@@ -468,7 +468,7 @@ def render(
 	# Phase K hardening: best-effort SQL parameter redaction over the
 	# slow-queries leaderboard (mirrors the recordings-side redaction).
 	_redact_call_queries(top_queries)
-	# B.DI4 — compute slow-threshold + suppressed-finding count from the
+	# B.DI4 compute slow-threshold + suppressed-finding count from the
 	# loaded leaderboard. Render-time so it picks up the latest Settings
 	# value without needing analyze to re-run.
 	from optimus.analyzers.top_queries import (
@@ -500,10 +500,10 @@ def render(
 				_t["ai_index"]["suggestion_html"] = _markdown_to_safe_html(raw)
 
 
-	# v0.6.x: a per-section LLM toggle being off is a hard disable — drop any
+	# v0.6.x: a per-section LLM toggle being off is a hard disable drop any
 	# previously-generated AI output for that section so re-rendering an older
 	# session (analyzed while it was on) doesn't show the block. (Humanized
-	# notes live in Optimus Session.notes — a plain HTML field — so they're
+	# notes live in Optimus Session.notes a plain HTML field so they're
 	# not stripped here; turning that section off stops new generation, but an
 	# already-humanized note stays until the session is re-analyzed.)
 	try:
@@ -514,7 +514,7 @@ def render(
 		_hide_framework_tables = getattr(_cfg, "hide_framework_tables", True)
 		# v0.6.x: snapshot the render-affecting settings so the footer can
 		# stamp THIS file with the values that were in effect. Saved HTML
-		# only re-renders on Regenerate Reports / Retry Analyze — the stamp
+		# only re-renders on Regenerate Reports / Retry Analyze the stamp
 		# means a user opening an old file can immediately tell whether the
 		# settings they expect are actually baked in.
 		_large_duration_threshold_ms = float(
@@ -561,7 +561,7 @@ def render(
 				_t.pop("ai_index", None)
 
 	# v0.6.x: drop framework/internal db tables from the "Time spent per
-	# database table" section — schema/meta (DocType/DocField/…), user-
+	# database table" section schema/meta (DocType/DocField/…), user-
 	# session bookkeeping (User/Has Role/DefaultValue/…), and information_
 	# schema.*. The note under the section's intro reports the count so the
 	# total stays honest. Scope is intentional: top-queries leaderboard /
@@ -586,18 +586,18 @@ def render(
 	)
 
 	# v0.5.2: split findings into two buckets per user feedback
-	# ("In Findings — what to fix, Show only the valid fixes").
+	# ("In Findings what to fix, Show only the valid fixes").
 	#
-	# ACTIONABLE: findings with a concrete fix the user can ship —
+	# ACTIONABLE: findings with a concrete fix the user can ship
 	# add an index, refactor a loop, trim a response. These go into
-	# the main "Findings — what to fix" section so the list reads
+	# the main "Findings what to fix" section so the list reads
 	# as a punchlist.
 	#
 	# OBSERVATIONS: informational findings that surface signal but
 	# don't prescribe a fix the user can act on (framework N+1 where
 	# the loop lives inside Frappe, system-level CPU/memory/queue
 	# pressure, repeated hot frames that need further investigation).
-	# These go into a separate "Observations" section — still
+	# These go into a separate "Observations" section still
 	# visible for users who want the full picture, but no longer
 	# cluttering the action list.
 	actionable_findings = [
@@ -638,7 +638,7 @@ def render(
 
 	# v0.5.0: infra_pressure + frontend_timings aggregates. One JSON field
 	# holds both. Empty fallbacks let sessions captured before v0.5.0
-	# render cleanly after the upgrade — the new panels just don't appear.
+	# render cleanly after the upgrade the new panels just don't appear.
 	try:
 		v5 = json.loads(getattr(session_doc, "v5_aggregate_json", None) or "{}")
 	except Exception:
@@ -647,13 +647,13 @@ def render(
 	# v0.5.0: pre-sanitize session.notes before the template uses |safe.
 	# The field was upgraded from plain Text to Text Editor in v0.5.0,
 	# which means `{{ session.notes | safe }}` would render stored HTML
-	# verbatim — a stored-XSS sink if any existing row has script content
+	# verbatim a stored-XSS sink if any existing row has script content
 	# (plain-text before, live HTML after).
 	#
 	# CRITICAL: pass always_sanitize=True. Without it, Frappe's
 	# sanitize_html has TWO fast-paths that skip bleach:
 	#   1. if is_json(html) → returns unchanged  (bypassable with
-	#      notes = '{"x":"<script>alert(1)</script>"}' — valid JSON
+	#      notes = '{"x":"<script>alert(1)</script>"}' valid JSON
 	#      containing a script tag)
 	#   2. if BeautifulSoup.find() returns nothing → returns unchanged
 	# Both paths would leak raw input to |safe in the template.
@@ -689,7 +689,7 @@ def render(
 	# it in its own prominent banner at the top of the report rather
 	# than burying it in the collapsed Analyzer Notes section. Users
 	# read an 8s Submit report without noticing the "566 queries were
-	# truncated" warning because it sat below the fold — then debugged
+	# truncated" warning because it sat below the fold then debugged
 	# based on an incomplete picture. The banner forces the visibility
 	# that the severity of the situation deserves.
 	truncation_banner = None
@@ -751,12 +751,12 @@ def render(
 	# v0.7.x: the per-action split now keys off the admin's
 	# ``Tracked Apps`` allowlist exclusively. When Tracked Apps is
 	# configured, only actions whose entry resolves to a tracked app
-	# land in the main table — everything else is in the collapsed
+	# land in the main table everything else is in the collapsed
 	# framework subsection. When Tracked Apps is empty (default), the
 	# split is skipped and ALL actions stay in the main table. This
 	# fixes a UX regression where every HTTP action that hit a Frappe
 	# endpoint (``/api/method/frappe.client.save``,
-	# ``/api/method/frappe.desk.form.save.savedocs`` — i.e. the actions
+	# ``/api/method/frappe.desk.form.save.savedocs``: i.e. the actions
 	# the user actually clicked Save / Submit for) was hidden in the
 	# framework subsection, leaving only background jobs in the main
 	# Per-Action Breakdown table.
@@ -772,9 +772,9 @@ def render(
 	# matches its ``idx``. The per-action row in the template uses
 	# this to embed the full finding card (severity badge, smoking
 	# gun, drill-down, AI fix, root-cause sub_findings) directly
-	# inside the action's sub-row — same structure as the Findings
+	# inside the action's sub-row same structure as the Findings
 	# section, scoped to that action. Findings without an action_ref
-	# (e.g. infra observations, SQL red flags) are skipped — they
+	# (e.g. infra observations, SQL red flags) are skipped they
 	# still appear in their respective top-level sections.
 	_findings_by_action_ref: dict[str, list] = {}
 	for _f in actionable_findings:
@@ -823,7 +823,7 @@ def render(
 	hot_frames_rows = build_hot_frames_table(_hf_raw_custom, is_hot=True)
 	hot_frames_rows_framework = build_hot_frames_table(_hf_raw_framework, is_hot=False)
 
-	# v0.5.2 round 3: executive summary — top 3 most-impactful findings
+	# v0.5.2 round 3: executive summary top 3 most-impactful findings
 	# stated in plain English, rendered in a card at the top of the
 	# report. A non-developer (e.g. a project manager) reading this
 	# should be able to decide "do we have a problem" in 30 seconds
@@ -842,7 +842,7 @@ def render(
 	# Phase K.5: nested-<details> call-tree panel for the slowest
 	# action. Empty string when no action carries a call_tree_json.
 	call_tree_html = _render_call_tree_panel(list(actions) + list(actions_framework))
-	# B.DI2 — aggregate frame-truncation across actions so the Hot Frames
+	# B.DI2 aggregate frame-truncation across actions so the Hot Frames
 	# banner can show "captured X frames, only top N shown" without making
 	# the reader hunt through analyzer_warnings.
 	frame_truncation = _aggregate_frame_truncation(
@@ -850,7 +850,7 @@ def render(
 	)
 	# v0.7.x redesign Phase C: Recommended Action plan + waterfall.
 	# Action plan: top-3 highest-impact ACTIONABLE findings, verb-led
-	# titles. Feed it the pre-split actionable list, NOT all_findings —
+	# titles. Feed it the pre-split actionable list, NOT all_findings
 	# else an observation-only finding (Framework N+1, infra pressure)
 	# can sort into "Fix these first" with an "est. saving", directly
 	# contradicting its own "usually not something you can change" body.
@@ -873,7 +873,7 @@ def render(
 	# v0.7.x: build the Summary section's HTML at render time. Pre-v0.7.x
 	# this was baked into ``session_doc.summary_html`` at analyze time, so
 	# template-shape changes (e.g. <p> → <ul>) only applied to sessions
-	# re-analyzed after the change — ``regenerate_reports`` re-renders the
+	# re-analyzed after the change ``regenerate_reports`` re-renders the
 	# template but doesn't re-run analyzers (see the docstring on
 	# ``_filter_top_queries_for_display`` below for the same pattern).
 	# Building at render time means the bullet shape always matches the
@@ -917,8 +917,8 @@ def render(
 		"findings_by_app": findings_by_app,
 		"observational_findings_by_app": observational_findings_by_app,
 		# v0.5.2: "findings" holds actionable items only (shown in
-		# "Findings — what to fix"); "observational_findings" the rest.
-		# "all_findings" is the full list — the "Issues found" stat card
+		# "Findings what to fix"); "observational_findings" the rest.
+		# "all_findings" is the full list the "Issues found" stat card
 		# shows that total and a severity breakdown of it, so its big
 		# number, its sub-line, and the Summary prose all agree.
 		"findings": findings,
@@ -929,12 +929,12 @@ def render(
 		# top_queries is already filtered at analyze time AND render time;
 		# the split is wired for consistency with the other 3 sections).
 		"top_queries_framework": top_queries_framework,
-		# B.DI4 — surfaced through to report_data so the template can
+		# B.DI4 surfaced through to report_data so the template can
 		# render a "X more slow queries suppressed" banner when the 5-cap
 		# clipped legitimate findings out of the list.
 		"top_queries_suppressed_count": _top_queries_suppressed_count,
 		"top_queries_slow_threshold_ms": _top_queries_slow_threshold_ms,
-		# B.DI2 — frame-truncation banner data for the Hot Frames section.
+		# B.DI2 frame-truncation banner data for the Hot Frames section.
 		"frame_truncation": frame_truncation,
 		"table_breakdown": table_breakdown,
 		"recordings_by_uuid": recordings_by_uuid,
@@ -946,7 +946,7 @@ def render(
 		# from Optimus Settings. Above the threshold → "5.23s"; below → "ms"
 		# (with caller-chosen decimals to preserve %.1f / %.2f precision).
 		"fmt_ms": _fmt_ms,
-		# Severity breakdown of ALL findings — feeds the "Issues found" stat
+		# Severity breakdown of ALL findings feeds the "Issues found" stat
 		# card's sub-line (which sums to the card's total).
 		"severity_counts": {
 			"High": sum(1 for f in all_findings if f["severity"] == "High"),
@@ -954,12 +954,12 @@ def render(
 			"Low": sum(1 for f in all_findings if f["severity"] == "Low"),
 		},
 		# v0.6.x: the "Ignored Apps" exclusion list, plus how many findings
-		# this render dropped — surfaced as a small note next to the stat
+		# this render dropped surfaced as a small note next to the stat
 		# card so the missing-bucket count is honest. Empty/zero → no note.
 		"ignored_apps": ignored_apps,
 		"ignored_findings_count": ignored_findings_count,
 		# v0.6.x: how many framework/internal db tables the "Time spent per
-		# database table" section dropped — surfaced as a small note in that
+		# database table" section dropped surfaced as a small note in that
 		# section. Zero → no note.
 		"hidden_db_tables_count": hidden_db_tables_count,
 		# v0.3.0 additions
@@ -1001,7 +1001,7 @@ def render(
 		# ``_build_summary_html`` call). The template prefers this over
 		# the stored ``session.summary_html``.
 		"summary_html": summary_html_rendered,
-		# v0.7.x redesign Phase B: TL;DR hero — single composed headline
+		# v0.7.x redesign Phase B: TL;DR hero single composed headline
 		# keyed off the highest-impact finding, with `<span class="hot">`
 		# inline emphases (rendered as Markup so Jinja autoescape leaves
 		# them intact).
@@ -1018,14 +1018,14 @@ def render(
 		"waterfall_rows": waterfall_rows,
 	}
 
-	# v0.7.x Phase J.1 — contract-shape adapter. Exposes the 19-key dict
+	# v0.7.x Phase J.1 contract-shape adapter. Exposes the 19-key dict
 	# per template_variable_contract.md under a single ``report_data``
 	# namespace; Phase J.2 migrated every template section to read from
 	# it instead of the flat legacy keys.
 	from optimus.report_context import build_report_context as _build_report_context
 	context["report_data"] = _build_report_context(session_doc, context)
 
-	# v0.7.x Phase J.3 — drop the now-unused legacy top-level keys.
+	# v0.7.x Phase J.3 drop the now-unused legacy top-level keys.
 	# Template grep confirms zero remaining references; the adapter has
 	# already consumed them (the pop runs AFTER build_report_context).
 	# Keys kept: session, fmt_dt/fmt_ms, generated_at/server_tz, severity_counts,
@@ -1059,7 +1059,7 @@ def render(
 
 
 def _e(text: object) -> str:
-	"""HTML-escape — small alias to keep the phase-2 builder readable."""
+	"""HTML-escape small alias to keep the phase-2 builder readable."""
 	import html as _html
 	return _html.escape("" if text is None else str(text))
 
@@ -1088,7 +1088,7 @@ def render_raw(session_doc: Any, recordings: list[dict]) -> str:
 	"""Render the admin-scoped report.
 
 	v0.6.0 Round 7: name kept as ``render_raw`` for back-compat but
-	there's no longer a ``render_safe`` counterpart — single rendering
+	there's no longer a ``render_safe`` counterpart single rendering
 	path. Requires the in-memory recordings list (raw SQL, headers,
 	form_dict, and full stack traces are NOT stored on the DocType).
 	"""
@@ -1145,7 +1145,7 @@ def _action_to_dict(child: Any) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# v0.6.0: "RQ Jobs" report section — render-time only (the pipeline is
+# v0.6.0: "RQ Jobs" report section render-time only (the pipeline is
 # frozen). Derived purely from the persisted Optimus Action rows that have
 # event_type == "RQ Job" (one per captured job recording), enriched
 # with the live recording's SQL when it's still in Redis.
@@ -1157,7 +1157,7 @@ _BG_JOB_TOP_QUERIES = 5
 def _clean_job_method(action_label, path, recording) -> str:
 	"""The most human-readable name for a background-job action.
 
-	``per_action._label`` writes job labels as ``"Job: <method>"`` — strip
+	``per_action._label`` writes job labels as ``"Job: <method>"``: strip
 	that prefix. Fall back to the job method path, then the recording's
 	``cmd``, then a generic placeholder."""
 	label = (action_label or "").strip()
@@ -1193,8 +1193,8 @@ def build_background_jobs(actions, recordings_by_uuid, findings=None, tracked_jo
 	reported instead of silently vanishing.
 
 	``actions`` items are ``_action_to_dict`` output plus an ``idx`` key
-	holding the action's original position (so findings — whose ``action_ref``
-	is that index as a string — can be tallied per job). ``recordings_by_uuid``
+	holding the action's original position (so findings whose ``action_ref``
+	is that index as a string can be tallied per job). ``recordings_by_uuid``
 	enriches each job with its slowest queries when the recording is still in
 	Redis (TTL ~10 min; a re-render long after analyze has none → the section
 	still renders from the persisted action rows alone). ``tracked_jobs`` are
@@ -1203,7 +1203,7 @@ def build_background_jobs(actions, recordings_by_uuid, findings=None, tracked_jo
 	captured action by ``recording_uuid``. A job that ran with profiling has
 	both an action (rich query data) and a tracked row (status); a job that
 	failed / timed out / ran past the wait has only a tracked row and still
-	appears, with its status + error but no query data. Pure — no I/O (the
+	appears, with its status + error but no query data. Pure no I/O (the
 	``entry_callsite`` on each job is pre-computed by ``render()`` and copied
 	through here).
 
@@ -1335,7 +1335,7 @@ def build_background_jobs(actions, recordings_by_uuid, findings=None, tracked_jo
 # module so call sites resolve unchanged.
 
 
-# (_read_source_window duplicate definition removed — the function now
+# (_read_source_window duplicate definition removed the function now
 # lives in optimus/renderer/source.py and is re-imported at the top of
 # this file.)
 
@@ -1350,15 +1350,15 @@ def build_background_jobs(actions, recordings_by_uuid, findings=None, tracked_jo
 # impactful actionable findings as plain-English bullets.
 #
 # v0.7.x: ``_build_executive_summary`` stays as the data layer (pace,
-# top-3 bullets, infra_note — feeds the upcoming Action plan section);
+# top-3 bullets, infra_note feeds the upcoming Action plan section);
 # the *headline* portion of the original "At a glance" card was
-# replaced template-side by ``_compose_tldr`` below — a hero block
+# replaced template-side by ``_compose_tldr`` below a hero block
 # composing one sentence keyed on the single highest-impact finding.
 
 
 # Mapping from analyzer finding_type to a short category slug used by
 # _compose_tldr for branch selection. Anything not in the map falls
-# through to the verbatim-title branch — safe default.
+# through to the verbatim-title branch safe default.
 _CATEGORY_FOR_FINDING_TYPE: dict[str, str] = {
 	"N+1 Query": "n_plus_one",
 	"Framework N+1": "n_plus_one",
@@ -1375,7 +1375,7 @@ _CATEGORY_FOR_FINDING_TYPE: dict[str, str] = {
 	"Low Filter Ratio": "low_filter",
 }
 
-# Ascending order for sorted() — High first. NOT the same as the
+# Ascending order for sorted() High first. NOT the same as the
 # `> max` _SEVERITY_RANK constant defined earlier in this module
 # (which uses {High:3, Medium:2, Low:1} for max-of comparisons).
 # Named distinctly to avoid the shadowing collision that broke
@@ -1389,7 +1389,7 @@ def _category_for(finding_type: str | None) -> str:
 
 
 # Verb-led action titles per finding category. Strings are short
-# imperative phrases — the user reads the title alone and knows what
+# imperative phrases the user reads the title alone and knows what
 # to do next. Fallback: the finding's own title (verbatim).
 _ACTION_VERB_FOR_FINDING_TYPE: dict[str, str] = {
 	"N+1 Query": "Eliminate the N+1 query",
@@ -1454,7 +1454,7 @@ def _build_action_plan(
 		desc = (f.get("customer_description") or "").strip()
 		if not desc:
 			# Fall back to the finding's title prose when no
-			# customer description is available — better than empty.
+			# customer description is available better than empty.
 			desc = (f.get("title") or "").strip()
 		callsite = None
 		detail = f.get("technical_detail") or {}
@@ -1501,7 +1501,7 @@ def _build_waterfall(
 	    {"name": str, "duration_ms": float, "pct": float,
 	     "hot": bool, "bg": bool}
 
-	`pct` is scaled to the displayed slice's max duration — so the
+	`pct` is scaled to the displayed slice's max duration so the
 	longest row always renders at 100% and shorter rows are visible.
 	Scaling to the session total would make sub-second actions
 	invisible.
@@ -1625,7 +1625,7 @@ def _savings_phrase(pct: float) -> str:
 
 
 def _aggregate_frame_truncation(actions: list[dict]) -> dict:
-	"""B.DI2 — sum captured / kept frames across actions whose call-tree
+	"""B.DI2 sum captured / kept frames across actions whose call-tree
 	hit ``CALL_TREE_HARD_TRUNCATE_KEEP_FRAMES``.
 
 	Returns ``{"captured": int, "kept": int, "actions_affected": int,
@@ -1680,12 +1680,12 @@ def _compose_tldr(
 	``{"label": str, "headline_markup": Markup, "sub_markup": Markup}``.
 
 	When ``findings`` is empty, returns the clean-session branch
-	(no <span class="hot"> — nothing's wrong, no signal red needed).
+	(no <span class="hot"> nothing's wrong, no signal red needed).
 
 	The Markup-aware composition mirrors the recently-fixed
 	executive-summary headline: f-strings would flatten Markup back
 	to str and Jinja would HTML-escape the spans, so we use
-	``Markup.format(...)`` — it escapes plain-string args and passes
+	``Markup.format(...)``: it escapes plain-string args and passes
 	Markup args through untouched.
 	"""
 	def _fmt(v):
@@ -1696,7 +1696,7 @@ def _compose_tldr(
 	total_actions = int(getattr(session_doc, "total_requests", 0) or 0)
 
 	if not findings:
-		# Clean-session branch — no signal red.
+		# Clean-session branch no signal red.
 		return {
 			"label": "Clean session",
 			"headline_markup": Markup(
@@ -1718,7 +1718,7 @@ def _compose_tldr(
 			),
 		}
 
-	# Sort by severity DESC then impact_ms DESC — be defensive even
+	# Sort by severity DESC then impact_ms DESC be defensive even
 	# though the upstream sort usually already has this order.
 	def _sort_key(f: dict):
 		return (
@@ -1736,7 +1736,7 @@ def _compose_tldr(
 
 	impact_html = _fmt(impact_ms)
 
-	# v0.7.x J.15: rich Hot Line branch — narrative two-sentence
+	# v0.7.x J.15: rich Hot Line branch narrative two-sentence
 	# headline that names the target DocType being fetched, the loop
 	# count, the action it's slowing, and the expected savings.
 	# Falls through to a slimmer sentence when any of those are missing.
@@ -1773,7 +1773,7 @@ def _compose_tldr(
 			headline = Markup(
 				"One line of code is responsible for "
 				"<span class=\"hot\">~{impact}</span> of this session "
-				"&mdash; a <strong>{target}</strong> document fetched "
+				" a <strong>{target}</strong> document fetched "
 				"<span class=\"hot\">{n} times inside a loop</span> that "
 				"should only run once. Fix it and the "
 				"<strong>{label}</strong> drops {savings}."
@@ -1790,7 +1790,7 @@ def _compose_tldr(
 			headline = Markup(
 				"One line of code is responsible for "
 				"<span class=\"hot\">~{impact}</span> of this session "
-				"&mdash; same line ran <span class=\"hot\">{n} times "
+				" same line ran <span class=\"hot\">{n} times "
 				"inside a loop</span>. Tune that line and most of the "
 				"cost goes away."
 			).format(impact=impact_html, n=affected)
@@ -1800,14 +1800,14 @@ def _compose_tldr(
 		# an old user N+1 isn't mislabelled as unfixable framework code.
 		_detail = top.get("technical_detail") or {}
 		if finding_type == "Framework N+1":
-			# Framework N+1: informational — the loop lives inside Frappe, not the
+			# Framework N+1: informational the loop lives inside Frappe, not the
 			# user's code. It can still win the hero slot (highest-impact signal),
 			# but it must NEVER be called "the single biggest win": that contradicts
 			# the finding body's own "rarely something you can change" framing.
 			# affected_count here is the cumulative total the title shows.
 			headline = Markup(
 				"Frappe's own code ran the same query <span class=\"hot\">{n}×"
-				"</span> this session &mdash; <span class=\"hot\">~{impact}</span> "
+				"</span> this session <span class=\"hot\">~{impact}</span> "
 				"total. That loop lives in framework code, so it's usually not "
 				"something you can change; shown here for transparency."
 			).format(n=affected, impact=impact_html)
@@ -1818,14 +1818,14 @@ def _compose_tldr(
 			# loop_count so the hero matches the finding title.
 			_loop_n = int(_detail.get("loop_count") or 0) or affected
 			# When the loop spans requests, loop_count is the PEAK single-request
-			# size — hedge ("up to") and name the spread so the per-request count and
+			# size hedge ("up to") and name the spread so the per-request count and
 			# the cumulative impact reconcile (as the title/card do).
 			_run = int(_detail.get("run_count") or 0)
 			_upto = "up to " if _run > 1 else ""
 			_spread = f" across {_run} requests" if _run > 1 else ""
 			headline = Markup(
 				"One line of code is responsible for <span class=\"hot\">~"
-				"{impact}</span> of this session &mdash; same query ran "
+				"{impact}</span> of this session same query ran "
 				"<span class=\"hot\">{upto}{n}× inside a loop</span>{spread}. "
 				"Removing the redundant round-trips is the single biggest "
 				"win here."
@@ -1833,26 +1833,26 @@ def _compose_tldr(
 	elif category == "slow_hook":
 		headline = Markup(
 			"<span class=\"hot\">{impact}</span> is spent inside a "
-			"doc-event hook — the slowest hook this session. {title}"
+			"doc-event hook the slowest hook this session. {title}"
 		).format(impact=impact_html, title=title)
 	elif category in ("slow_query", "missing_index", "full_table_scan"):
 		headline = Markup(
 			"A single query took <span class=\"hot\">{impact}</span> "
-			"— {title}"
+			" {title}"
 		).format(impact=impact_html, title=title)
 	elif category == "redundant_call":
 		if affected:
 			headline = Markup(
 				"Same call repeated <span class=\"hot\">{n}×</span> "
-				"— {impact} of this session. {title}"
+				" {impact} of this session. {title}"
 			).format(n=affected, impact=impact_html, title=title)
 		else:
 			headline = Markup(
-				"<span class=\"hot\">{impact}</span> in redundant work — "
+				"<span class=\"hot\">{impact}</span> in redundant work "
 				"{title}"
 			).format(impact=impact_html, title=title)
 	else:
-		# Fallback — verbatim title with the impact called out.
+		# Fallback verbatim title with the impact called out.
 		headline = Markup(
 			"<span class=\"hot\">{impact}</span> &middot; {title}"
 		).format(impact=impact_html, title=title)
@@ -1913,7 +1913,7 @@ def _build_executive_summary(
 
 	Shape: ``{"headline": Markup, "bullets": list[str], "show": bool}``
 
-	``show`` is False when there's nothing meaningful to summarize —
+	``show`` is False when there's nothing meaningful to summarize
 	e.g. a clean session with no findings. The template renders the
 	card only when ``show`` is True.
 	"""
@@ -1921,7 +1921,7 @@ def _build_executive_summary(
 	total_queries = getattr(session_doc, "total_queries", 0) or 0
 	total_actions = getattr(session_doc, "total_requests", 0) or 0
 
-	# Headline — describes the session at a glance.
+	# Headline describes the session at a glance.
 	if total_ms >= 5000:
 		pace = "slow"
 	elif total_ms >= 2000:
@@ -1933,15 +1933,15 @@ def _build_executive_summary(
 		round(total_queries / total_actions, 1) if total_actions else 0
 	)
 	# v0.7.x: honour the timing rule for the headline duration. The
-	# helper returns Markup (always — for ms / s / "0ms" branches), so
-	# we build the headline as Markup.format(...) — that escapes the
+	# helper returns Markup (always for ms / s / "0ms" branches), so
+	# we build the headline as Markup.format(...) that escapes the
 	# plain-string args while passing the Markup duration through
 	# unchanged, keeping the <span class="time-high">…</span> intact
 	# under Jinja autoescape.
 	duration_html = _format_duration_ms(total_ms, large_duration_threshold_ms)
 	headline = Markup(
 		"This session took {duration} across {actions} operation{plural} "
-		"— {queries} database queries, ~{qpa} per operation."
+		" {queries} database queries, ~{qpa} per operation."
 	).format(
 		duration=duration_html,
 		actions=total_actions,
@@ -1964,13 +1964,13 @@ def _build_executive_summary(
 		impact = f.get("estimated_impact_ms") or 0
 		title = f.get("title") or "Finding"
 		# v0.6.x: append the target document and the doc-event lifecycle hook
-		# when known, so the bullet says e.g. "… — Sales Invoice SINV-1
+		# when known, so the bullet says e.g. "… Sales Invoice SINV-1
 		# (during the validate hook)" instead of just the action name.
 		_detail = f.get("technical_detail") or {}
 		_td = _detail.get("target_doc") or {}
 		_hevs = _detail.get("hook_events") or []
 		if _td.get("doctype"):
-			title += " — " + _td["doctype"] + (" " + _td["name"] if _td.get("name") else "")
+			title += ": " + _td["doctype"] + (" " + _td["name"] if _td.get("name") else "")
 		if _hevs:
 			title += " (during the " + str(_hevs[0].get("event") or "") + " hook)"
 		bullets.append({
@@ -1979,7 +1979,7 @@ def _build_executive_summary(
 			"severity": f.get("severity") or "Low",
 		})
 
-	# Infra signal — if swap was active or memory grew >50MB, call it out.
+	# Infra signal if swap was active or memory grew >50MB, call it out.
 	infra_summary = v5.get("infra_summary") or {}
 	rss_delta_mb = round((infra_summary.get("rss_delta") or 0) / 1_000_000, 0)
 	swap_mb = infra_summary.get("swap_peak_mb") or 0
@@ -2009,7 +2009,7 @@ def _build_executive_summary(
 # analyzers (when they can resolve a blame frame). We bucket findings by
 # their top-level app segment so the report reads as:
 #
-#   Findings — what to fix
+#   Findings what to fix
 #     ▸ myapp (3 findings, ~420ms)
 #         N+1 in ...
 #         Missing index on ...
@@ -2076,7 +2076,7 @@ def _is_framework_app(filename_or_app, tracked_apps: tuple[str, ...] = ()) -> bo
 	"""Tiny adapter around ``analyzers.base.is_framework_callsite`` that accepts
 	any of: (a) a callsite filename (passed through), (b) a bare app name like
 	``"frappe"``, or (c) a dotted Python module/method like
-	``"frappe.desk.form.save.savedocs"`` — both (b) and (c) are normalised to
+	``"frappe.desk.form.save.savedocs"``: both (b) and (c) are normalised to
 	``"<app>/x.py"`` so the boundary-sensitive substring checks in
 	``is_framework_callsite`` fire. Falsy/missing input → ``False`` (treat as
 	user code so unattributable rows aren't penalised).
@@ -2092,7 +2092,7 @@ def _is_framework_app(filename_or_app, tracked_apps: tuple[str, ...] = ()) -> bo
 		return False
 	norm = val.replace("\\", "/")
 	if "/" not in norm:
-		# Bare app name OR dotted module path — take the first dotted
+		# Bare app name OR dotted module path take the first dotted
 		# segment (the top-level package) and synthesise a path so the
 		# substring checks against ``<app>/`` fire.
 		first = norm.split(".", 1)[0]
@@ -2119,7 +2119,7 @@ def _app_from_finding(finding: dict) -> str:
 	"""Return the top-level app name for a finding, or ``_OTHER_APP_LABEL``.
 
 	Inspects ``technical_detail.callsite.filename`` using the same
-	boundary-sensitive split as the framework classifier — the goal is
+	boundary-sensitive split as the framework classifier the goal is
 	that the app name shown in the sub-section header matches what
 	``is_framework_callsite`` would see.
 
@@ -2152,7 +2152,7 @@ def _bucket_findings_by_app(
 	1. Tracked apps first, in the order the admin listed them in
 	   Optimus Settings (user's mental model: "my apps first").
 	2. Any other apps next, sorted by total estimated impact desc.
-	3. ``_OTHER_APP_LABEL`` (no resolvable callsite) last — always the
+	3. ``_OTHER_APP_LABEL`` (no resolvable callsite) last always the
 	   tail bucket because its contents are less actionable.
 	"""
 	if not findings:
@@ -2196,13 +2196,13 @@ def _bucket_findings_by_app(
 	remainder.sort(key=lambda a: (-_impact(a), a))
 	ordered.extend(remainder)
 
-	# Tail buckets — user-app findings come first.
+	# Tail buckets user-app findings come first.
 	# "Request hotspots" (hot-path findings that lost their callsite to
 	# pyinstrument's collapsing but are still typed) is kept; the
 	# generic "Other (no callsite)" bucket is suppressed entirely
 	# (v0.7.x). Findings binned into that label are typically the
 	# residue of analyzer paths that couldn't attach a representative
-	# callsite — surfacing them as a generic tail bucket added noise
+	# callsite surfacing them as a generic tail bucket added noise
 	# without an actionable file:line for the developer.
 	if _HOTPATH_BUCKET_LABEL in buckets:
 		ordered.append(_HOTPATH_BUCKET_LABEL)
@@ -2230,7 +2230,7 @@ def _now_iso() -> str:
 
 
 # v0.10.0+: duration + datetime formatting moved to
-# optimus/renderer/time_format.py — see top-of-file import.
+# optimus/renderer/time_format.py see top-of-file import.
 
 
 # ---------------------------------------------------------------------------
@@ -2241,7 +2241,7 @@ HARDCODED_ALLOWED_PREFIXES = ("frappe.", "erpnext.", "payments.", "hrms.")
 
 
 # v0.5.2: finding types that carry a concrete, user-actionable fix.
-# These render in the main "Findings — what to fix" section.
+# These render in the main "Findings what to fix" section.
 # Everything else (framework-level, system-level, informational)
 # renders in a separate "Observations" section below so the action
 # list stays tight.
@@ -2252,7 +2252,7 @@ HARDCODED_ALLOWED_PREFIXES = ("frappe.", "erpnext.", "payments.", "hrms.")
 # finding is an observation about the system or framework where the
 # user has no direct code change to make, it's an Observation.
 _ACTIONABLE_FINDING_TYPES = frozenset({
-	# SQL — all have concrete DDL / refactor guidance
+	# SQL all have concrete DDL / refactor guidance
 	"N+1 Query",
 	"Missing Index",
 	"Full Table Scan",
@@ -2265,21 +2265,21 @@ _ACTIONABLE_FINDING_TYPES = frozenset({
 	"Hook Bottleneck",     # user's own doc-event hook is slow
 	"Slow Background Job", # BG-job fallback finding (v0.7.x)
 	"Redundant Call",      # v0.5.2: framework callsites already filtered
-	# Frontend — user can trim responses / optimize JS
+	# Frontend user can trim responses / optimize JS
 	"Slow Frontend Render",
 	"Heavy Response",
 	# v0.6.0 phase-2 line profiler
 	"Hot Line",            # one source line concentrates the function's time
 })
 # Observation-only finding types (informational, no direct fix):
-#   Framework N+1            — loop inside frappe/*
-#   Repeated Hot Frame       — function repeated across actions; needs
+#   Framework N+1 loop inside frappe/*
+#   Repeated Hot Frame function repeated across actions; needs
 #                               investigation, not a shippable fix
-#   Resource Contention      — system CPU sustained high
-#   Memory Pressure          — worker RSS growth / swap
-#   DB Pool Saturation       — infra-level
-#   Background Queue Backlog — infra-level
-#   Network Overhead         — client/proxy territory, not user code
+#   Resource Contention system CPU sustained high
+#   Memory Pressure worker RSS growth / swap
+#   DB Pool Saturation infra-level
+#   Background Queue Backlog infra-level
+#   Network Overhead client/proxy territory, not user code
 
 
 # v0.10.0+: redact_frame_name + build_donut_data + build_donut_svg +
@@ -2291,6 +2291,6 @@ _ACTIONABLE_FINDING_TYPES = frozenset({
 # re-imported at the top of this file.)
 
 
-# (build_donut_svg / build_hot_frames_table removed — they live in
+# (build_donut_svg / build_hot_frames_table removed they live in
 # optimus/renderer/visualization.py and are re-imported at the top
 # of this file.)

--- a/optimus/renderer/call_tree_renderer.py
+++ b/optimus/renderer/call_tree_renderer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Call-tree panel renderer — the hierarchical "where did wall-clock time go"
+"""Call-tree panel renderer the hierarchical "where did wall-clock time go"
 section of the safe report.
 
 Sourced from the slowest action's ``call_tree_json`` (built by the
@@ -9,7 +9,7 @@ analyzer); rendered as nested ``<details>`` elements with auto-open
 breadcrumb down to the user-app's first hot frame and depth-capped
 expanders past ``_CALL_TREE_MAX_DEPTH``. Synthetic placeholder nodes
 (``[other: N frames]``, ``[N more frames omitted]``) and ``<sql>``
-query leaves are dropped from the visible tree per user request — the
+query leaves are dropped from the visible tree per user request the
 queries live in their own table-shaped sections; this panel shows only
 the Python hierarchy.
 
@@ -31,7 +31,7 @@ import re
 _CALL_TREE_MAX_DEPTH = 12
 _CALL_TREE_HARD_CAP = 64
 # v0.13: the panel renders the top-N slowest actions' call trees, not just the
-# single slowest — so a flat #1 action (e.g. an RQ job that just loops one
+# single slowest so a flat #1 action (e.g. an RQ job that just loops one
 # function) doesn't hide the deep, structurally-rich trees of the next-slowest
 # actions in the same session.
 _CALL_TREE_MAX_ACTIONS = 3
@@ -42,7 +42,7 @@ _CT_OTHER_RE = re.compile(
 
 
 def _e(text: object) -> str:
-	"""HTML-escape. Local copy of ``_internal._e`` — keeps this
+	"""HTML-escape. Local copy of ``_internal._e``: keeps this
 	submodule free of a back-reference into ``_internal.py`` (which
 	would create a circular import once ``_internal`` re-imports the
 	call-tree symbols)."""
@@ -52,7 +52,7 @@ def _e(text: object) -> str:
 
 
 def _ct_is_other_frame(fn) -> bool:
-	"""A synthetic call-tree collapse node — either ``[other: N frames]`` or the
+	"""A synthetic call-tree collapse node either ``[other: N frames]`` or the
 	analyzer's deep-tree pruning placeholder ``[N more frames omitted]``
 	(call_tree.py). Both are dropped from the call tree per user request: they
 	carry no callsite to act on, so they're just noise."""
@@ -61,7 +61,7 @@ def _ct_is_other_frame(fn) -> bool:
 
 def _ct_is_sql_leaf(node) -> bool:
 	"""A ``<sql>`` query leaf frame. Dropped from the call-tree display per
-	user request — the tree shows only the Python hierarchy; the queries
+	user request the tree shows only the Python hierarchy; the queries
 	themselves live, itemised, in the Slowest-queries / per-action sections,
 	so nothing is lost. (The analyzer still keeps these in ``call_tree_json``.)"""
 	cn = node or {}
@@ -102,7 +102,7 @@ def _render_call_tree_node(node, parent_ms, depth=0, unlimited=False, breadcrumb
 		return ""
 	fn = node.get("function") or "<?>"
 	# v0.7.x: drop synthetic "[other: N frames]" collapse nodes entirely (user
-	# request — accepts that a branch's visible children may not sum to its total).
+	# request accepts that a branch's visible children may not sum to its total).
 	if _ct_is_other_frame(fn):
 		return ""
 	file = node.get("filename") or ""
@@ -165,7 +165,7 @@ def _render_call_tree_node(node, parent_ms, depth=0, unlimited=False, breadcrumb
 				))
 			out.append('</div>')
 		elif within_hard:
-			# Past default cap — click-to-expand the rest of the
+			# Past default cap click-to-expand the rest of the
 			# subtree. ``unlimited=True`` prevents further wrapping
 			# at every nested level.
 			out.append(
@@ -236,7 +236,7 @@ def _render_call_tree_panel(actions):
 	carries a renderable tree (the template's ``{% if %}`` guard hides the
 	section).
 
-	Was: the single slowest action only — which hid the deep, structurally
+	Was: the single slowest action only which hid the deep, structurally
 	rich trees of every other slow action (a flow whose #1 action is a flat
 	RQ loop surfaced no hierarchy). Now the ``_CALL_TREE_MAX_ACTIONS``
 	slowest actions are each rendered as their own labeled sub-tree.

--- a/optimus/renderer/doc_event_renderer.py
+++ b/optimus/renderer/doc_event_renderer.py
@@ -12,7 +12,7 @@ lifecycle" report sections.
 Two public surfaces (both called from the render orchestrator in
 ``_internal.py``):
 
-* ``_attach_action_context(actions, findings, recordings_by_uuid)`` —
+* ``_attach_action_context(actions, findings, recordings_by_uuid)``:
   in-place enrichment of ``action["target_doc"]``,
   ``finding["technical_detail"]["target_doc"]``, and
   ``finding["technical_detail"]["hook_events"]``. Also rewrites
@@ -20,7 +20,7 @@ Two public surfaces (both called from the render orchestrator in
   ``action["entry_callsite"]["function"]`` / the matching
   ``finding["customer_description"]`` italicised phrase to carry the
   DocType suffix.
-* ``_build_doc_event_breakdown(findings)`` — pure-function transform
+* ``_build_doc_event_breakdown(findings)``: pure-function transform
   that groups findings by DocType → lifecycle event for the
   "Doc-event lifecycle" report section.
 
@@ -38,7 +38,7 @@ import json
 # Constants
 # ---------------------------------------------------------------------------
 
-# Frappe's doc-event lifecycle method names — a function whose bare name is one
+# Frappe's doc-event lifecycle method names a function whose bare name is one
 # of these AND whose file is a controller (``.../doctype/<scrub>/<scrub>.py``)
 # is a lifecycle override.
 _LIFECYCLE_EVENTS = frozenset({
@@ -81,7 +81,7 @@ def _doctype_from_controller_path(filename) -> str | None:
 	"""``erpnext/accounts/doctype/sales_invoice/sales_invoice.py`` → ``"Sales Invoice"``
 	(the segment right after ``doctype/``, un-scrubbed). Works on app-relative,
 	bench-relative, and absolute paths. ``None`` for non-controller paths. NB:
-	``.title()`` mangles multi-cap names ("gl_entry" → "Gl Entry") — same as
+	``.title()`` mangles multi-cap names ("gl_entry" → "Gl Entry") same as
 	``frappe.unscrub``; accepted."""
 	if not filename:
 		return None
@@ -105,7 +105,7 @@ def _doctype_from_controller_path(filename) -> str | None:
 
 def _extract_target_doc(form_dict) -> dict | None:
 	"""Best-effort: pull ``{"doctype", "name"}`` out of a request's form_dict
-	for doc-mutating endpoints — ``savedocs`` / ``frappe.client.save|insert|submit``
+	for doc-mutating endpoints ``savedocs`` / ``frappe.client.save|insert|submit``
 	(a ``doc`` JSON string or dict), ``run_doc_method`` (``dt``/``dn`` or a
 	``docs`` JSON), ``apply_workflow`` (``doc``), or bare ``doctype``/``name``
 	fields. ``name`` may be a temp name ("new-…") or ``None`` for an unsaved
@@ -169,7 +169,7 @@ def _saved_doc_from_response(response, want_doctype, client_name=None):
 			# Real name = the response name the save assigned, i.e. one that differs
 			# from the browser's temp name. Comparing to the actual temp name (not a
 			# "new-" prefix guess) keeps a genuine "new-0001" from being discarded.
-			# Accept a str OR an int (autoincrement naming assigns an integer name — a
+			# Accept a str OR an int (autoincrement naming assigns an integer name a
 			# standard Frappe option); reject bool and any non-scalar (dict/list/float)
 			# so a malformed response can't stamp a garbage string as the docname.
 			if isinstance(nm, str) or (isinstance(nm, int) and not isinstance(nm, bool)):
@@ -192,8 +192,8 @@ def resolve_target_doc_from_response(form_dict, response):
 
 
 def _build_doc_event_hook_index(doc_events) -> dict:
-	"""Flatten Frappe's ``doc_events`` map — ``{doctype: {event: [paths]}}``
-	(``doctype`` may be ``"*"``) — into ``{dotted_path: [(doctype, event), …]}``.
+	"""Flatten Frappe's ``doc_events`` map ``{doctype: {event: [paths]}}``
+	(``doctype`` may be ``"*"``) into ``{dotted_path: [(doctype, event), …]}``.
 	Pure. Empty on bad input."""
 	index: dict[str, list[tuple[str, str]]] = {}
 	if not isinstance(doc_events, dict):
@@ -213,7 +213,7 @@ def _build_doc_event_hook_index(doc_events) -> dict:
 
 
 def _doc_event_hook_index() -> dict:
-	"""``_build_doc_event_hook_index(frappe.get_hooks("doc_events"))`` — or ``{}``
+	"""``_build_doc_event_hook_index(frappe.get_hooks("doc_events"))``: or ``{}``
 	when frappe isn't available (e.g. unit tests with no running site)."""
 	try:
 		import frappe
@@ -260,11 +260,11 @@ def _finding_hook_events(detail, hook_index, *, action_doctype: str | None = Non
 def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 	"""Enrich ``actions`` and ``findings`` (in place):
 
-	  * ``action["target_doc"]`` — the document a save/submit-style action
+	  * ``action["target_doc"]``: the document a save/submit-style action
 	    touched (from the recording's form_dict), or ``None``.
-	  * ``finding["technical_detail"]["target_doc"]`` — same, via the finding's
+	  * ``finding["technical_detail"]["target_doc"]``: same, via the finding's
 	    ``action_ref`` → action (key omitted when there's no doc).
-	  * ``finding["technical_detail"]["hook_events"]`` — the doc-event lifecycle
+	  * ``finding["technical_detail"]["hook_events"]``: the doc-event lifecycle
 	    hook(s) the finding's hot function fired in (``[{doctype,event}, …]``);
 	    key omitted when the function isn't a registered ``doc_events`` hook.
 	"""
@@ -298,7 +298,7 @@ def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 						"name": _resolved.get("name"),
 					}
 		# v0.7.x J.13: fallback when the recording isn't available
-		# (Redis TTL expired between record-time and regenerate-time) —
+		# (Redis TTL expired between record-time and regenerate-time)
 		# infer the action's DocType from any related finding's callsite
 		# filepath via the controller-path mapping
 		# (e.g. ``erpnext/.../sales_invoice/sales_invoice.py`` → "Sales Invoice").
@@ -333,7 +333,7 @@ def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 			a["path"] = f"{_a_path} ({_td_doctype})"
 		# v0.7.x J.11: enrich the entry-callsite `function` so the small
 		# `.action-meta` line under each action row reads
-		# `…/save.py:16 · savedocs (Sales Invoice)` — keeps every filepath
+		# `…/save.py:16 · savedocs (Sales Invoice)`: keeps every filepath
 		# surface in the report consistently tagged with its DocType.
 		_ec = a.get("entry_callsite")
 		if _td_doctype and isinstance(_ec, dict):
@@ -358,7 +358,7 @@ def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 			# v0.7.x J.7: inject the DocType inline at the end of the
 			# italicised action-label phrase so the reader sees
 			# "During *frappe.desk.form.save.savedocs:Save (Sales Invoice)*"
-			# instead of "During *frappe.desk.form.save.savedocs:Save*" —
+			# instead of "During *frappe.desk.form.save.savedocs:Save*"
 			# keeps the technical label and the doctype emphasised together
 			# inside one self-contained italic phrase. Guards on the
 			# `"During *…*"` prose shape so self-referential / non-action
@@ -381,7 +381,7 @@ def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 
 
 # ---------------------------------------------------------------------------
-# v0.6.x: "Doc-event lifecycle" section — re-group the slow call-tree findings
+# v0.6.x: "Doc-event lifecycle" section re-group the slow call-tree findings
 # by DocType → lifecycle event (validate / on_submit / …), tagging each as a
 # registered ``doc_events`` hook vs a controller method override, and surfacing
 # cascaded DocTypes (e.g. GL Entry touched during a Sales Invoice submit).
@@ -391,11 +391,11 @@ def _attach_action_context(actions, findings, recordings_by_uuid) -> None:
 
 
 def _finding_lifecycle_bindings(finding) -> list[tuple[str, str, str]]:
-	"""Return ``[(doctype, event, kind), …]`` — the doc-event lifecycle slots a
+	"""Return ``[(doctype, event, kind), …]``: the doc-event lifecycle slots a
 	finding belongs to (usually 0 or 1). ``kind`` is ``_KIND_DOC_EVENTS_HOOK``
 	(from the finding's already-resolved ``technical_detail.hook_events``) or
 	``_KIND_CONTROLLER_OVERRIDE`` (function name is a lifecycle event AND its
-	file is a controller). Deduped by ``(doctype, event)`` — hook bindings first.
+	file is a controller). Deduped by ``(doctype, event)``: hook bindings first.
 	Empty when the finding isn't a lifecycle method (a generic Slow Hot Path on
 	a helper, an N+1 with no controller callsite, …)."""
 	if not isinstance(finding, dict):
@@ -477,7 +477,7 @@ def _build_doc_event_breakdown(findings) -> dict:
 				rec["count"] += 1
 				if _SEVERITY_RANK.get(severity, 0) > _SEVERITY_RANK.get(rec["severity"], 0):
 					rec["severity"] = severity
-				# A controller override is the more specific label — prefer it.
+				# A controller override is the more specific label prefer it.
 				if kind == _KIND_CONTROLLER_OVERRIDE:
 					rec["kind"] = kind
 

--- a/optimus/renderer/finding_enrichment.py
+++ b/optimus/renderer/finding_enrichment.py
@@ -1,31 +1,31 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Finding enrichment helpers — extracted from ``_internal.py``
+"""Finding enrichment helpers extracted from ``_internal.py``
 incrementally to keep the renderer-package boundary clean.
 
 Two phases shipped so far:
 
-  * **Phase 1 (v0.12.16)** — three pure-function helpers with
+  * **Phase 1 (v0.12.16)**: three pure-function helpers with
     minimal back-coupling to ``_internal.py``:
-    - ``_root_cause_key(finding)`` — ``(basename, function)``
+    - ``_root_cause_key(finding)``: ``(basename, function)``
       deepest-user-code anchor for finding grouping.
-    - ``_group_findings_by_root_cause(findings)`` — collapse
+    - ``_group_findings_by_root_cause(findings)``: collapse
       same-root-cause findings into one primary +
       ``sub_findings`` list.
-    - ``_normalize_callsite(callsite)`` — dict-or-string callsite
+    - ``_normalize_callsite(callsite)``: dict-or-string callsite
       shape normalization.
 
-  * **Phase 2 (v0.12.19)** — the drill-down chain attachers (a
+  * **Phase 2 (v0.12.19)**: the drill-down chain attachers (a
     self-contained sub-cluster of the larger finding-enrichment
     family that depends only on stdlib + ``call_tree_renderer.
     _ct_is_other_frame`` + a lazy ``optimus.analyzers.base.
     is_framework_callsite`` import):
-    - ``_find_node_in_tree(tree, basename, function)`` — DFS for
+    - ``_find_node_in_tree(tree, basename, function)``: DFS for
       a node by (basename, function).
-    - ``_walk_drilldown_chain(tree, callsite, ...)`` — hottest-
+    - ``_walk_drilldown_chain(tree, callsite, ...)``: hottest-
       child traversal below a finding's origin frame.
-    - ``_attach_drilldown_chains(findings, actions, ...)`` —
+    - ``_attach_drilldown_chains(findings, actions, ...)``:
       in-place attachment of the chain onto each finding's
       ``technical_detail``.
 
@@ -66,16 +66,16 @@ def _root_cause_key(finding: dict) -> tuple | None:
 	Resolution order:
 
 	1. If the finding has a non-empty ``drilldown_chain``, use the
-	   chain's last entry — that's the deepest user-code frame the
+	   chain's last entry that's the deepest user-code frame the
 	   drill-down walker found. Stable across all per-action analyzer
 	   findings (Slow Hot Path, Hook Bottleneck, ...).
 
 	2. Else use the callsite's own ``(filename, function)``. This is
 	   the path most analyzer findings (Hot Line, Redundant Call,
-	   N+1, etc.) take — their callsite already names the leaf.
+	   N+1, etc.) take their callsite already names the leaf.
 
 	Returns ``None`` only when the finding has no usable callsite at
-	all (e.g. infra/system observations) — those don't group.
+	all (e.g. infra/system observations) those don't group.
 
 	Match is by ``(os.path.basename(filename), function)`` so
 	dev-vs-deploy absolute path differences don't fragment groups.
@@ -111,7 +111,7 @@ def _group_findings_by_root_cause(findings: list[dict]) -> list[dict]:
 	``sub_findings``.
 
 	One root cause (e.g. a hot get_doc call inside ``_check_user_exists``)
-	commonly triggers several different finding types — a Slow Hot Path
+	commonly triggers several different finding types a Slow Hot Path
 	at the wrapper, a Hot Line on the exact line, a Redundant Call for
 	the doc, a Redundant Permission Check for its read perm. Today each
 	renders as its own card; the dev only has ONE fix to make and the
@@ -119,7 +119,7 @@ def _group_findings_by_root_cause(findings: list[dict]) -> list[dict]:
 	highest-impact finding becomes the visible card; the others appear
 	as collapsible sub-rows beneath it.
 
-	Returns a NEW list — primaries kept (with ``sub_findings`` attached
+	Returns a NEW list primaries kept (with ``sub_findings`` attached
 	when applicable), grouped non-primaries dropped, ungrouped findings
 	(no resolvable root cause) passed through as-is.
 
@@ -210,7 +210,7 @@ def _normalize_callsite(callsite) -> dict | None:
 	if isinstance(callsite, dict):
 		return callsite
 	if isinstance(callsite, str):
-		# Shape: "file.py:lineno" — split from the RIGHT so Windows
+		# Shape: "file.py:lineno" split from the RIGHT so Windows
 		# paths ("C:\\foo\\bar.py:12") keep their drive letter.
 		filename = callsite
 		lineno: int | None = None
@@ -223,7 +223,7 @@ def _normalize_callsite(callsite) -> dict | None:
 				except ValueError:
 					lineno = None
 		return {"filename": filename, "lineno": lineno, "function": ""}
-	# Unknown shape — log-worthy but don't crash. Return None so the
+	# Unknown shape log-worthy but don't crash. Return None so the
 	# template skips the Callsite block entirely.
 	return None
 
@@ -284,12 +284,12 @@ def _walk_drilldown_chain(
 	  origin's ``cumulative_ms`` (drops noisy near-leaf frames).
 
 	Returns a list of ``{filename, lineno, function, cumulative_ms,
-	pct_of_origin}`` dicts — one per level *below* the origin. The origin
+	pct_of_origin}`` dicts one per level *below* the origin. The origin
 	itself is omitted (already rendered in the smoking-gun block).
 
 	Defensive: any malformed input → ``[]``.
 	"""
-	# Lazy imports — these belong to sibling modules; importing at
+	# Lazy imports these belong to sibling modules; importing at
 	# module-top would create a circular if call_tree_renderer ever
 	# grew a dependency on this submodule.
 	from optimus.analyzers.base import is_framework_callsite
@@ -303,7 +303,7 @@ def _walk_drilldown_chain(
 		return []
 
 	# If the finding's own callsite is already in framework code, the chain
-	# below would be even further from user-actionable code — skip.
+	# below would be even further from user-actionable code skip.
 	if is_framework_callsite(filename, tracked_apps=tracked_apps or None):
 		return []
 
@@ -323,7 +323,7 @@ def _walk_drilldown_chain(
 		if not children:
 			break
 		# Pick the hottest child by cumulative_ms, skipping synthetic
-		# "[other: N frames]" collapse nodes (v0.7.x: not shown in chains —
+		# "[other: N frames]" collapse nodes (v0.7.x: not shown in chains
 		# you can't drill into a collapsed bucket).
 		hottest = max(
 			(c for c in children
@@ -354,7 +354,7 @@ def _walk_drilldown_chain(
 def _attach_drilldown_chains(findings, actions, tracked_apps: tuple[str, ...] = ()) -> None:
 	"""Walk each finding's representative call tree and attach a
 	``drilldown_chain`` to its ``technical_detail`` dict. Mutates findings in
-	place — same pattern as ``_attach_representative_callsites``.
+	place same pattern as ``_attach_representative_callsites``.
 
 	Tree JSON parses are cached per ``action_idx`` so a session with several
 	findings on the same slow action only deserialises the tree once.
@@ -396,7 +396,7 @@ def _attach_drilldown_chains(findings, actions, tracked_apps: tuple[str, ...] = 
 		if not tree:
 			continue
 		chain = _walk_drilldown_chain(tree, callsite, tracked_apps=tracked_apps)
-		# v0.7.x: always attach the chain — even empty. The template
+		# v0.7.x: always attach the chain even empty. The template
 		# distinguishes "key absent" (no callsite/action/tree, never
 		# attempted) from "empty list" (attempted but no eligible
 		# user-code descendants) to decide whether to render a "no
@@ -410,13 +410,13 @@ def _attach_drilldown_chains(findings, actions, tracked_apps: tuple[str, ...] = 
 # attacher + self-time snippet expander + phase-1 callsite retargeter +
 # their helpers (markdown-to-html, function-body snippet reader, AST
 # call-line finder). The HIGH-coupling subset that was deferred from
-# phases 1 + 2 — now ships because v0.12.23's source_resolution.py
+# phases 1 + 2 now ships because v0.12.23's source_resolution.py
 # extraction supplied the dependency.
 # ---------------------------------------------------------------------------
 
 # v0.6.x: SQL "red flag" findings (Missing Index, Full Table Scan, Filesort,
 # Temporary Table, Low Filter Ratio) are keyed by (finding_type, table) and
-# carry no callsite — the offending query is issued from many places. At
+# carry no callsite the offending query is issued from many places. At
 # render time we still have the recordings, so we pick a *representative*
 # callsite: the hottest user-app frame among the calls whose normalized query
 # matches the finding's. Surfaced as "Most-called from:" with a
@@ -439,14 +439,14 @@ def _find_call_line_in_function_body(
 	``parent_filename``. ``None`` if the source can't be read or no call
 	is found.
 
-	AST primary — locates the matching ``FunctionDef`` / ``AsyncFunctionDef``
+	AST primary locates the matching ``FunctionDef`` / ``AsyncFunctionDef``
 	node by name/lineno, then walks its body for ``Call`` expressions
 	whose target resolves to ``callee_function`` (matches both bare
 	``callee_function(...)`` via ``Name`` and ``obj.callee_function(...)``
 	via ``Attribute``).
 
 	Regex fallback when AST parse fails (truncated file, syntax error
-	elsewhere) — scans lines below the def for ``\\b<callee>\\s*\\(``
+	elsewhere) scans lines below the def for ``\\b<callee>\\s*\\(``
 	stopping at a same-or-lower indented ``def `` / ``class `` /
 	``async def `` or after 200 lines.
 
@@ -478,7 +478,7 @@ def _find_call_line_in_function_body(
 
 	if tree is not None:
 		# Find the function def closest to parent_def_lineno (defensive
-		# against the parent being a nested function — pick by name match
+		# against the parent being a nested function pick by name match
 		# AND minimum lineno distance).
 		candidates: list[_ast.AST] = []
 		for node in _ast.walk(tree):
@@ -486,7 +486,7 @@ def _find_call_line_in_function_body(
 				candidates.append(node)
 		if candidates:
 			# Filter by lineno proximity to the recorded def lineno (within
-			# a few lines is usually enough — pyinstrument's lineno can
+			# a few lines is usually enough pyinstrument's lineno can
 			# be the def or the first executed line of the body).
 			best = min(
 				candidates,
@@ -527,7 +527,7 @@ def _find_call_line_in_function_body(
 	for i in range(parent_def_lineno, max_scan):
 		raw = lines[i]
 		# Strip trailing # comments naively (string-aware comment
-		# stripping is overkill here — the worst case is a false
+		# stripping is overkill here the worst case is a false
 		# negative which falls back to the def-line behavior).
 		hash_idx = raw.find("#")
 		body = raw if hash_idx < 0 else raw[:hash_idx]
@@ -561,10 +561,10 @@ def _retarget_phase1_callsites_to_drilldown_leaf(
 	even that frame's ``def`` line is a function header rather than the
 	expensive call. The reader's eye lands on the most actionable info
 	when the snippet shows the **call expression** for the deepest
-	leaf — typically the line inside the **parent** of the deepest
+	leaf typically the line inside the **parent** of the deepest
 	frame that invokes it.
 
-	Phase-1 only — no phase-2 dependency. Hot Line / Function Not
+	Phase-1 only no phase-2 dependency. Hot Line / Function Not
 	Invoked findings (phase-2 native) are skipped. SQL "red flag"
 	findings whose callsite is a representative one are skipped too.
 
@@ -657,7 +657,7 @@ def _retarget_phase1_callsites_to_drilldown_leaf(
 		}
 		# If we anchored on a Server Script parent (its body is now readable, so
 		# call_lineno resolves and the anchor keeps the ``<serverscript>`` filename),
-		# tag it as a Desk link like _finding_to_dict does — otherwise the template
+		# tag it as a Desk link like _finding_to_dict does otherwise the template
 		# emits a broken ``vscode://file`` link built from the wrapper's real path.
 		if anchor_filename.startswith("<serverscript") or anchor_filename.startswith("<server-script"):
 			from optimus.server_script_source import desk_url, extract_script_name
@@ -673,15 +673,15 @@ def _markdown_to_safe_html(text) -> str:
 	"""Render Markdown → sanitized HTML for embedding in the report.
 
 	Mirrors the notes sanitization path (``frappe.utils.markdown`` +
-	``sanitize_html(..., always_sanitize=True)``). On ANY failure — Frappe
-	not importable, markdown/bleach hiccup — falls back to an HTML-escaped
+	``sanitize_html(..., always_sanitize=True)``). On ANY failure Frappe
+	not importable, markdown/bleach hiccup falls back to an HTML-escaped
 	``<pre>`` block so the report NEVER renders un-sanitized model output.
 
 	After sanitizing, fenced ``diff`` code blocks (which the AI-fix prompt
 	asks the model to use for before/after) get per-line ``dh-add`` /
 	``dh-del`` / ``dh-meta`` span wrappers so the report CSS can colour them
 	like a real diff. We only add ``<span>`` wrappers around already-escaped
-	text — nothing that could re-introduce unsafe markup.
+	text nothing that could re-introduce unsafe markup.
 	"""
 	from optimus.renderer.syntax import _highlight_diff_html
 
@@ -702,7 +702,7 @@ def _finding_to_dict(child, file_cache: dict | None = None) -> dict:
 
 	v0.6.0 Round 2: synthesize a unified ``callsite`` shape for findings
 	that store their location at the top level. Lazily attach a ±1 source
-	snippet to the callsite when one isn't already persisted — covers
+	snippet to the callsite when one isn't already persisted covers
 	(a) sessions analyzed before the analyze-time enrichment shipped,
 	(b) the synthesized callsites. The optional ``file_cache`` is shared
 	across all findings in the same render so a cluster of findings in
@@ -720,13 +720,13 @@ def _finding_to_dict(child, file_cache: dict | None = None) -> dict:
 	except Exception:
 		detail = {}
 	# A non-object blob (list / ``null``) would crash the ``detail.get()`` calls
-	# below — normalize so one bad finding can't take down the render.
+	# below normalize so one bad finding can't take down the render.
 	if not isinstance(detail, dict):
 		detail = {}
 
 	# Back-compat: backfill impact_scope_label for sessions analyzed before that
 	# field shipped, so the card's scope tag agrees with the TL;DR hero on
-	# re-render — but ONLY for findings that carry a loop-scoped magnitude
+	# re-render but ONLY for findings that carry a loop-scoped magnitude
 	# (loop_count / run_count). A pre-loop-scoping session stored
 	# estimated_impact_ms as the cross-request CUMULATIVE total; tagging that
 	# 'recoverable' (a loop-scoped claim) would misdescribe the number, so those
@@ -754,7 +754,7 @@ def _finding_to_dict(child, file_cache: dict | None = None) -> dict:
 	if "callsite" in detail:
 		detail["callsite"] = _normalize_callsite(detail.get("callsite"))
 
-	# v0.6.x: findings that name a function but carry no file:line — resolve
+	# v0.6.x: findings that name a function but carry no file:line resolve
 	# them so the smoking-gun block can render.
 	if not (detail.get("callsite") or {}).get("lineno"):
 		_ftype = child.finding_type or ""
@@ -776,7 +776,7 @@ def _finding_to_dict(child, file_cache: dict | None = None) -> dict:
 					"source_snippet": _read_source_snippet(_abs, _ln, cache=file_cache),
 				}
 
-	# Hot Line finding line_content windowing — keep the profiled text
+	# Hot Line finding line_content windowing keep the profiled text
 	# authoritative for the hot line itself.
 	callsite = detail.get("callsite") or {}
 	if (
@@ -865,7 +865,7 @@ def _attach_representative_callsites(findings, recordings, *, file_cache: dict |
 	red-flag findings by matching their normalized query against the recording
 	calls and picking the hottest user-app frame. Mutates ``findings`` (the
 	``_finding_to_dict`` output dicts) in place. No-op when there are no such
-	findings, no recordings, or nothing matches — those cards just render
+	findings, no recordings, or nothing matches those cards just render
 	without the block.
 	"""
 	from optimus.renderer.source import _read_source_snippet, _resolve_source_path
@@ -946,7 +946,7 @@ def _snippet_row(lines: list[str], idx: int, limit: int) -> dict:
 # A ``def`` / ``async def`` line (any indent, tab or space).
 _DEF_RE = re.compile(r"^[ \t]*(?:async[ \t]+)?def[ \t]")
 # A ``class`` line. A decorator block that reaches a ``class`` before a ``def``
-# is a class header, not a function's — stop rather than grab a method inside.
+# is a class header, not a function's stop rather than grab a method inside.
 _CLASS_RE = re.compile(r"^[ \t]*class[ \t]")
 # Cap on how far a decorator block may reach before its ``def`` (stacked and/or
 # multi-line decorators). Generous; real whitelisted endpoints use one or two.
@@ -954,7 +954,7 @@ _MAX_DECORATOR_BLOCK_LINES = 25
 
 
 def _find_header_def_line(lines: list[str], ln: int) -> int | None:
-	"""Lineno of the ``def`` for the header at ``lines[ln-1]`` — ``ln`` itself, or
+	"""Lineno of the ``def`` for the header at ``lines[ln-1]``: ``ln`` itself, or
 	(CPython 3.11+, where ``co_firstlineno`` is the first ``@decorator``) scanning
 	forward past the decorator block to it. None if ``ln`` is neither def nor
 	decorator, a ``class`` is hit first, or no ``def`` within the block cap."""
@@ -979,7 +979,7 @@ def _decorator_through_def_rows(
 	cache: dict | None = None,
 ) -> tuple[list[dict] | None, int]:
 	"""``(rows, def_lineno)`` spanning a self-time finding's recorded line through
-	the function's ``def`` — so the card shows the function name, not just a
+	the function's ``def``: so the card shows the function name, not just a
 	decorator (pyinstrument anchors a decorated fn at its first ``@decorator`` on
 	CPython 3.11+). ``def_lineno`` anchors the highlight; ``(None, lineno)`` when the
 	file can't be read / the line is out of range (caller keeps its snippet)."""
@@ -997,7 +997,7 @@ def _decorator_through_def_rows(
 
 	def_lineno = _find_header_def_line(lines, ln)
 	if def_lineno is None:
-		def_lineno = ln  # not a header line — show only the recorded line.
+		def_lineno = ln  # not a header line show only the recorded line.
 
 	limit = _SNIPPET_TRUNCATE_CHARS
 	rows = [_snippet_row(lines, i, limit) for i in range(ln, def_lineno + 1)]
@@ -1009,7 +1009,7 @@ def _expand_self_time_snippets(findings, *, file_cache: dict | None = None) -> N
 	(empty ``drilldown_chain``), narrow the smoking-gun snippet to the function's
 	signature line and flag it ``self_time_no_pinpoint``. Phase-1 sampling can't
 	pinpoint a single hot line inside the function, so dumping the whole body
-	(highlighting only the def) was a misleading wall of code — the card now
+	(highlighting only the def) was a misleading wall of code the card now
 	shows just the def + a note pointing the developer at a Line-Level Drilldown
 	on the function (which CAN give per-line timing).
 
@@ -1029,7 +1029,7 @@ def _expand_self_time_snippets(findings, *, file_cache: dict | None = None) -> N
 		ln = callsite.get("lineno")
 		if not fn or ln is None:
 			continue
-		# Flag drives the "no single hot line — run a Line-Level Drilldown" note.
+		# Flag drives the "no single hot line run a Line-Level Drilldown" note.
 		callsite["self_time_no_pinpoint"] = True
 		# ``ln`` is pyinstrument's frame line; on CPython 3.11+ a decorated
 		# function reports its FIRST decorator line (e.g. @frappe.whitelist()),

--- a/optimus/renderer/line_drilldown.py
+++ b/optimus/renderer/line_drilldown.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Line-Level Drilldown panel — the Phase-2 per-line profiling section.
+"""Line-Level Drilldown panel the Phase-2 per-line profiling section.
 
 Sourced from the session's ``phase_2_runs`` child table (one row per
 line-profile pass); each row carries a ``results_json`` blob shaped as
@@ -11,17 +11,17 @@ line-profile pass); each row carries a ``results_json`` blob shaped as
 Two public surfaces (called from the render orchestrator in
 ``_internal.py``):
 
-* ``_build_line_drilldown_callsite_index(session_doc)`` — semi-public:
+* ``_build_line_drilldown_callsite_index(session_doc)``: semi-public:
   ``optimus.analyze`` also calls it (via the renderer-package shim) to
   power the finding-card "Line-Level Drilldown hot line: ..." callout.
   Returns a ``(basename, function_name) → hottest-line`` dict.
-* ``_render_line_drilldown_panel(session_doc)`` — the section HTML.
+* ``_render_line_drilldown_panel(session_doc)``: the section HTML.
   Empty string when the session has no phase-2 runs.
 
-Plus four internal helpers — ``_make_line_drilldown_lookup`` (Jinja
+Plus four internal helpers ``_make_line_drilldown_lookup`` (Jinja
 adapter for tuple-keyed lookups), ``_phase2_invoked`` (per-function
 "did it run?" check), ``_render_phase2_function_table``,
-``_render_phase2_diff_table`` (per-function HTML pieces) — and two
+``_render_phase2_diff_table`` (per-function HTML pieces) and two
 back-compat aliases (``_build_phase2_callsite_index``,
 ``_make_phase2_lookup``, ``_render_phase2_panel``) that pre-v0.7.x
 renames left behind.
@@ -31,7 +31,7 @@ package roadmap. The 840-LOC line_drilldown cluster was the README's
 "single biggest remaining chunk." NB: ``_find_call_line_in_function_body``
 (an AST-walking helper used by ``_retarget_phase1_callsites_to_drilldown_leaf``
 which is part of the still-pending finding_enrichment cluster) stays
-in ``_internal.py`` for now — it'll move with that cluster, not this
+in ``_internal.py`` for now it'll move with that cluster, not this
 one. Same for ``_root_cause_key`` / ``_group_findings_by_root_cause``.
 """
 
@@ -47,7 +47,7 @@ from optimus.renderer.time_format import _format_duration_ms
 
 def _e(text: object) -> str:
 	"""HTML-escape. Local copy of ``_internal._e`` (same pattern as
-	``call_tree_renderer.py`` / ``doc_event_renderer.py``) — keeps this
+	``call_tree_renderer.py`` / ``doc_event_renderer.py``) keeps this
 	submodule free of a back-reference into ``_internal.py`` that would
 	create a circular import once ``_internal`` re-imports from here."""
 	import html as _html
@@ -56,7 +56,7 @@ def _e(text: object) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Callsite index — semi-public (analyze.py calls it via the package shim)
+# Callsite index semi-public (analyze.py calls it via the package shim)
 # ---------------------------------------------------------------------------
 
 
@@ -69,9 +69,9 @@ def _build_line_drilldown_callsite_index(session_doc: Any) -> dict:
 	Keyed by file basename (not absolute path) so the lookup survives
 	dev-vs-deploy path differences. When the same function appears in
 	multiple runs, the entry with the largest single-line ``total_ms``
-	wins — that's the most informative callout for the developer.
+	wins that's the most informative callout for the developer.
 
-	Per-function, own hottest line — no cross-function redirection.
+	Per-function, own hottest line no cross-function redirection.
 	The cross-link's job is "this function's hottest internal line";
 	the smoking-gun snippet's job (handled by
 	``_retarget_phase1_callsites_to_drilldown_leaf``) is "land the
@@ -118,7 +118,7 @@ def _build_line_drilldown_callsite_index(session_doc: Any) -> dict:
 			# v0.7.x: key under BOTH the full qualname and its bare last
 			# segment. resolve_freeform may emit a prefixed qualname
 			# (``common.bg_recheck_users`` / ``SalesInvoice.validate``) while a
-			# call_tree finding's callsite carries the bare function name — the
+			# call_tree finding's callsite carries the bare function name the
 			# callout silently missed when the two disagreed on the prefix even
 			# though the function was profiled (and showing in the panel).
 			basename = os.path.basename(file_path)
@@ -130,7 +130,7 @@ def _build_line_drilldown_callsite_index(session_doc: Any) -> dict:
 	return index
 
 
-# Back-compat alias — pre-v0.7.x name.
+# Back-compat alias pre-v0.7.x name.
 _build_phase2_callsite_index = _build_line_drilldown_callsite_index
 
 
@@ -144,7 +144,7 @@ def _make_line_drilldown_lookup(index: dict):
 		if not filename or not function_name:
 			return None
 		base = os.path.basename(filename)
-		# Try the function name as-is, then its bare last segment — mirrors the
+		# Try the function name as-is, then its bare last segment mirrors the
 		# dual keying in _build_line_drilldown_callsite_index so a prefix
 		# mismatch (qualname vs callsite function) can't break the callout.
 		return index.get((base, function_name)) or index.get((base, function_name.rsplit(".", 1)[-1]))
@@ -152,7 +152,7 @@ def _make_line_drilldown_lookup(index: dict):
 	return lookup
 
 
-# Back-compat alias — pre-v0.7.x name.
+# Back-compat alias pre-v0.7.x name.
 _make_phase2_lookup = _make_line_drilldown_lookup
 
 
@@ -195,7 +195,7 @@ def _render_phase2_function_table(fn: dict) -> str:
 	source = fn.get("source") or "curated"
 
 	# v0.7.x: a picked function that never ran (no lines, or all hits/total
-	# zero) renders nothing — the caller folds it into one "Not exercised in
+	# zero) renders nothing the caller folds it into one "Not exercised in
 	# this pass" note instead of a noisy empty per-line table.
 	if not _phase2_invoked(fn):
 		return ""
@@ -242,7 +242,7 @@ def _render_phase2_function_table(fn: dict) -> str:
 			tr_cls = ' class="zero"'
 		else:
 			tr_cls = ""
-		# `per_hit_us` is microseconds — convert to ms so the timing
+		# `per_hit_us` is microseconds convert to ms so the timing
 		# rule (1s threshold for the `.time-high` highlight) applies.
 		per_hit_ms = (line.get("per_hit_us") or 0) / 1000.0
 		_src_html = line.get("content_html")
@@ -263,7 +263,7 @@ def _render_phase2_function_table(fn: dict) -> str:
 
 def _render_phase2_diff_table(diff_rows: list[dict]) -> str:
 	"""Render the cross-run delta table for one function profiled in 2+
-	runs — the verify-the-fix view.
+	runs the verify-the-fix view.
 
 	v0.6.0 Round 7: source column always shows full code (was previously
 	gated by ``mode == "safe"`` + the safe-source toggle).
@@ -311,7 +311,7 @@ def _render_phase2_diff_table(diff_rows: list[dict]) -> str:
 			tr_cls = ' class="removed"'
 
 		def _fmt(v):
-			return "—" if v is None else (f"{v:.2f}" if isinstance(v, float) else str(v))
+			return "" if v is None else (f"{v:.2f}" if isinstance(v, float) else str(v))
 
 		_src_html = row.get("content_html")
 		_src = _src_html if _src_html else _e(row.get("content", ""))
@@ -433,7 +433,7 @@ def _render_line_drilldown_panel(session_doc: Any) -> str:
 		started = _e(run.get("started_at"))
 		status = _e(run.get("status", ""))
 		total_ms = run.get("total_ms", 0)
-		# v0.7.x: the "Picks:" line is dropped — the per-function tables below
+		# v0.7.x: the "Picks:" line is dropped the per-function tables below
 		# enumerate the picks that ran, and the "Not exercised in this pass" note
 		# lists the rest, so listing all picks again here is redundant.
 		html.append(
@@ -472,7 +472,7 @@ def _render_line_drilldown_panel(session_doc: Any) -> str:
 			"</p>"
 		)
 		for path, diff_meta in diffs.items():
-			label = f"{path} — Run {diff_meta['prev_run_idx'] + 1} → Run {diff_meta['curr_run_idx'] + 1}"
+			label = f"{path} Run {diff_meta['prev_run_idx'] + 1} → Run {diff_meta['curr_run_idx'] + 1}"
 			html.append(f'<div class="phase2-func"><div class="fn-name">{_e(label)}</div>')
 			html.append(_render_phase2_diff_table(diff_meta["rows"]))
 			html.append("</div>")
@@ -481,5 +481,5 @@ def _render_line_drilldown_panel(session_doc: Any) -> str:
 	return "".join(html)
 
 
-# Back-compat alias — pre-v0.7.x name.
+# Back-compat alias pre-v0.7.x name.
 _render_phase2_panel = _render_line_drilldown_panel

--- a/optimus/renderer/source.py
+++ b/optimus/renderer/source.py
@@ -8,20 +8,20 @@ that includes a source window, and every Phase-2 hot-line drilldown
 ultimately calls back here to read source lines from the bench's app
 files. Three responsibilities:
 
-  * **Path resolution** — :func:`_resolve_source_path` turns the
+  * **Path resolution**: :func:`_resolve_source_path` turns the
     app-relative paths recorded by the analyzer (``ugly_code/python/
     common.py``) into real absolute paths via ``frappe.get_app_path`` /
     bench fallback. Server Script callsites resolve to a tuple sentinel
     that downstream branches load from the ``tabServer Script`` DocType
     instead of disk.
 
-  * **Bench-boundary check** — :func:`_path_within_bench` is the Phase-K
+  * **Bench-boundary check**: :func:`_path_within_bench` is the Phase-K
     hardening guard: a synthetic callsite that points at ``/etc/passwd``
     (analyzer dict tampering, malformed pyinstrument frame) is refused.
     Bypassed under ``frappe.flags.in_test`` so pytest fixtures pointing
     at ``/tmp/...`` paths work.
 
-  * **Per-render file cache** — :class:`_BoundedFileCache` is the bounded
+  * **Per-render file cache**: :class:`_BoundedFileCache` is the bounded
     LRU dict the per-render call sites pass around as ``file_cache=``.
     Caps memory growth on sessions that touch many unique source files
     (the unbounded variant could hold ~50MB of file content on a
@@ -33,7 +33,7 @@ share the per-line truncation constant (:data:`_SNIPPET_TRUNCATE_CHARS`,
 or the finding card. Both readers go through :func:`_resolve_source_path`
 so the boundary check and Server Script branching are uniform.
 
-This module imports nothing from ``optimus.renderer._internal`` — the
+This module imports nothing from ``optimus.renderer._internal``: the
 ``_internal`` module is the consumer. ``frappe`` is lazy-imported inside
 the functions so the pure-pytest tests don't need a bench.
 """
@@ -43,10 +43,10 @@ from __future__ import annotations
 import os
 from collections import OrderedDict
 
-# Per-line truncation for source snippets/windows — keeps a single
+# Per-line truncation for source snippets/windows keeps a single
 # multi-kilobyte minified line out of technical_detail_json / the LLM
 # prompt. Kept here (with the readers) rather than imported from
-# analyze.py — so the readers don't pull in analyze.py, which imports
+# analyze.py so the readers don't pull in analyze.py, which imports
 # frappe.recorder.
 _SNIPPET_TRUNCATE_CHARS = 200
 
@@ -118,22 +118,22 @@ def _path_within_bench(path: str) -> bool:
 
 
 def _resolve_source_path(filename):
-	"""Map a finding's callsite ``filename`` to a real file on disk — OR to a
+	"""Map a finding's callsite ``filename`` to a real file on disk OR to a
 	Server Script sentinel for synthetic ``<serverscript>`` filenames.
 
 	Return shapes:
-	  - ``str`` — a real on-disk path (for app code / framework code).
-	  - ``("server_script", scrubbed_name)`` — Server Script tuple sentinel.
+	  - ``str``: a real on-disk path (for app code / framework code).
+	  - ``("server_script", scrubbed_name)``: Server Script tuple sentinel.
 	    Snippet readers branch on ``isinstance(resolved, tuple)`` and load
 	    the script body from the ``tabServer Script`` DocType via
 	    ``optimus.server_script_source.get_server_script_lines``. The
 	    template/callsite-builder side branches similarly to render a Desk
 	    link instead of a ``vscode://file`` editor link.
-	  - ``None`` — unresolvable (truly synthetic frames like ``<string>`` /
+	  - ``None``: unresolvable (truly synthetic frames like ``<string>`` /
 	    ``<frozen …>``, missing files, or paths that escape the bench).
 
 	Call-tree / pyinstrument callsites are stored in app-relative form
-	(``<app>/<module-path-within-the-app-dir>`` — e.g. ``ugly_code/python/
+	(``<app>/<module-path-within-the-app-dir>``: e.g. ``ugly_code/python/
 	common.py`` for ``<bench>/apps/ugly_code/ugly_code/python/common.py``,
 	or ``frappe/handler.py``). A bare ``open()`` fails because the Frappe
 	process cwd is ``<bench>/sites``. Resolve via ``frappe.get_app_path``
@@ -159,7 +159,7 @@ def _resolve_source_path(filename):
 		_scrubbed = extract_script_name(name)
 		if _scrubbed:
 			return ("server_script", _scrubbed)
-		# Bare ``<serverscript>`` — no script to look up; treat as
+		# Bare ``<serverscript>``: no script to look up; treat as
 		# unresolvable so the renderer falls back to plain-text display
 		# without a broken link.
 		return None
@@ -260,7 +260,7 @@ def _read_source_snippet(
 	limit = _SNIPPET_TRUNCATE_CHARS
 	snippet: list[dict] = []
 	# v0.7.x: read a ±2-line window around the anchor (compromise
-	# between ±1 — too tight, body invisible — and ±4 — included
+	# between ±1 too tight, body invisible and ±4 included
 	# preceding-function noise). The template's blank-line filter
 	# drops empties (except the callsite itself), so the visible
 	# snippet ends up at ~3-4 lines: the anchor `def` + a couple of

--- a/optimus/renderer/source_resolution.py
+++ b/optimus/renderer/source_resolution.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Source-resolution helpers — dotted-path → ``(abs_file, lineno,
+"""Source-resolution helpers dotted-path → ``(abs_file, lineno,
 func_name)`` and adjacent display helpers.
 
 Used by the renderer to resolve action entry-points (the ``def`` line
@@ -11,13 +11,13 @@ emits) to a concrete source location + a ±1-line snippet for the
 report's "Where this fired" callsite blocks.
 
 Extracted from ``_internal.py`` in v0.12.23 as **prep work for
-finding_enrichment phase 3** — the HIGH-coupling finding-enrichment
+finding_enrichment phase 3**: the HIGH-coupling finding-enrichment
 subset (`_finding_to_dict`, `_attach_representative_callsites`, etc.)
 depends on the 6 helpers in this module. With them lifted to a sibling
 submodule, the next renderer extraction PR can move that subset cleanly
 without dragging in a sprawling helper family.
 
-The 6 functions move as a tight cluster — they only call each other
+The 6 functions move as a tight cluster they only call each other
 plus stdlib (`importlib`, `inspect`, `os`, `re`) and lazy imports of
 sibling renderer submodules (`source.py`'s `_read_source_snippet` /
 `_resolve_source_path`) and `frappe.utils.get_bench_path`. No back-
@@ -26,18 +26,18 @@ reference into `_internal.py`.
 Public surface (all underscore-prefixed but exposed via the package
 ``__init__.py`` dir-walk so legacy `renderer.X` resolves):
 
-* ``_action_dotted_entry(action)`` — derive an action's dotted entry-
+* ``_action_dotted_entry(action)``: derive an action's dotted entry-
   point path, or ``None``.
-* ``_skip_decorators_to_def(abs_filename, start_lineno, fn_name)`` —
+* ``_skip_decorators_to_def(abs_filename, start_lineno, fn_name)``:
   walk past `@decorator` lines to land on `def <fn_name>`.
-* ``_resolve_dotted_to_code(dotted)`` —
+* ``_resolve_dotted_to_code(dotted)``:
   ``(abs_filename, lineno, func_name)`` from a dotted module path.
-* ``_bench_relative_display(abs_path)`` — display form
+* ``_bench_relative_display(abs_path)``: display form
   (``apps/<app>/...``).
-* ``_action_entry_callsite(action, *, cache)`` — full resolution:
+* ``_action_entry_callsite(action, *, cache)``: full resolution:
   action → dotted → code → ``{filename, _abs, lineno, function,
   source_snippet}``.
-* ``_resolve_frame_key_to_callsite(function_key, *, cache)`` — same
+* ``_resolve_frame_key_to_callsite(function_key, *, cache)``: same
   but starting from a repeated-hot-frame key (``short_path::func``).
 """
 
@@ -53,7 +53,7 @@ def _action_dotted_entry(action) -> str | None:
 	"""Derive an action's dotted entry-point path, or ``None``.
 
 	- RQ Job: ``action["path"]`` is already the job method (Frappe's
-	  recorder stores ``frappe.job.method`` there — e.g.
+	  recorder stores ``frappe.job.method`` there e.g.
 	  ``ugly_code.python.common.bg_recheck_users``).
 	- HTTP Request whose path is ``/api/method/<dotted>``: the ``<dotted>``
 	  segment, with any ``?query`` and trailing ``/...`` stripped.
@@ -106,7 +106,7 @@ def _skip_decorators_to_def(
 	if not lines and not abs_filename.startswith("<"):
 		# _source_lines rejects out-of-bench paths (Phase-K hardening). But
 		# abs_filename is a trusted co_filename and we return only a line number,
-		# never content — so read an out-of-bench app's source directly.
+		# never content so read an out-of-bench app's source directly.
 		try:
 			with open(abs_filename, encoding="utf-8") as _fh:
 				lines = _fh.read().splitlines()
@@ -132,7 +132,7 @@ def _skip_decorators_to_def(
 	for i in range(start_lineno, last):
 		if pat.match(lines[i]):
 			return i + 1  # convert 0-indexed to 1-indexed lineno
-	return start_lineno  # no def found — fall back to original
+	return start_lineno  # no def found fall back to original
 
 
 def _resolve_dotted_to_code(
@@ -142,13 +142,13 @@ def _resolve_dotted_to_code(
 ) -> tuple[str, int, str] | None:
 	"""Resolve a dotted module path to ``(abs_filename, lineno, func_name)``.
 
-	Uses ``importlib`` directly — NOT ``frappe.get_attr`` — because the
+	Uses ``importlib`` directly NOT ``frappe.get_attr``: because the
 	latter needs a running site (it touches ``frappe.local``), which the unit
 	tests don't have. Mirrors ``line_profile.picker.resolve_freeform``'s
 	import strategy (longest importable leading prefix, then ``getattr`` the
 	rest), minus its eligibility checks. ``inspect.unwrap`` sees through
 	``functools.wraps`` decorators (e.g. ``@frappe.whitelist``). Returns
-	``None`` on any failure — never raises.
+	``None`` on any failure never raises.
 
 	v0.7.x: when ``code.co_firstlineno`` points at a decorator line
 	(CPython 3.11+ behavior for decorated functions), the lineno is
@@ -215,13 +215,13 @@ def _action_entry_callsite(action, *, cache: dict | None = None) -> dict | None:
 
 	Returns ``{"filename": <bench-relative display path>, "_abs": <absolute>,
 	"lineno": <def line>, "function": <name>, "source_snippet": [...] | None}``
-	— or ``None`` when there's no clean dotted entry point / it can't be
+	or ``None`` when there's no clean dotted entry point / it can't be
 	resolved / the callable has no real source. ``source_snippet`` may itself
 	be ``None`` if the file can't be read (the template guards on it).
 
 	``cache`` (shared across all actions in one render) is forwarded to
 	``_read_source_snippet`` so a cluster of actions in one source file reads
-	it once. Resolution itself isn't memoized — it's cheap (``importlib`` on
+	it once. Resolution itself isn't memoized it's cheap (``importlib`` on
 	already-imported modules) and reports have only tens of actions.
 	"""
 	dotted = _action_dotted_entry(action)
@@ -258,7 +258,7 @@ def _resolve_frame_key_to_callsite(function_key, *, cache: dict | None = None) -
 
 	A bare ``func`` (no ``::``) can't be resolved without a module → ``None``.
 	Returns ``{"filename","_abs","lineno","function","source_snippet"}`` or
-	``None``. Wrapped in try/except — never raises.
+	``None``. Wrapped in try/except never raises.
 	"""
 	if not function_key:
 		return None

--- a/optimus/renderer/syntax.py
+++ b/optimus/renderer/syntax.py
@@ -16,19 +16,19 @@ Two responsibilities:
     explicit language hint), and wraps each ``+`` / ``-`` / ``@@`` line
     in a classed span so the template's CSS can colour the diff.
 
-Pygments is loaded lazily inside :func:`_ensure_pygments` — paths that
+Pygments is loaded lazily inside :func:`_ensure_pygments`: paths that
 never highlight code (DocType save callbacks, janitor sweeps, the bulk
 of the regenerate path) don't pay the ~30-50ms import cost at app load.
 Module-level slots are populated on first use and cached for the worker
 process's lifetime.
 
-The :func:`_highlight_python_block_cached` LRU has ``maxsize=512`` — large
+The :func:`_highlight_python_block_cached` LRU has ``maxsize=512``: large
 enough that overlapping snippets across N findings tokenise the same
 underlying source exactly once, small enough that the cache fits in the
 worker's heap on extreme-session sizes.
 
 Failures degrade silently: when Pygments is unavailable or tokenisation
-raises (rare — malformed source), the row's ``content_html`` is set to
+raises (rare malformed source), the row's ``content_html`` is set to
 ``None`` and the template falls back to the plain-text ``content``. The
 report stays readable; only the colour goes away.
 """
@@ -147,7 +147,7 @@ def _highlight_all_snippets(actions, all_findings):
 
 
 # ---------------------------------------------------------------------------
-# Diff-block highlighting — used by the AI fix card
+# Diff-block highlighting used by the AI fix card
 # ---------------------------------------------------------------------------
 
 # <pre> block, optionally wrapping a <code>...</code> (with or without a class).
@@ -178,14 +178,14 @@ def _diff_line_class(line: str) -> str | None:
 
 def _highlight_diff_html(html: str) -> str:
 	"""Wrap +/-/@@ lines inside diff-looking ``<pre>`` blocks in classed
-	spans. Pure string transform over already-sanitized HTML — only adds
+	spans. Pure string transform over already-sanitized HTML only adds
 	``<span class="dh-…">`` wrappers around existing escaped text."""
 
 	def _wrap(match: re.Match) -> str:
 		code_attrs = match.group(1) or ""
 		inner = match.group(2) or ""
 		lines = inner.split("\n")
-		# A trailing "" from the markdown renderer's final newline — drop it
+		# A trailing "" from the markdown renderer's final newline drop it
 		# so we don't emit an empty trailing block-span.
 		if lines and lines[-1] == "":
 			lines = lines[:-1]

--- a/optimus/renderer/time_format.py
+++ b/optimus/renderer/time_format.py
@@ -6,19 +6,19 @@
 Three small functions the template's context dict exposes as callables
 (``fmt_ms`` / ``fmt_dt``) plus the server-timezone label resolver:
 
-  * :func:`_format_duration_ms` — turns milliseconds into ``"<n>ms"`` (with
+  * :func:`_format_duration_ms`: turns milliseconds into ``"<n>ms"`` (with
     configurable decimal places) below ``threshold_ms``, or ``"<n.nn>s"``
     above it. The seconds branch wraps the result in a
     ``<span class="time-high">`` so the report's eye-catch CSS draws the
     reader to slow values. Returns ``markupsafe.Markup`` so the wrapper
     isn't escaped when rendered through Jinja.
 
-  * :func:`_format_datetime_display` — formats a datetime per the site's
+  * :func:`_format_datetime_display`: formats a datetime per the site's
     System Settings (Date Format + Time Format), dropping microseconds.
     Falls back to a microsecond-stripped string when Frappe isn't
     importable (pure-pytest path).
 
-  * :func:`_get_server_timezone` — best-effort server timezone label:
+  * :func:`_get_server_timezone`: best-effort server timezone label:
     System Settings → Python's datetime tzname → "UTC". Used by the
     footer to disambiguate "what does '2026-05-24 18:12:53' mean".
 
@@ -34,7 +34,7 @@ from markupsafe import Markup
 
 
 def _format_duration_ms(ms, threshold_ms: float = 1000.0, decimals: int = 0):
-	"""Render a duration as ``"<n>ms"`` (with ``decimals`` digits) — or, if it
+	"""Render a duration as ``"<n>ms"`` (with ``decimals`` digits) or, if it
 	crosses ``threshold_ms``, as ``"<n.nn>s"`` (always 2 decimals). The
 	``decimals`` arg controls only the ms branch so the existing ``%.1f`` /
 	``%.2f`` callsites (sub-ms query timings) keep their resolution below the
@@ -45,7 +45,7 @@ def _format_duration_ms(ms, threshold_ms: float = 1000.0, decimals: int = 0):
 	v0.7.x: returns ``markupsafe.Markup`` so the seconds branch can
 	emit a ``<span class="time-high">`` wrapper without being escaped
 	when rendered via ``{{ fmt_ms(...) }}`` in Jinja. The wrapper draws
-	the reader's eye to values slow enough to roll over into seconds —
+	the reader's eye to values slow enough to roll over into seconds
 	the timing rule itself is unchanged, just the visual emphasis is
 	new. ``Markup`` subclasses ``str`` so Python callers that compare /
 	concat the return value still work.
@@ -61,7 +61,7 @@ def _format_duration_ms(ms, threshold_ms: float = 1000.0, decimals: int = 0):
 
 def _format_datetime_display(value) -> str:
 	"""Format a datetime (or datetime-string) for display in the report using
-	the site's System Settings (Date Format + Time Format) — which also drops
+	the site's System Settings (Date Format + Time Format) which also drops
 	the microseconds. Falls back to the value with any trailing microseconds
 	stripped when Frappe isn't available (standalone / tests)."""
 	if not value:

--- a/optimus/renderer/visualization.py
+++ b/optimus/renderer/visualization.py
@@ -6,23 +6,23 @@
 Three small public functions the template's context dict exposes as
 callables, plus :func:`redact_frame_name` for tree-node display:
 
-  * :func:`build_donut_data` — turns ``session_time_breakdown_json`` into
+  * :func:`build_donut_data`: turns ``session_time_breakdown_json`` into
     ``[(label, ms, color), …]`` for the donut chart. Hides slices that
-    round to 0ms (v0.5.1 fix — a session with 148ms of SQL and a handful
-    of sub-ms Python self-times was rendering seven "Python (…) — 0ms"
+    round to 0ms (v0.5.1 fix a session with 148ms of SQL and a handful
+    of sub-ms Python self-times was rendering seven "Python (…) 0ms"
     noise entries).
-  * :func:`build_donut_svg` — inline-SVG donut chart for PDF mode (wkhtml
+  * :func:`build_donut_svg`: inline-SVG donut chart for PDF mode (wkhtml
     can't render CSS conic-gradient reliably).
-  * :func:`build_hot_frames_table` — leaderboard row formatter; takes the
+  * :func:`build_hot_frames_table`: leaderboard row formatter; takes the
     ``is_hot`` flag to switch between self-time and cumulative-time
     columns and to mark user-code rows for the tinted CSS variant.
 
-These four are **public** — the renderer passes them into the Jinja
+These four are **public**: the renderer passes them into the Jinja
 context dict and the template calls them as ``{{ build_donut_svg(...) }}``
 helpers. The :data:`_DONUT_COLORS` palette is module-private (8 colours,
 rolls over for slice counts > 8).
 
-No Frappe dependency — pure dicts in, pure HTML strings / list-of-dicts
+No Frappe dependency pure dicts in, pure HTML strings / list-of-dicts
 out. Safe to call from any context the renderer reaches.
 """
 
@@ -39,7 +39,7 @@ _DONUT_COLORS = [
 
 def redact_frame_name(node: dict) -> str:
 	"""Build a tree node's display name. Always emits the full function
-	name plus its short filename and line number — single admin-scoped
+	name plus its short filename and line number single admin-scoped
 	report has no need for the safe-mode app collapse this used to do.
 	"""
 	if not isinstance(node, dict):
@@ -58,7 +58,7 @@ def build_donut_data(breakdown: dict) -> list:
 
 	v0.5.1: hides slices that round to 0ms in display. A session with
 	148ms of SQL and only a handful of sub-ms Python self-times was
-	rendering seven "Python (…) — 0ms" entries, all noise.
+	rendering seven "Python (…) 0ms" entries, all noise.
 	"""
 	if not breakdown:
 		return []
@@ -123,7 +123,7 @@ def build_hot_frames_table(rows: list, is_hot: bool = False) -> list:
 	user-code rows (yellow tint) and leave the framework rows
 	unmarked. The renderer always splits hot frames into user-vs-
 	framework lists before calling this builder, so the flag is a
-	per-list constant — True for the user-code table, False for the
+	per-list constant True for the user-code table, False for the
 	framework sibling.
 
 	v0.7.x: ``is_hot`` also selects WHICH time metric the row
@@ -136,7 +136,7 @@ def build_hot_frames_table(rows: list, is_hot: bool = False) -> list:
 	"""
 	out = []
 	for row in rows or []:
-		# The hot-frame key already encodes "<short_path>::<func>" — use it
+		# The hot-frame key already encodes "<short_path>::<func>" use it
 		# directly. Routing through redact_frame_name appended a bogus "(?:0)"
 		# (placeholder file "?" + lineno 0, since no file/line is known here).
 		display = row.get("function") or "<unknown>"
@@ -154,7 +154,7 @@ def build_hot_frames_table(rows: list, is_hot: bool = False) -> list:
 			"action_refs": row.get("action_refs", []),
 			"is_hot": is_hot,
 		})
-	# Framework variant ranks by the displayed (cumulative) metric —
+	# Framework variant ranks by the displayed (cumulative) metric
 	# the aggregator's outer sort was by self_ms, which produces
 	# all-zero ties on framework rows.
 	if not is_hot:

--- a/optimus/report_context.py
+++ b/optimus/report_context.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Phase J adapter — transform our flat render-context into the 19-key
+"""Phase J adapter transform our flat render-context into the 19-key
 contract shape per ``template_variable_contract.md`` (in the reference
 design package).
 
@@ -23,7 +23,7 @@ from typing import Any
 from markupsafe import Markup
 
 # ---------------------------------------------------------------------------
-# Helpers — small pure functions called by sub-builders below
+# Helpers small pure functions called by sub-builders below
 # ---------------------------------------------------------------------------
 
 
@@ -84,7 +84,7 @@ def _ms_display(ms) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Sub-builders — one per contract key, in contract order
+# Sub-builders one per contract key, in contract order
 # ---------------------------------------------------------------------------
 
 
@@ -141,7 +141,7 @@ def _build_kpis(session_doc, ctx) -> list[dict]:
 	medium = severity_counts.get("Medium", 0) or 0
 	low = severity_counts.get("Low", 0) or 0
 
-	# "X high · Y medium · Z low" — only non-zero buckets, separator-joined.
+	# "X high · Y medium · Z low" only non-zero buckets, separator-joined.
 	sev_parts = []
 	if high:
 		sev_parts.append(f"{high} high")
@@ -152,7 +152,7 @@ def _build_kpis(session_doc, ctx) -> list[dict]:
 	findings_sub = " · ".join(sev_parts) if sev_parts else "none detected"
 
 	server_ms = total_ms - total_query_ms
-	# Markup-aware concat — fmt_ms returns Markup for ≥1s values
+	# Markup-aware concat fmt_ms returns Markup for ≥1s values
 	# (`<span class="time-high">…</span>`). f-string would coerce to plain
 	# str and Jinja autoescape would HTML-encode the span.
 	total_time_sub = (
@@ -161,7 +161,7 @@ def _build_kpis(session_doc, ctx) -> list[dict]:
 
 	ops_plural = "s" if total_requests != 1 else ""
 
-	# C.UT2 — Total-time KPI carries a caveat about wall-clock sampling.
+	# C.UT2 Total-time KPI carries a caveat about wall-clock sampling.
 	# The interval is dynamic (Optimus Settings); read once for the sub-line.
 	try:
 		from optimus.settings import get_config as _get_cfg
@@ -225,7 +225,7 @@ def _build_summary(summary_html) -> dict | None:
 	"""Contract ``summary`` = {paragraphs_html: [...]}.
 
 	Our existing summary is one HTML chunk (``<ul>`` of bullets). Wrap in
-	a single-paragraph list — the contract permits HTML inside each entry.
+	a single-paragraph list the contract permits HTML inside each entry.
 	"""
 	if not summary_html:
 		return None
@@ -453,7 +453,7 @@ def _build_actions(actions, findings, fmt_ms=None) -> list[dict]:
 	J.2.3: We *spread the original action dict* so the existing
 	``action_row`` macro (which reads ``action_label``, ``http_method``,
 	``path``, ``entry_callsite``, ``target_doc``, ``related_findings`` and
-	more) keeps working unchanged. Contract fields are added on top — they
+	more) keeps working unchanged. Contract fields are added on top they
 	never collide with the legacy keys.
 	"""
 	fmt = fmt_ms or (lambda v, **kw: _ms_display(v))
@@ -536,7 +536,7 @@ def _build_background_jobs(jobs, fmt_ms=None) -> list[dict]:
 			"queries": job.get("queries_count", 0) or 0,
 			"db_time_display": fmt(job.get("query_time_ms", 0) or 0),
 			"finding_count": job.get("findings_count", 0) or 0,
-			# Also coerce the ORIGINAL ``findings_count`` (with 's') key —
+			# Also coerce the ORIGINAL ``findings_count`` (with 's') key
 			# the existing line above only adds a new ``finding_count``
 			# (without 's'). Jobs that Failed before producing findings
 			# carry ``findings_count: None`` from analyze; the bg_jobs
@@ -545,7 +545,7 @@ def _build_background_jobs(jobs, fmt_ms=None) -> list[dict]:
 			# Undefined (not None), so an uncoerced None crashes the whole
 			# render with ``unsupported operand type(s) for +: 'int' and
 			# 'NoneType'``. The fix is render-time so it applies on
-			# regenerate_reports too — no re-analyze needed.
+			# regenerate_reports too no re-analyze needed.
 			"findings_count": int(job.get("findings_count") or 0),
 		})
 		result.append(entry)
@@ -667,7 +667,7 @@ def _build_resource(infra_summary, infra_timeline) -> dict | None:
 	# J.2.4 non-contract additions: keep the raw summary + timeline reachable
 	# under ``report_data.resource`` so the existing per-action infra table
 	# and the inline rc-card markup migrate as a straight key rename.
-	# J.13: normalise the timeline's snapshotted action labels — the
+	# J.13: normalise the timeline's snapshotted action labels the
 	# rows were stamped by infra_pressure.analyze at analyse-time and
 	# carry the pre-J.12 ``"Job: <method>"`` prefix on bg jobs. Rewrite
 	# at render time so the Server Resource per-action timeline reads
@@ -698,7 +698,7 @@ def _build_frontend(ctx) -> dict | None:
 	if not vitals_by_page and not xhrs and not summary:
 		return None
 
-	# web_vitals — per-page row with computed *_class fields
+	# web_vitals per-page row with computed *_class fields
 	web_vitals = []
 	for page, v in vitals_by_page.items():
 		fcp = v.get("fcp_ms")
@@ -708,19 +708,19 @@ def _build_frontend(ctx) -> dict | None:
 		dcl = v.get("dom_content_loaded_ms")
 		web_vitals.append({
 			"url": page,
-			"fcp_display": f"{fcp:.0f} ms" if fcp else "—",
+			"fcp_display": f"{fcp:.0f} ms" if fcp else "",
 			"fcp_class": _web_vital_class(fcp, 1800, 3000),
-			"lcp_display": f"{lcp:.0f} ms" if lcp else "—",
+			"lcp_display": f"{lcp:.0f} ms" if lcp else "",
 			"lcp_class": _web_vital_class(lcp, 2500, 4000),
-			"cls_display": f"{cls:.3f}" if cls is not None else "—",
+			"cls_display": f"{cls:.3f}" if cls is not None else "",
 			"cls_class": _web_vital_class(cls, 0.1, 0.25) if cls is not None else "vital-none",
-			"ttfb_display": f"{ttfb:.0f} ms" if ttfb else "—",
+			"ttfb_display": f"{ttfb:.0f} ms" if ttfb else "",
 			"ttfb_class": _web_vital_class(ttfb, 800, 1800),
-			"dcl_display": f"{dcl:.0f} ms" if dcl else "—",
+			"dcl_display": f"{dcl:.0f} ms" if dcl else "",
 			"dcl_class": _web_vital_class(dcl, 1500, 3000),
 		})
 
-	# xhrs — display-formatted
+	# xhrs display-formatted
 	xhrs_out = []
 	for x in xhrs:
 		backend_ms = x.get("backend_ms", 0) or 0
@@ -741,7 +741,7 @@ def _build_frontend(ctx) -> dict | None:
 			"browser_is_hot": xhr_ms >= 1000,
 		})
 
-	# kpis — 4-item summary
+	# kpis 4-item summary
 	kpis = []
 	if summary:
 		total_xhrs = summary.get("total_xhrs", 0) or 0
@@ -929,7 +929,7 @@ def _build_footer(render_config) -> dict:
 	"""Contract ``footer`` = {framework, settings}.
 
 	``settings`` lists every render-time toggle that affects the report. The
-	contract example shows 3 toggles; our config has 6 — we include all of
+	contract example shows 3 toggles; our config has 6 we include all of
 	them so the legacy footer's full disclosure carries over post-migration.
 	"""
 	rc = render_config or {}
@@ -980,9 +980,9 @@ def build_report_context(session_doc: Any, ctx: dict) -> dict:
 	except Exception:
 		_sampler_ms = 1.0
 	# AI token-usage transparency: total tokens every AI feature consumed this
-	# session — fix suggestions (per finding), index suggestions (per table),
+	# session fix suggestions (per finding), index suggestions (per table),
 	# and the Steps-to-Reproduce humanization (one per session). Derived at
-	# render time so re-generated reports stay in sync — never baked at
+	# render time so re-generated reports stay in sync never baked at
 	# analyze time. (The connectivity probe is a Settings test, not session
 	# work, so it's deliberately excluded.)
 	_ai_tokens_total = 0
@@ -1032,7 +1032,7 @@ def build_report_context(session_doc: Any, ctx: dict) -> dict:
 		"actions": _build_actions(
 			ctx.get("actions", []), ctx.get("findings", []), ctx.get("fmt_ms")
 		),
-		# J.2.3 non-contract addition — pragmatic extension so the framework
+		# J.2.3 non-contract addition pragmatic extension so the framework
 		# sub-block keeps rendering. May be folded into ``actions`` with an
 		# ``is_framework`` flag in J.3.
 		"actions_framework": _build_actions(
@@ -1041,7 +1041,7 @@ def build_report_context(session_doc: Any, ctx: dict) -> dict:
 		"background_jobs": _build_background_jobs(
 			(ctx.get("background_jobs") or {}).get("jobs", []) or [], ctx.get("fmt_ms")
 		),
-		# J.2.3 non-contract addition — see actions_framework note above.
+		# J.2.3 non-contract addition see actions_framework note above.
 		"background_jobs_framework": _build_background_jobs(
 			(ctx.get("background_jobs") or {}).get("jobs_framework", []) or [], ctx.get("fmt_ms")
 		),
@@ -1060,11 +1060,11 @@ def build_report_context(session_doc: Any, ctx: dict) -> dict:
 		"slow_queries": _build_slow_queries(ctx.get("top_queries", []), ctx.get("fmt_ms")),
 		# J.2.5 non-contract addition for framework split.
 		"slow_queries_framework": _build_slow_queries(ctx.get("top_queries_framework", []), ctx.get("fmt_ms")),
-		# B.DI4 — how many user-app slow queries the analyzer truncated
+		# B.DI4 how many user-app slow queries the analyzer truncated
 		# out of the findings list (5-cap). 0 when nothing was suppressed.
 		"top_queries_suppressed_count": int(ctx.get("top_queries_suppressed_count") or 0),
 		"top_queries_slow_threshold_ms": float(ctx.get("top_queries_slow_threshold_ms") or 0),
-		# B.DI2 — Hot Frames section truncation banner data:
+		# B.DI2 Hot Frames section truncation banner data:
 		# {captured, kept, actions_affected, keep_limit}. actions_affected=0 hides it.
 		"frame_truncation": ctx.get("frame_truncation") or {
 			"captured": 0, "kept": 0, "actions_affected": 0, "keep_limit": 0,
@@ -1072,7 +1072,7 @@ def build_report_context(session_doc: Any, ctx: dict) -> dict:
 		"db": _build_db(ctx.get("table_breakdown", []), ctx.get("fmt_ms")),
 		"how_to_read_items": None,
 		"footer": _build_footer(ctx.get("render_config")),
-		# J.3.1 non-contract additions — the remaining two passthroughs
+		# J.3.1 non-contract additions the remaining two passthroughs
 		# the template needs before the legacy top-level keys can be
 		# dropped from renderer.py's context dict.
 		"large_duration_threshold_ms": (
@@ -1093,7 +1093,7 @@ def _build_background_jobs_summary(background_jobs) -> dict:
 	dict can be dropped.
 	"""
 	bj = background_jobs or {}
-	# v0.7.x: per-status tally so the section heading can break down "N jobs —
+	# v0.7.x: per-status tally so the section heading can break down "N jobs
 	# X completed, Y failed, Z timed out, W running" and flag failures. Ordered
 	# worst-first; zero categories are dropped so the line stays terse.
 	sc = bj.get("status_counts") or {}

--- a/optimus/server_script_source.py
+++ b/optimus/server_script_source.py
@@ -11,7 +11,7 @@ Server Script bodies with a synthetic filename:
 
 These never resolve to an on-disk file. ``renderer._resolve_source_path``
 rejects them by the ``startswith("<")`` rule, so callsites in Server Script
-bodies render without a code snippet and without an editor link — the user
+bodies render without a code snippet and without an editor link the user
 sees ``<server-script body>`` with no actionable context.
 
 This module is the render-time bridge that loads the Server Script's stored
@@ -47,7 +47,7 @@ def extract_script_name(filename) -> str | None:
 	filename. Returns the scrubbed name (e.g. ``"my_script"``) or ``None`` when:
 
 	  - ``filename`` doesn't match the ``<serverscript>[: name]`` shape;
-	  - the filename is bare ``<serverscript>`` (no name attached — no script
+	  - the filename is bare ``<serverscript>`` (no name attached no script
 	    to look up).
 
 	Examples (matching ``apps/frappe/frappe/utils/safe_exec.py:118``)::
@@ -67,7 +67,7 @@ def extract_script_name(filename) -> str | None:
 
 
 def is_server_script_filename(filename) -> bool:
-	"""``True`` for any ``<serverscript>`` filename — named or bare. Lets
+	"""``True`` for any ``<serverscript>`` filename named or bare. Lets
 	callers branch on the family before bothering with name extraction."""
 	if not filename or not isinstance(filename, str):
 		return False
@@ -99,7 +99,7 @@ def get_server_script_record(scrubbed_name: str, *, cache: dict | None = None) -
 		# Match the requested (already-scrubbed) name against every Server
 		# Script by scrubbing each candidate the way Frappe canonically does
 		# (frappe.scrub). Done in Python rather than SQL REPLACE chains so it's
-		# portable across MariaDB/Postgres (no backticks) and exactly correct —
+		# portable across MariaDB/Postgres (no backticks) and exactly correct
 		# the Server Script table is tiny, so the full scan is cheap.
 		target = (scrubbed_name or "").lower()
 		for cand in frappe.get_all("Server Script", fields=["name", "script"]):

--- a/optimus/session.py
+++ b/optimus/session.py
@@ -3,7 +3,7 @@
 
 """Redis state for the profiler session lifecycle.
 
-This module is intentionally pure state-management — no business logic, no
+This module is intentionally pure state-management no business logic, no
 DocType I/O, no recorder coupling. It owns three Redis key shapes:
 
     profiler:active:<user_email>          → string, value=session_uuid, TTL
@@ -12,7 +12,7 @@ DocType I/O, no recorder coupling. It owns three Redis key shapes:
 
 The active key has a TTL that matches the recorder's auto-disable so a
 forgotten Stop button can never run forever. The meta and recordings keys
-have no TTL — they live until the analyze pipeline finalizes the session
+have no TTL they live until the analyze pipeline finalizes the session
 into a `Optimus Session` DocType row and explicitly deletes them.
 """
 
@@ -43,7 +43,7 @@ _SIG_LEN = 32  # SHA-256 digest size in bytes.
 # HMAC and the payload at sign time, so future signing-scheme bumps
 # (HMAC-SHA512, AES-SIV, key-rotation tag, …) have an extension point
 # without breaking blobs in flight. The version byte is COVERED BY
-# THE HMAC — tampering with it is detected. Backward compatibility on
+# THE HMAC tampering with it is detected. Backward compatibility on
 # read is automatic: if the post-signature body's first byte is the
 # current version marker, strip it; otherwise the body is a legacy
 # pre-v0.12.14 payload. Pickle never uses ``\x01`` as a leading
@@ -128,14 +128,14 @@ def unsign_blob(signed: bytes) -> bytes | None:
 
 	v0.12.14: handles two body shapes after the 32-byte signature:
 
-	  * **v1 (current, v0.12.14+)** — body starts with
+	  * **v1 (current, v0.12.14+)**: body starts with
 	    ``_HMAC_SCHEME_V1``. The signature covers the version-tagged
 	    body. Returns ``body[1:]`` (the payload, with the version
 	    byte stripped).
-	  * **v0 (legacy, pre-v0.12.14)** — body is the raw payload. The
+	  * **v0 (legacy, pre-v0.12.14)**: body is the raw payload. The
 	    signature covers the body directly. Returns ``body``.
 
-	The single HMAC verification step handles both cases — for v1 the
+	The single HMAC verification step handles both cases for v1 the
 	HMAC was computed over ``\\x01 + payload`` AND that's exactly what
 	the body is; for v0 the HMAC was computed over the payload AND
 	the body is just the payload. The post-verify branch inspects the
@@ -161,8 +161,8 @@ def unsign_blob(signed: bytes) -> bytes | None:
 # centralized ``optimus.redis_keys.session_*`` functions. Same byte-
 # identical key strings as the pre-v0.12.24 local helpers (which were
 # the last surviving inline f-strings outside ``redis_keys.py``).
-# Existing call sites — both inside this module and from tests
-# (``session._meta_key(uuid)`` / ``session._jobs_key(sid)``) — keep
+# Existing call sites both inside this module and from tests
+# (``session._meta_key(uuid)`` / ``session._jobs_key(sid)``) keep
 # working unchanged through the module-level aliases.
 from optimus import redis_keys as _redis_keys
 
@@ -216,7 +216,7 @@ def set_active_session(user: str, session_uuid: str) -> None:
 def clear_active_session(user: str) -> None:
 	"""Clear the active session pointer for the user.
 
-	Idempotent — safe to call when no session is active.
+	Idempotent safe to call when no session is active.
 	"""
 	frappe.cache.delete_value(_active_key(user))
 
@@ -309,7 +309,7 @@ def register_recording(
 
 	# Refresh the active-session TTL so long flows don't silently expire.
 	# If the caller didn't pass a user, fall back to reading it from the
-	# session meta — one extra Redis roundtrip in exchange for a safer
+	# session meta one extra Redis roundtrip in exchange for a safer
 	# default.
 	if not user:
 		meta = get_session_meta(session_uuid) or {}
@@ -323,7 +323,7 @@ def register_recording(
 		# call, causing subsequent HTTP requests on the same worker
 		# to keep being recorded into the (now-stopped) session and
 		# the widget to silently flip back to Recording state.
-		# EXPIRE returns 0 for a missing key — no key resurrected.
+		# EXPIRE returns 0 for a missing key no key resurrected.
 		expire_key(_active_key(user), SESSION_TTL_SECONDS)
 
 	return True
@@ -393,7 +393,7 @@ def get_pending_jobs(session_uuid: str) -> set[str]:
 # analyze's ``_finalize_pending_statuses`` at the wait cap) can DROP fields
 # via interleaved read-modify-write. The helper falls back to non-atomic
 # read-modify-write for cache backends without ``.eval()`` (FakeCache in
-# tests, exotic Redis variants) — preserves existing behavior, sheds the
+# tests, exotic Redis variants) preserves existing behavior, sheds the
 # multi-worker guarantee in those contexts.
 
 
@@ -430,7 +430,7 @@ return 1
 # bypasses the pickle wrapper. Returns None in test contexts where
 # ``frappe.cache`` is a FakeCache stand-in (no connection_pool); _read_job /
 # _write_job then fall back to ``frappe.cache.hget`` / ``.hset`` directly,
-# which is fine because FakeCache stores values as-is (no pickling) — the
+# which is fine because FakeCache stores values as-is (no pickling) the
 # encoding stays consistent within either environment.
 _RAW_REDIS = None
 
@@ -497,7 +497,7 @@ def _atomic_merge_job_meta(
 	Filters None values so callers can pass ``error=None`` without nuking a
 	real error already in meta. Falls back to the legacy non-atomic
 	read-modify-write on any backend that rejects ``.eval()`` (FakeCache in
-	tests, exotic Redis variants) — best-effort, never raises."""
+	tests, exotic Redis variants) best-effort, never raises."""
 	if not session_uuid or not job_id:
 		return
 	fields = {k: v for k, v in fields.items() if v is not None}
@@ -596,7 +596,7 @@ def get_jobs(session_uuid: str) -> list[dict]:
 
 def set_draining(session_uuid: str, until_ts: float) -> None:
 	"""Keep accepting job recordings for this session until ``until_ts``
-	(a unix timestamp). Stored on the session meta dict (no separate TTL —
+	(a unix timestamp). Stored on the session meta dict (no separate TTL
 	meta lives until the analyze pipeline deletes it)."""
 	if not session_uuid:
 		return
@@ -636,7 +636,7 @@ def delete_session_state(session_uuid: str) -> None:
 	# v0.6.0: pending-jobs set (the draining_until flag lives inside the
 	# meta hash, deleted above).
 	frappe.cache.delete_value(_pending_jobs_key(session_uuid))
-	# v0.7.x: per-job metadata hash (terminal statuses) — persisted to the
+	# v0.7.x: per-job metadata hash (terminal statuses) persisted to the
 	# Optimus Background Job child table by analyze before this runs.
 	frappe.cache.delete_value(_jobs_key(session_uuid))
 	# v0.5.0: clean up the frontend metrics Redis lists written by

--- a/optimus/settings.py
+++ b/optimus/settings.py
@@ -4,7 +4,7 @@
 """Cached reader for Optimus Settings.
 
 Every request goes through ``hooks_callbacks.before_request`` which
-checks ``is_enabled()`` — reading the Single doc directly on every
+checks ``is_enabled()``: reading the Single doc directly on every
 request would be a DB hit per request. We cache the resolved config
 in Redis with a version key; the DocType controller bumps the key
 on save.
@@ -39,15 +39,15 @@ from dataclasses import dataclass, field
 _DEFAULTS = {
 	"enabled": True,
 	"session_retention_days": 30,
-	"tracked_apps": (),  # tuple, not list — immutable for caching
-	# Exclusion list — findings whose blame app falls in this tuple are
+	"tracked_apps": (),  # tuple, not list immutable for caching
+	# Exclusion list findings whose blame app falls in this tuple are
 	# dropped from the report (both Findings and Observations sections).
 	# v0.13.x: default seeded with every Frappe-organization-maintained
 	# app (frappe, erpnext, hrms, lms, helpdesk, insights, crm, builder,
 	# wiki, drive, payments). The install hook
 	# (``optimus.install._seed_ignored_apps_with_framework_apps``) writes
 	# these as initial rows into the Optimus Settings DocType on fresh
-	# installs (idempotent — never overwrites an existing configuration).
+	# installs (idempotent never overwrites an existing configuration).
 	# Pre-v0.13.x sites stay at whatever they configured manually; only
 	# new sites pick up the seed. Operators who actively contribute to
 	# one of these apps (ERPNext core devs, HRMS maintainers, etc.)
@@ -67,7 +67,7 @@ _DEFAULTS = {
 	),
 	# v0.6.x: when True, the "Time spent per database table" section drops
 	# Frappe schema/meta tables, framework-internal tables (User, Has Role,
-	# DefaultValue, …), and information_schema.* — framework noise the app
+	# DefaultValue, …), and information_schema.* framework noise the app
 	# developer can't act on. Default on; admins can uncheck.
 	"hide_framework_tables": True,
 	# v0.5.3: per-recording EXPLAIN / enrichment cap. Long flows (bulk
@@ -96,7 +96,7 @@ _DEFAULTS = {
 	"phase2_default_auto_expand": True,
 	# v0.6.0: how long the analyze job waits (seconds, capped at 300) for the
 	# background jobs the profiled flow enqueued to finish before gathering
-	# recordings — so jobs that a worker picks up shortly after Stop aren't
+	# recordings so jobs that a worker picks up shortly after Stop aren't
 	# lost. 0 = don't wait (pre-v0.6.0 behavior). On a single-worker bench
 	# the analyze job yields the worker between checks (it re-enqueues
 	# itself) so those jobs can actually run; if no worker / scheduler is
@@ -114,7 +114,7 @@ _DEFAULTS = {
 	# entry per line, # comments, blank lines dropped.
 	"sensitive_sql_columns": (),
 	"sensitive_form_keys": (),
-	# v0.6.0: opt-in LLM "suggest a fix" feature. The API key is NOT here —
+	# v0.6.0: opt-in LLM "suggest a fix" feature. The API key is NOT here
 	# it's secret, stored in a Password field, and read on demand by
 	# ai_fix.py via frappe.utils.password.get_decrypted_password.
 	"ai_enabled": False,
@@ -130,7 +130,7 @@ _DEFAULTS = {
 	# readable flow via the LLM (falls back to the raw action list on any
 	# failure). Also available on-demand from the Optimus Session form.
 	"ai_humanize_steps": True,
-	# v0.6.x: per-section "use the LLM for X" toggles — hard off (no auto-
+	# v0.6.x: per-section "use the LLM for X" toggles hard off (no auto-
 	# bake, the form buttons hide, the API refuses, re-rendered reports omit
 	# the block). Default on, so the master ai_enabled switch alone turns
 	# everything on. (ai_humanize_steps above is the third one.)
@@ -139,7 +139,7 @@ _DEFAULTS = {
 	# v0.7.x: Sensitivity Profile. "Custom" means "read the per-field stored
 	# values" (the pre-profile behavior). The named presets below override the
 	# nine detection-sensitivity knobs at resolve time. Default is "Custom" so a
-	# pre-profile Single (no config_profile key) keeps its stored thresholds —
+	# pre-profile Single (no config_profile key) keeps its stored thresholds
 	# see _read_doctype_row's coalesce and the back-compat note in _resolve.
 	"config_profile": "Custom",
 	# v0.9.0: AI privacy hardening (closes Critical Risk #2). Exclusion
@@ -152,11 +152,11 @@ _DEFAULTS = {
 }
 
 # v0.13.x: every knob whose DocType description advertises a
-# "Reference values — Strict: X · Recommended: Y · Relaxed: Z" triplet
+# "Reference values: Strict: X · Recommended: Y · Relaxed: Z" triplet
 # joins the Sensitivity Profile. Pre-v0.13.x this was nine detection-
 # sensitivity thresholds only (the comment block here used to say
 # "display filters / Phase-2 UI / capture caps / retention / AI are
-# deployment choices, not detection sensitivity") — but every one of
+# deployment choices, not detection sensitivity") but every one of
 # those fields ALSO advertises a triplet in its operator-facing
 # description, which made the UI promise something the resolve path
 # wasn't keeping. The fix: honor the triplet everywhere it's
@@ -178,7 +178,7 @@ _SENSITIVITY_KEYS = (
 	# Display filters
 	"min_action_duration_ms",
 	"large_duration_threshold_ms",
-	# Analyzer thresholds (detection — the original nine)
+	# Analyzer thresholds (detection the original nine)
 	"redundant_doc_threshold",
 	"redundant_cache_threshold",
 	"redundant_perm_threshold",
@@ -196,16 +196,16 @@ _SENSITIVITY_KEYS = (
 	"ai_auto_suggest_max",
 )
 
-# Named Sensitivity Profiles — the single source of truth for preset numbers
+# Named Sensitivity Profiles the single source of truth for preset numbers
 # (the DocType JS reads this via the get_config_profiles API; tests assert
 # Recommended == _DEFAULTS). "Recommended" mirrors the shipped _DEFAULTS, so a
 # user on Recommended automatically tracks any future retune. "Strict" catches
 # more (lower count/ms thresholds, lower %); "Relaxed" catches less. All values
-# respect the controller's _NUMERIC_FLOORS. "Custom" is intentionally absent —
+# respect the controller's _NUMERIC_FLOORS. "Custom" is intentionally absent
 # _resolve keys off ``_PROFILES.get(profile)`` so Custom falls through to the
 # stored-value logic. Build Recommended from _DEFAULTS to prevent drift.
 #
-# Numbers below mirror the "Reference values — Strict: X · Recommended: Y ·
+# Numbers below mirror the "Reference values: Strict: X · Recommended: Y ·
 # Relaxed: Z" triplet baked into each field's DocType description, so the
 # operator-facing form text and the resolve-path behaviour stay in sync.
 # ``test_profiles_match_doctype_reference_values`` regression-guards the
@@ -218,11 +218,11 @@ _PROFILES = {
 		# Fields with a "0 = unlimited" sentinel that the read site
 		# honors use 0 where the user actually wants unbounded behavior
 		# (Strict catches the longest possible report by not capping
-		# the data) — but only when leaving zero around makes
+		# the data) but only when leaving zero around makes
 		# operational sense. Session retention isn't one of them: a
 		# Strict deployment treats old session rows as housekeeping
 		# liability, so we set it to 1 day instead of 0/forever. Same
-		# logic for the two display-style "min" timings — Strict's
+		# logic for the two display-style "min" timings Strict's
 		# floor isn't literal-zero noise (sampler jitter, sub-ms
 		# children) but a small meaningful floor: 1ms for action
 		# visibility, 10ms for hot-chain expansion.
@@ -296,7 +296,7 @@ class OptimusConfig:
 	session_retention_days: int = 30
 	tracked_apps: tuple[str, ...] = field(default_factory=tuple)
 	# v0.6.x: drop findings whose blame app is in this tuple (both sections).
-	# v0.13.x: dataclass default mirrors ``_DEFAULTS`` — fresh installs
+	# v0.13.x: dataclass default mirrors ``_DEFAULTS``: fresh installs
 	# get every Frappe-organization-maintained app seeded into the DocType,
 	# and the no-bench / pre-migrate fallback path returns the same tuple
 	# so pure-Python unit tests see the same behaviour as the bench.
@@ -349,13 +349,13 @@ class OptimusConfig:
 	# Small Text fields by splitting on newlines and dropping comments.
 	skip_request_paths: tuple[str, ...] = field(default_factory=tuple)
 	skip_users: tuple[str, ...] = field(default_factory=tuple)
-	# v0.7.x+ — additive lists for capture-time redaction. Defaults
+	# v0.7.x+ additive lists for capture-time redaction. Defaults
 	# carry the 12 canonical patterns inside optimus.redaction; these
-	# extend them. Never replace — a config typo can't disable
+	# extend them. Never replace a config typo can't disable
 	# redaction of a known-sensitive key.
 	sensitive_sql_columns: tuple[str, ...] = field(default_factory=tuple)
 	sensitive_form_keys: tuple[str, ...] = field(default_factory=tuple)
-	# v0.6.0: AI "suggest a fix" config. Non-secret only — the API key is
+	# v0.6.0: AI "suggest a fix" config. Non-secret only the API key is
 	# never cached here (see _DEFAULTS note + ai_fix._resolve_provider).
 	ai_enabled: bool = False
 	ai_provider: str = "Anthropic"
@@ -398,7 +398,7 @@ def _read_doctype_row() -> dict | None:
 
 	We use ``get_single_value`` per-field instead of ``get_single`` so
 	we can degrade cleanly when ``Optimus Settings`` isn't yet in the
-	schema — some deployments install the app but haven't migrated.
+	schema some deployments install the app but haven't migrated.
 	"""
 	import frappe
 	try:
@@ -407,7 +407,7 @@ def _read_doctype_row() -> dict | None:
 		if not frappe.db.exists("DocType", "Optimus Settings"):
 			return None
 	except Exception:
-		# frappe.db unavailable (e.g. schema still loading) — defaults.
+		# frappe.db unavailable (e.g. schema still loading) defaults.
 		return None
 
 	try:
@@ -417,7 +417,7 @@ def _read_doctype_row() -> dict | None:
 
 	return {
 		"enabled": bool(doc.get("enabled", 1)),
-		# v0.13.x: 0 is legitimate (= keep forever — janitor early-returns).
+		# v0.13.x: 0 is legitimate (= keep forever janitor early-returns).
 		# Was ``or 30`` which silently clobbered the operator's "forever"
 		# intent. Preserve the stored value; ``_sens_int_zero_ok`` does
 		# the missing-value fallback.
@@ -436,7 +436,7 @@ def _read_doctype_row() -> dict | None:
 			if (row.app_name or "").strip()
 		),
 		"hide_framework_tables": bool(doc.get("hide_framework_tables", 1)),
-		# v0.13.x: 0 is legitimate (= no cap — enrich every query). Was
+		# v0.13.x: 0 is legitimate (= no cap enrich every query). Was
 		# ``or None`` which fell through to MAX_QUERIES_ENRICHED_PER_
 		# RECORDING. Coerce to int, preserve 0.
 		"max_queries_per_recording": (
@@ -473,7 +473,7 @@ def _read_doctype_row() -> dict | None:
 			int(doc.get("phase2_max_runs_per_session"))
 			if doc.get("phase2_max_runs_per_session") is not None else None
 		),
-		# 0 is legitimate (= don't wait) — don't fall through to the default.
+		# 0 is legitimate (= don't wait) don't fall through to the default.
 		"background_job_wait_seconds": int(
 			doc.get("background_job_wait_seconds", _DEFAULTS["background_job_wait_seconds"]) or 0
 		),
@@ -497,7 +497,7 @@ def _read_doctype_row() -> dict | None:
 		"sensitive_sql_columns": _parse_skip_list(doc.get("sensitive_sql_columns")),
 		"sensitive_form_keys": _parse_skip_list(doc.get("sensitive_form_keys")),
 		# v0.6.0 AI fix config (non-secret). ``ai_enabled`` /
-		# ``ai_auto_suggest`` are Checks — can't use ``or None`` because
+		# ``ai_auto_suggest`` are Checks can't use ``or None`` because
 		# False is legitimate. ``ai_auto_suggest_max`` allows 0 (= all).
 		"ai_enabled": bool(doc.get("ai_enabled")),
 		"ai_provider": (doc.get("ai_provider") or "").strip() or None,
@@ -505,14 +505,14 @@ def _read_doctype_row() -> dict | None:
 		"ai_model": (doc.get("ai_model") or "").strip() or None,
 		"ai_auto_suggest": bool(doc.get("ai_auto_suggest")),
 		"ai_auto_suggest_max": int(doc.get("ai_auto_suggest_max") or 0),
-		# Default-on (when AI is enabled) — pass a default to .get() so a
+		# Default-on (when AI is enabled) pass a default to .get() so a
 		# Single row predating this field still reads as True.
 		"ai_humanize_steps": bool(doc.get("ai_humanize_steps", 1)),
 		"ai_suggest_findings": bool(doc.get("ai_suggest_findings", 1)),
 		"ai_suggest_indexes": bool(doc.get("ai_suggest_indexes", 1)),
 		# v0.7.x: Sensitivity Profile. Empty / missing (a pre-profile Single
 		# that predates the field, or an unsaved fresh Single) coalesces to
-		# "Custom" so existing stored thresholds keep driving analysis — no
+		# "Custom" so existing stored thresholds keep driving analysis no
 		# migration patch, no silent reset to Recommended.
 		"config_profile": (doc.get("config_profile") or "Custom"),
 		# v0.9.0: AI privacy. Exclusion list parsed with the same skip-list
@@ -587,7 +587,7 @@ def _resolve() -> OptimusConfig:
 		return int(_DEFAULTS[key])
 
 	# v0.7.x: Sensitivity Profile. A named preset (Strict/Recommended/Relaxed)
-	# is authoritative for the nine _SENSITIVITY_KEYS — it overrides both the
+	# is authoritative for the nine _SENSITIVITY_KEYS it overrides both the
 	# stored field value and the site_config fallback. "Custom" (or any
 	# unknown/absent value) → preset is None → fall through to the existing
 	# per-field precedence (DocType row > site_config > default).
@@ -606,7 +606,7 @@ def _resolve() -> OptimusConfig:
 
 	# v0.13.x: zero-allowed sensitivity fields use this helper instead of
 	# the generic ``_sens_int`` so an operator who wrote 0 in the form
-	# (under Custom) gets 0 — not the _DEFAULTS fallback the truthy-check
+	# (under Custom) gets 0 not the _DEFAULTS fallback the truthy-check
 	# in ``_threshold`` would trigger.
 	def _sens_int_zero_ok(key: str) -> int:
 		if preset is not None:
@@ -626,12 +626,12 @@ def _resolve() -> OptimusConfig:
 
 	return OptimusConfig(
 		enabled=bool(row.get("enabled", _DEFAULTS["enabled"])),
-		# v0.13.x: profile-aware. 0 is legitimate (= forever — janitor
+		# v0.13.x: profile-aware. 0 is legitimate (= forever janitor
 		# treats it as "never sweep"), so use the zero-OK variant.
 		session_retention_days=_sens_int_zero_ok("session_retention_days"),
 		tracked_apps=tuple(row.get("tracked_apps") or ()),
 		# v0.13.x: fall through to ``_DEFAULTS["ignored_apps"]`` (frappe +
-		# erpnext) when the DocType row hasn't populated this field —
+		# erpnext) when the DocType row hasn't populated this field
 		# i.e. when ``_read_doctype_row`` returned ``None`` (fresh install
 		# / pre-migrate). On a real bench the install hook seeds the
 		# rows themselves, so the row read returns the configured tuple
@@ -645,10 +645,10 @@ def _resolve() -> OptimusConfig:
 			if "hide_framework_tables" in row
 			else _DEFAULTS["hide_framework_tables"]
 		),
-		# v0.13.x: profile-aware. 0 is legitimate (= no cap — analyze
+		# v0.13.x: profile-aware. 0 is legitimate (= no cap analyze
 		# enriches every query); zero-OK variant preserves it.
 		max_queries_per_recording=_sens_int_zero_ok("max_queries_per_recording"),
-		# Original nine detection-sensitivity knobs — profile-aware
+		# Original nine detection-sensitivity knobs profile-aware
 		# (see _sens_* above). Still here for clarity.
 		redundant_doc_threshold=_sens_int("redundant_doc_threshold"),
 		redundant_cache_threshold=_sens_int("redundant_cache_threshold"),
@@ -663,7 +663,7 @@ def _resolve() -> OptimusConfig:
 		pyinstrument_sampler_interval_ms=_sens_float("pyinstrument_sampler_interval_ms"),
 		# v0.13.x: profile-aware. ``min_action_duration_ms`` allows 0 as a
 		# legitimate "show everything" sentinel, so we use the
-		# zero-OK variant — under Custom, a stored 0 doesn't fall
+		# zero-OK variant under Custom, a stored 0 doesn't fall
 		# through to the default.
 		min_action_duration_ms=_sens_float_zero_ok("min_action_duration_ms"),
 		# v0.13.x: profile-aware (was ``_float``).
@@ -683,7 +683,7 @@ def _resolve() -> OptimusConfig:
 		background_job_wait_seconds=max(
 			0, min(300, _sens_int_zero_ok("background_job_wait_seconds"))
 		),
-		# v0.13.x: profile-aware. 0 is legitimate for both — depth 0 =
+		# v0.13.x: profile-aware. 0 is legitimate for both depth 0 =
 		# walk to leaves, min_ms 0 = no minimum. Zero-OK variants.
 		auto_expand_max_depth=_sens_int_zero_ok("auto_expand_max_depth"),
 		auto_expand_min_ms=_sens_float_zero_ok("auto_expand_min_ms"),
@@ -704,7 +704,7 @@ def _resolve() -> OptimusConfig:
 			if "ai_auto_suggest" in row
 			else _DEFAULTS["ai_auto_suggest"]
 		),
-		# v0.13.x: profile-aware. Allows 0 (= every eligible finding) —
+		# v0.13.x: profile-aware. Allows 0 (= every eligible finding)
 		# the zero-OK variant keeps a stored 0 under Custom.
 		ai_auto_suggest_max=_sens_int_zero_ok("ai_auto_suggest_max"),
 		ai_humanize_steps=bool(
@@ -724,7 +724,7 @@ def _resolve() -> OptimusConfig:
 		),
 		config_profile=profile,
 		# v0.9.0: AI privacy. Tuple straight through (already parsed in
-		# _read_doctype_row). Timeout clamped to [10, 600] — below 10s
+		# _read_doctype_row). Timeout clamped to [10, 600] below 10s
 		# breaks the LLM round-trip; above 600s holds the analyze worker
 		# longer than the time budget is willing to tolerate anyway.
 		ai_excluded_finding_types=tuple(row.get("ai_excluded_finding_types") or ()),
@@ -736,7 +736,7 @@ def get_config() -> OptimusConfig:
 	"""Return the resolved config, cached in Redis until the Single is
 	saved (controller's on_update deletes the cache key).
 
-	Fails soft — on ANY exception during lookup (including Frappe not
+	Fails soft on ANY exception during lookup (including Frappe not
 	being importable in unit-test contexts), returns the hardcoded
 	defaults. The profiler must never crash a request because of a
 	settings read, especially on bench startup before Redis is warm.
@@ -744,7 +744,7 @@ def get_config() -> OptimusConfig:
 	try:
 		import frappe
 	except ImportError:
-		# Unit-test path — no bench context.
+		# Unit-test path no bench context.
 		return OptimusConfig()
 
 	try:
@@ -755,7 +755,7 @@ def get_config() -> OptimusConfig:
 		# legacy bare-dict shape (pre-v0.12.11 writes still flow through
 		# unchanged via the legacy-detection branch). On a schema-version
 		# bump WITHOUT a migration, ``unwrap_value`` returns ``(default=
-		# None, observed_version)`` — the request falls through to the slow
+		# None, observed_version)``: the request falls through to the slow
 		# path (``_resolve``) and re-writes a fresh envelope.
 		from optimus import redis_schema
 
@@ -784,12 +784,12 @@ def get_config() -> OptimusConfig:
 
 
 def is_enabled() -> bool:
-	"""Convenience wrapper — hot-path entry point from hooks_callbacks."""
+	"""Convenience wrapper hot-path entry point from hooks_callbacks."""
 	try:
 		return get_config().enabled
 	except Exception:
 		# Fail open: if we can't read the setting, don't silently
-		# disable the profiler — that would be a very confusing
+		# disable the profiler that would be a very confusing
 		# support issue ("why isn't recording working"). Default to
 		# on, matching the DocType default.
 		return True
@@ -810,8 +810,8 @@ def get_tracked_apps() -> tuple[str, ...]:
 
 
 def get_ignored_apps() -> tuple[str, ...]:
-	"""v0.6.x: exclusion list — apps whose findings are dropped from the
-	report entirely (both ``Findings — what to fix`` and ``Framework-level
+	"""v0.6.x: exclusion list apps whose findings are dropped from the
+	report entirely (both ``Findings what to fix`` and ``Framework-level
 	observations``). Empty tuple → no findings dropped."""
 	try:
 		return get_config().ignored_apps

--- a/optimus/templates/report.html
+++ b/optimus/templates/report.html
@@ -296,7 +296,7 @@
   /* Explicit URL-column width so it isn't squeezed to a sliver on narrow viewports. */
   table.xhr-timing-table col.col-url    { width: 34%; }
 
-  /* Frontend disclosure table — URL takes the bulk, Duration stays
+  /* Frontend disclosure table URL takes the bulk, Duration stays
      narrow, Reason wraps in whatever's left. */
   table.orphaned-xhrs-table { table-layout: fixed; }
   table.orphaned-xhrs-table col.col-url { width: 60%; }
@@ -314,7 +314,7 @@
   table.db-tables-table tbody td:first-child { overflow-wrap: anywhere; }
   /* col.col-url uses the remaining width implicitly (auto) */
 
-  /* resource-table column widths — pairs with the tbl-clip class
+  /* resource-table column widths pairs with the tbl-clip class
      on the same table. Without these the fixed-layout distributes
      width equally and the `#` column gets ~14% of the table while
      the Action column gets crammed. */
@@ -323,7 +323,7 @@
   table.resource-table col.col-num-wide { width: 110px; }
   /* col.col-action gets the remaining width implicitly (auto). */
 
-  /* Queries-per-action flat table — same fixed-column scheme as the resource
+  /* Queries-per-action flat table same fixed-column scheme as the resource
      table so long action labels / callsite paths wrap inside their columns
      and the numeric columns stay aligned (instead of the auto-layout ragged
      widths). col.col-action takes the remaining width. */
@@ -339,7 +339,7 @@
      indexes fit inside the narrow col-idx without wrapping. The
      default table.data td padding (14px each side) eats 28px of
      column width before content; with col-idx at 32-40px, that
-     leaves 4-12px of content area — not enough for "10" or
+     leaves 4-12px of content area not enough for "10" or
      "999". This override gives ~28px of content room at 40px
      total width (40 − 12 = 28). */
   table.per-action-table tbody td:first-child,
@@ -691,7 +691,7 @@
   .kpi-value.danger { color: var(--accent); }
   .kpi-unit { font-size: 14px; color: var(--ink-mute); font-weight: 400; margin-left: 2px; }
   .kpi-sub { font-size: 12px; color: var(--ink-soft); margin-top: 6px; line-height: 1.45; }
-  /* C.UT2: tiny caveat line under a KPI's sub-text — explains a known
+  /* C.UT2: tiny caveat line under a KPI's sub-text explains a known
      limitation of the metric (e.g. sampler interval for Total time). */
   .kpi-caveat {
     font-size: 11px;
@@ -708,7 +708,7 @@
      -----
      Terminology decision (U1, intentional split):
      - Data-layer field names use ``cumulative_ms`` (pyinstrument's
-       term — sum of self_time + descendant time).
+       term sum of self_time + descendant time).
      - UI text uses ``consolidated`` (the user-facing word, picked
        by the project owner for the scope-tag vocabulary).
      This split is intentional. Keep cumulative_ms in fixtures /
@@ -725,7 +725,7 @@
        quietly clipping mid-word. */
     white-space: nowrap;
   }
-  /* Stack scope-tag sub-labels BELOW the main header text — keeps tight
+  /* Stack scope-tag sub-labels BELOW the main header text keeps tight
      numeric columns from having their sub-labels (e.g. "per hit", "per req
      · all queries") overflow into the next column's header. The
      vitals-table used to override this case-by-case; now it's the default
@@ -879,7 +879,7 @@
     color: var(--ink-soft); font-variant-numeric: tabular-nums;
   }
   .waterfall-time.hot { color: var(--accent); font-weight: 600; }
-  /* a11y: per-bar text label (redundant with bar colour). Mini severity pill —
+  /* a11y: per-bar text label (redundant with bar colour). Mini severity pill
      reuses the --X-soft bg + --X text pairing so it's legible over any bar and
      passes AA in light + dark. */
   .bar-label {
@@ -1004,7 +1004,7 @@
   .code-block .added { color: #6A9955; }
   .code-block .removed { color: #F48771; text-decoration: line-through; opacity: 0.85; }
 
-  /* VS Code Dark Modern token palette — smoking-gun .code-block
+  /* VS Code Dark Modern token palette smoking-gun .code-block
      snippet only. The hot-line amber wrapper sits OUTSIDE these
      per-token spans so the highlight composes correctly. */
   .code-block .tok-k, .code-block .tok-kn        { color: #C586C0; }
@@ -1027,7 +1027,7 @@
   .code-block .tok-cm                            { color: #6A9955; font-style: italic; }
   .code-block .tok-o, .code-block .tok-p         { color: #D4D4D4; }
 
-  /* VS Code Light Modern token palette — Line-Level Drilldown
+  /* VS Code Light Modern token palette Line-Level Drilldown
      .line-prof table only (light to match the editorial report
      page). */
   .line-prof .tok-k, .line-prof .tok-kn, .line-prof .tok-kc,
@@ -1472,7 +1472,7 @@
   .job-status-warn { background: var(--warn-soft); color: var(--warn); }
   .job-status-info { background: var(--info-soft); color: var(--info); }
   .job-status-mute { background: var(--rule); color: var(--ink-mute); }
-  /* v0.7.x: RQ Jobs table was cramped across 8 columns — give Method room and
+  /* v0.7.x: RQ Jobs table was cramped across 8 columns give Method room and
      keep the numeric columns tight (fixed layout so the colgroup widths hold). */
   table.bg-jobs-table { table-layout: fixed; }
   table.bg-jobs-table .bgcol-idx { width: 30px; }
@@ -1538,7 +1538,7 @@
   table.line-prof tbody tr.hot td.num { color: var(--accent); font-weight: 600; }
   /* v0.7.x: dim lines that never executed (0 hits / 0ms) - def, comments,
      blank, closing parens - so the lines that actually ran stand out. */
-  /* a11y: dim 0-hit lines via the (now AA-compliant) mute token, not opacity —
+  /* a11y: dim 0-hit lines via the (now AA-compliant) mute token, not opacity
      opacity dropped them back under 4.5:1. Still reads dimmer than the near-black hot lines. */
   table.line-prof tbody tr.zero td { color: var(--ink-mute); }
   table.line-prof tbody tr.added td { background: rgba(45, 106, 60, 0.12); }
@@ -1998,7 +1998,7 @@
     {% if f.llm_fix and f.llm_fix.suggestion_html and not hide_ai_fix %}
     <div class="fix-box">
       <div class="fix-head">
-        <span>Suggested fix <span class="fix-badge">Unverified &mdash; review before applying</span></span>
+        <span>Suggested fix <span class="fix-badge">Unverified review before applying</span></span>
         <span class="ai-tag">AI{% if f.llm_fix.model %} &middot; {{ f.llm_fix.model }}{% endif %}{% if f.llm_fix.tokens and f.llm_fix.tokens.total_tokens %} &middot; {{ f.llm_fix.tokens.total_tokens }} tokens{% endif %}</span>
       </div>
       {% if not f.llm_fix.source_available %}
@@ -2132,7 +2132,7 @@
   {% if action.related_findings %}
   <tr>
     <td colspan="7" class="row-finding">
-      {# Count-only header — the finding card(s) render right below and carry the
+      {# Count-only header the finding card(s) render right below and carry the
          title + impact + detail, so echoing the title here just duplicated it
          (mirrors the clean bg_job_row header). #}
       &#9888; <strong>{{ action.related_findings | length }} finding{{ "s" if action.related_findings | length != 1 else "" }} linked to this action</strong>
@@ -2381,7 +2381,7 @@
      v0.7.x Phase A: restyled as nav pills (editorial design tokens).
      Anchors unchanged so external links / docs still resolve. The
      "Jump to" navigational cue lives in aria-label on the <nav>
-     itself — visually clean, still announced by screen readers. #}
+     itself visually clean, still announced by screen readers. #}
   <nav class="nav-pills" aria-label="Jump to">
     {% if report_data.line_drilldown_html %}<a href="#line-drilldown">Line-Level Drilldown</a>{% endif %}
     <a href="#findings">Findings</a>
@@ -2533,7 +2533,7 @@
       <p class="small muted" style="font-style: italic;">
         Note: finding impacts may overlap when several findings cover the
         same code path (e.g. a Slow Hot Path and an N+1 inside the same
-        function) &mdash; don't sum <em>estimated_impact_ms</em> across findings.
+        function) don't sum <em>estimated_impact_ms</em> across findings.
       </p>
 
       {% if report_data.findings_by_app | length == 1 %}
@@ -2703,12 +2703,12 @@
             <td class="num"><strong>{{ fmt_ms(report_data.actions | map(attribute='duration_ms') | map('default', 0) | sum) }}</strong></td>
             <td class="num"><strong>{{ report_data.actions | map(attribute='queries_count') | map('default', 0) | sum }}</strong></td>
             <td class="num"><strong>{{ fmt_ms(report_data.actions | map(attribute='query_time_ms') | map('default', 0) | sum) }}</strong></td>
-            <td class="num muted" title="Per-row maxes are not additive — column total intentionally suppressed">&mdash;</td>
+            <td class="num muted" title="Per-row maxes are not additive, so the column total is intentionally suppressed"></td>
           </tr>
         </tfoot>
       </table>
       <p class="small muted" style="font-style: italic; margin-top: 6px;">
-        Note: <em>Slowest query</em> values are per-row maxes &mdash; don't sum them.
+        Note: <em>Slowest query</em> values are per-row maxes don't sum them.
         Use the <em>DB time</em> column when you want a column total.
       </p>
       {% else %}
@@ -2782,7 +2782,7 @@
     <p class="small muted" style="font-style: italic;">
       Note: the consolidated total sums each job's wall time. If your
       bench runs multiple RQ workers in parallel, the actual elapsed
-      pool time may be less than this sum &mdash; the per-job Duration
+      pool time may be less than this sum the per-job Duration
       column shows each job's true wall.
     </p>
     <p class="small muted">
@@ -2825,17 +2825,17 @@
       <tfoot>
         <tr class="totals-row">
           <td colspan="2"><strong>Total / {{ report_data.background_jobs | length }} job{{ 's' if report_data.background_jobs | length != 1 else '' }}</strong></td>
-          <td class="muted">&mdash;</td>
+          <td class="muted"></td>
           <td class="num"><strong>{{ fmt_ms(report_data.background_jobs | map(attribute='duration_ms') | map('default', 0) | sum) }}</strong></td>
           <td class="num"><strong>{{ report_data.background_jobs | map(attribute='queries_count') | map('default', 0) | sum }}</strong></td>
           <td class="num"><strong>{{ fmt_ms(report_data.background_jobs | map(attribute='query_time_ms') | map('default', 0) | sum) }}</strong></td>
-          <td class="num muted" title="Per-row maxes are not additive — column total intentionally suppressed">&mdash;</td>
+          <td class="num muted" title="Per-row maxes are not additive, so the column total is intentionally suppressed"></td>
           {% if report_data.background_jobs_summary.any_findings_counted %}<td class="num"><strong>{{ report_data.background_jobs | map(attribute='findings_count') | map('default', 0) | sum }}</strong></td>{% endif %}
         </tr>
       </tfoot>
     </table>
     <p class="small muted" style="font-style: italic; margin-top: 6px;">
-      Note: <em>Slowest query</em> values are per-row maxes &mdash; don't sum them.
+      Note: <em>Slowest query</em> values are per-row maxes don't sum them.
       Use the <em>DB time</em> column when you want a column total.
     </p>
     {% else %}
@@ -3174,7 +3174,7 @@
         <tr>
           <th>Function</th>
           <th class="num">Total time <small class="scope-tag">consolidated</small></th>
-          <th class="num" title="Sampler hits — proportional to call count but not exact. Use Line-Level Drilldown for a true call count.">Samples</th>
+          <th class="num" title="Sampler hits proportional to call count but not exact. Use Line-Level Drilldown for a true call count.">Samples</th>
           <th class="num">Distinct actions</th>
         </tr>
       </thead>
@@ -3192,7 +3192,7 @@
       <summary class="small muted"><strong>{{ report_data.hot_frames_framework | length }}</strong> framework frame{{ "s" if report_data.hot_frames_framework | length != 1 else "" }} (click to expand) - <code>frappe</code>, <code>erpnext</code>, and friends; the developer can't easily patch these</summary>
       <p class="small muted" style="margin: 6px 0 8px; font-style: italic;">
         Framework rows show <em>cumulative</em> time (includes nested
-        calls) &mdash; wrapper self-time is sub-sampler-interval and
+        calls) wrapper self-time is sub-sampler-interval and
         would round to 0ms otherwise.
       </p>
       <table class="data hot-frames-table">
@@ -3200,7 +3200,7 @@
           <tr>
             <th>Function</th>
             <th class="num">Total time <small class="scope-tag">consolidated</small></th>
-            <th class="num" title="Sampler hits — proportional to call count but not exact. Use Line-Level Drilldown for a true call count.">Samples</th>
+            <th class="num" title="Sampler hits proportional to call count but not exact. Use Line-Level Drilldown for a true call count.">Samples</th>
             <th class="num">Distinct actions</th>
           </tr>
         </thead>
@@ -3229,7 +3229,7 @@
         additional quer{{ "ies" if report_data.top_queries_suppressed_count != 1 else "y" }}
         cleared the {{ '%.0f'|format(report_data.top_queries_slow_threshold_ms) }}ms slow threshold but
         {{ "were" if report_data.top_queries_suppressed_count != 1 else "was" }} suppressed from the
-        Findings list to avoid noise &mdash; the full leaderboard above shows
+        Findings list to avoid noise the full leaderboard above shows
         every query above the 10ms display floor.
       </p>
       {% endif %}
@@ -3257,7 +3257,7 @@
     {% else %}
       <div class="empty-state">
         <div class="empty-icon">&check; Clear</div>
-        <p>No queries cleared the 10ms display floor this session &mdash; sub-10ms queries are hidden by default to avoid noise. The per-action breakdown below lists every query, fast and framework ones included.</p>
+        <p>No queries cleared the 10ms display floor this session sub-10ms queries are hidden by default to avoid noise. The per-action breakdown below lists every query, fast and framework ones included.</p>
       </div>
     {% endif %}
     {% if report_data.slow_queries_framework %}
@@ -3299,7 +3299,7 @@
 
     {# Flatten each action's queries into one list, then show the global slowest
        in a single flat table (like Server Resource). Collecting each action's
-       top-20 bounds the work and still captures the overall top-N — a query
+       top-20 bounds the work and still captures the overall top-N a query
        outside its own action's top-20 can't be in the global top-N. #}
     {% set ns = namespace(rows=[]) %}
     {% for action in (report_data.actions + (report_data.actions_framework or [])) %}
@@ -3417,7 +3417,7 @@
          get cards: a concrete `recommended_index` (LLM-vetted) or
          at least one heuristic `index_candidates` column. The
          "nothing to suggest" branches (Frappe meta tables, framework-
-         only filters, full-scan reads) are skipped — they took space
+         only filters, full-scan reads) are skipped they took space
          without telling the reader anything actionable. #}
       {% set _rec_tables = [] %}
       {% for t in report_data.db.tables %}
@@ -3507,10 +3507,10 @@
       <li>The server-resource and frontend panels show CPU / memory / queue pressure and browser timings - only when captured.</li>
       <li>Expand any row of the per-action breakdown for that action's queries and timings - the deep-dive detail.</li>
       <li>Click any <code>file.py:123</code> callsite to open it in VS&nbsp;Code. Anything starting with <code>tab</code> is a database table; the DocType is the part after <code>tab</code>.</li>
-      <li>Every duration carries a small grey scope tag: <strong>per hit</strong> (one occurrence — a single request, one query execution) or <strong>consolidated</strong> (sum across all hits in this session — total time in a table, full impact of a finding's pattern, etc.).</li>
-      <li>Call-tree and Hot-frame timings come from a wall-clock sampler at ≈{{ report_data.sampler_interval_ms }}ms intervals. Functions whose execution is shorter than the interval can be under-sampled or invisible — for exact per-line timings, use the <strong>Line-Level Drilldown</strong>.</li>
-      <li><strong>Self-time</strong> is wall-clock self-time (the sampler measures elapsed time, not CPU). A function that blocks on I/O — <code>requests.get</code>, sync DB calls outside the recorder, <code>time.sleep</code> — counts that wait as self-time. Check the call tree for hidden I/O before optimising compute.</li>
-      <li><strong>Searching with browser find (Ctrl/Cmd-F)?</strong> Text inside collapsed drilldowns and call-tree branches may not be matched — expand the sections you want to search first.</li>
+      <li>Every duration carries a small grey scope tag: <strong>per hit</strong> (one occurrence a single request, one query execution) or <strong>consolidated</strong> (sum across all hits in this session total time in a table, full impact of a finding's pattern, etc.).</li>
+      <li>Call-tree and Hot-frame timings come from a wall-clock sampler at ≈{{ report_data.sampler_interval_ms }}ms intervals. Functions whose execution is shorter than the interval can be under-sampled or invisible for exact per-line timings, use the <strong>Line-Level Drilldown</strong>.</li>
+      <li><strong>Self-time</strong> is wall-clock self-time (the sampler measures elapsed time, not CPU). A function that blocks on I/O <code>requests.get</code>, sync DB calls outside the recorder, <code>time.sleep</code> counts that wait as self-time. Check the call tree for hidden I/O before optimising compute.</li>
+      <li><strong>Searching with browser find (Ctrl/Cmd-F)?</strong> Text inside collapsed drilldowns and call-tree branches may not be matched expand the sections you want to search first.</li>
     </ul>
   </section>
 

--- a/optimus/tests/conftest.py
+++ b/optimus/tests/conftest.py
@@ -3,7 +3,7 @@
 
 """Pytest configuration for optimus analyzer tests.
 
-These tests are deliberately decoupled from Frappe — each analyzer is
+These tests are deliberately decoupled from Frappe each analyzer is
 a pure function over a list of recording dicts, so we can exercise them
 with JSON fixtures and no running site. Run with:
 
@@ -55,7 +55,7 @@ except ImportError:
 	def _stub_get_bench_path():
 		# Two levels above the package root, so a relpath of files inside
 		# the package against this value yields a tidy display like
-		# ``<package>/<package>/<file>.py`` — that's the shape the
+		# ``<package>/<package>/<file>.py``: that's the shape the
 		# ``_action_entry_callsite`` tests assert on (``endswith
 		# 'optimus/renderer.py'``).
 		here = os.path.abspath(__file__)  # .../optimus/tests/conftest.py
@@ -67,12 +67,12 @@ except ImportError:
 		m = _types.ModuleType(name)
 		# Mark every stub module as a package so submodule attribute access
 		# (e.g. ``frappe.utils.X`` after ``import frappe.utils.X``) works.
-		m.__path__ = []  # arbitrary — Python only needs the attribute to exist
+		m.__path__ = []  # arbitrary Python only needs the attribute to exist
 		for k, v in attrs.items():
 			setattr(m, k, v)
 		sys.modules[name] = m
 		# Link as an attribute on the parent module so ``frappe.utils`` style
-		# access works after ``import frappe.utils`` — Python's import machinery
+		# access works after ``import frappe.utils``: Python's import machinery
 		# normally does this, but only for real packages on disk.
 		if "." in name:
 			parent_name, leaf = name.rsplit(".", 1)
@@ -91,7 +91,7 @@ except ImportError:
 		# tmp_path fixtures pointing at /tmp/... aren't rejected. On a real
 		# bench the same path-resolution attempt raises RuntimeError from
 		# the unbound LocalProxy and the boundary check's outer try/except
-		# catches that — but the SimpleNamespace stub returns False instead
+		# catches that but the SimpleNamespace stub returns False instead
 		# of raising, so we have to set the flag explicitly here.
 		flags=_types.SimpleNamespace(in_test=True),
 		cache=_types.SimpleNamespace(),
@@ -105,7 +105,7 @@ except ImportError:
 		# Real frappe exposes a top-level ``frappe.has_permission`` (re-export of
 		# frappe.permissions.has_permission). The baseline stub must too:
 		# ``api._require_session_permission`` calls ``frappe.has_permission`` and now
-		# fails CLOSED if it raises — so a MISSING stub attribute (AttributeError)
+		# fails CLOSED if it raises so a MISSING stub attribute (AttributeError)
 		# would deny every session-scoped endpoint test. Default-allow here; the
 		# deny / fail-closed paths are covered explicitly in
 		# test_api_session_permission.py by monkeypatching this.
@@ -143,7 +143,7 @@ except ImportError:
 	)
 	_mk_module("frappe.database")
 	_mk_module("frappe.database.utils", is_query_type=lambda *a, **kw: False)
-	# ``rate_limit`` is a decorator factory — ``@rate_limit(key=..., limit=...,
+	# ``rate_limit`` is a decorator factory ``@rate_limit(key=..., limit=...,
 	# seconds=...)`` wraps API handlers in optimus/api.py. The stub returns a
 	# no-op decorator so the wrapped functions stay callable for tests.
 	_mk_module(
@@ -179,11 +179,11 @@ except ImportError:
 # This autouse fixture snapshots ``sys.modules`` BEFORE each test and
 # restores it AFTER, so any test's mutations are contained to that test
 # regardless of whether the test itself remembered to clean up. Cost per
-# test: a shallow ``dict()`` of ~hundreds of keys — well under 1ms.
+# test: a shallow ``dict()`` of ~hundreds of keys well under 1ms.
 #
 # Modules a test legitimately ADDS during its run (e.g. importing a fresh
 # patch module to ``importlib.reload`` it) are dropped from sys.modules
-# at teardown ONLY when they're one of the known pollution targets — so
+# at teardown ONLY when they're one of the known pollution targets so
 # we don't churn the import cache for unrelated tests, but we also don't
 # let stub-installed shims leak.
 _POLLUTION_PRONE_MODULES = frozenset({
@@ -194,7 +194,7 @@ _POLLUTION_PRONE_MODULES = frozenset({
 
 # optimus modules that ``import frappe`` at module top. Their
 # top-level binding captures whatever was in ``sys.modules["frappe"]``
-# AT IMPORT TIME — so if they get imported while a test has installed a
+# AT IMPORT TIME so if they get imported while a test has installed a
 # stub-frappe (and then the fence restores the real frappe at teardown),
 # their captured reference is now stale. We evict these from
 # ``sys.modules`` when we detect the frappe-swap so the next test
@@ -219,7 +219,7 @@ def _sys_modules_fence():
 	try:
 		yield
 	finally:
-		# Detect frappe-swap BEFORE we restore sys.modules — that's the
+		# Detect frappe-swap BEFORE we restore sys.modules that's the
 		# signal that cached optimus.* modules now hold stale refs.
 		frappe_was_swapped = (
 			"frappe" in sys.modules
@@ -242,7 +242,7 @@ def _sys_modules_fence():
 
 		# If frappe was swapped during this test, evict the cached
 		# frappe-dependent leaf modules. They captured the stub at module
-		# top during their import — restoring sys.modules doesn't repair
+		# top during their import restoring sys.modules doesn't repair
 		# that. Eviction forces a fresh import on next use, which rebinds
 		# their ``import frappe`` to the now-restored real module.
 		if frappe_was_swapped:
@@ -252,7 +252,7 @@ def _sys_modules_fence():
 
 @pytest.fixture(autouse=True)
 def _reset_dbdialect_cache():
-	"""Each test gets a fresh dialect adapter — prevents the cached
+	"""Each test gets a fresh dialect adapter prevents the cached
 	MariaDBDialect (and its max_connections cache) leaking across tests, and
 	lets the dialect-factory tests flip db_type freely."""
 	try:
@@ -287,7 +287,7 @@ def clean_recording():
 
 @pytest.fixture
 def empty_context():
-	"""Minimal AnalyzeContext — just enough to satisfy analyzer signatures."""
+	"""Minimal AnalyzeContext just enough to satisfy analyzer signatures."""
 	from optimus.analyzers.base import AnalyzeContext
 
 	return AnalyzeContext(session_uuid="test-uuid", docname="test-docname")

--- a/optimus/tests/fixture_builders.py
+++ b/optimus/tests/fixture_builders.py
@@ -18,7 +18,7 @@ builders reduce that to ~10 lines of Python:
     )
 
 Keep the hand-written JSON fixtures in tests/fixtures/ for integration-
-style tests — they exercise the full recording shape. Use these builders
+style tests they exercise the full recording shape. Use these builders
 for narrow unit tests that care only about one aspect (e.g. "does the
 N+1 analyzer handle this stack?").
 """

--- a/optimus/tests/test_action_context.py
+++ b/optimus/tests/test_action_context.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Unit tests for the render-time action/finding context enrichment —
+"""Unit tests for the render-time action/finding context enrichment
 ``renderer._attach_action_context`` and its helpers: which document a
 save/submit-style action touched (from the recording's form_dict) and which
 doc-event lifecycle hook a slow function fired in (from frappe's doc_events).
@@ -126,7 +126,7 @@ class TestResolveTargetDocFromResponse:
 
 	def test_non_scalar_response_name_is_rejected(self):
 		# A malformed (non-str/non-int) response name must NOT be stringified into a
-		# garbage docname — the resolver falls back to None (keep the placeholder).
+		# garbage docname the resolver falls back to None (keep the placeholder).
 		fd = {"doc": json.dumps({"doctype": "Widget", "name": "new-widget-abc"})}
 		assert self._resolve(fd, {"docs": [{"doctype": "Widget", "name": {"k": "v"}}]}) is None
 		assert self._resolve(fd, {"docs": [{"doctype": "Widget", "name": 42.0}]}) is None
@@ -155,7 +155,7 @@ class TestBuildDocEventHookIndex:
 	def test_flattens_doctype_event_methods(self):
 		idx = renderer._build_doc_event_hook_index({
 			"Sales Invoice": {"validate": ["ugly_code.x.f"], "on_submit": ["a.b.g", "a.b.g2"]},
-			"*": {"validate": "a.b.h"},  # string, not list — must still be handled
+			"*": {"validate": "a.b.h"},  # string, not list must still be handled
 		})
 		assert idx == {
 			"ugly_code.x.f": [("Sales Invoice", "validate")],
@@ -231,7 +231,7 @@ class TestAttachActionContext:
 
 	def test_temp_name_resolved_from_recording_resolved_target_doc(self):
 		# The insert request carries a "new-…" placeholder; the recording carries the
-		# real name captured from the save response — the action shows the real one.
+		# real name captured from the save response the action shows the real one.
 		actions = [self._act(0, recording_uuid="r0")]
 		recs = {"r0": {
 			"form_dict": {"doc": json.dumps({"doctype": "Sales Order", "name": "new-sales-order-abc"})},
@@ -250,7 +250,7 @@ class TestAttachActionContext:
 		assert actions[0]["target_doc"] == {"doctype": "Lead", "name": "CRM-LEAD-0001"}
 
 	def test_real_request_name_not_overridden_by_resolved(self):
-		# A real name in the request (edit/submit) is authoritative — never replaced.
+		# A real name in the request (edit/submit) is authoritative never replaced.
 		actions = [self._act(0, recording_uuid="r0")]
 		recs = {"r0": {
 			"form_dict": {"doc": json.dumps({"doctype": "Sales Order", "name": "SAL-ORD-2026-00042"})},
@@ -308,7 +308,7 @@ class TestResolvedDocSidecarWiring:
 		from optimus import hooks_callbacks
 
 		src = inspect.getsource(hooks_callbacks.after_request)
-		# The RMW imported the recorder hash and wrote it back with hset() — neither may reappear.
+		# The RMW imported the recorder hash and wrote it back with hset() neither may reappear.
 		assert "from frappe.recorder import RECORDER_REQUEST_HASH" not in src
 		assert "hset(" not in src
 

--- a/optimus/tests/test_action_entry_callsite.py
+++ b/optimus/tests/test_action_entry_callsite.py
@@ -8,7 +8,7 @@ The per-action breakdown and the RQ Jobs section identify an action
 only by a dotted module path (``ugly_code.python.common.bg_recheck_users``)
 or a URL. This resolves that entry point to ``file:line`` + a ±1-line source
 snippet. The tests resolve a real function in *this* app
-(``optimus.renderer.render``) so they're hermetic — no running site,
+(``optimus.renderer.render``) so they're hermetic no running site,
 no dependence on frappe core's layout.
 """
 
@@ -99,7 +99,7 @@ class TestActionEntryCallsite:
 		fn = cs["filename"].replace("\\", "/")
 		assert fn.endswith("optimus/renderer/_internal.py")
 		assert not os.path.isabs(cs["filename"])
-		# v0.7.x: snippet window widened from ±1 to ±4 — up to 9 rows
+		# v0.7.x: snippet window widened from ±1 to ±4 up to 9 rows
 		# centered on the target line. The target row is "def render(".
 		assert cs["source_snippet"] and len(cs["source_snippet"]) <= 5
 		target = [r for r in cs["source_snippet"] if r["lineno"] == cs["lineno"]]
@@ -161,7 +161,7 @@ class TestActionEntryCallsite:
 
 
 # ---------------------------------------------------------------------------
-# v0.6.x: _resolve_frame_key_to_callsite — Repeated Hot Frame's "path::func" key
+# v0.6.x: _resolve_frame_key_to_callsite Repeated Hot Frame's "path::func" key
 # ---------------------------------------------------------------------------
 
 class TestResolveFrameKeyToCallsite:
@@ -203,13 +203,13 @@ class TestResolveFrameKeyToCallsite:
 
 
 # ---------------------------------------------------------------------------
-# v0.6.x: _attach_representative_callsites — SQL red-flag findings ← recordings
+# v0.6.x: _attach_representative_callsites SQL red-flag findings ← recordings
 # ---------------------------------------------------------------------------
 
 # A real, readable, in-bench-but-not-frappe-app .py for the "user code" frame
 # would be ideal, but walk_callsite treats any path containing "frappe/" or
 # "optimus/" as framework/profiler-own. So use a stdlib module's file
-# (absolute, readable, neither substring) — _resolve_source_path passes
+# (absolute, readable, neither substring) _resolve_source_path passes
 # absolute paths straight through, so the snippet still reads.
 _USER_FRAME_FILE = inspect.__file__
 
@@ -324,7 +324,7 @@ class TestAttachRepresentativeCallsites:
 	def test_framework_only_stack_falls_back_to_frappe_frame(self):
 		# A query issued purely from frappe core: walk_callsite falls back to
 		# the innermost frame (so we never silently drop a legit framework
-		# finding). A callsite IS attached, pointing at frappe — still useful.
+		# finding). A callsite IS attached, pointing at frappe still useful.
 		nq = "SELECT ... FROM `tabUser`"
 		findings = [_sql_finding("Missing Index", "tabUser", nq)]
 		recs = [_rec([
@@ -415,11 +415,11 @@ class TestSkipDecoratorsToDef:
 
 	def test_non_decorated_lineno_unchanged(self, tmp_path):
 		"""When the line at start_lineno doesn't start with ``@``, the
-		early exit returns it unchanged — no scan, no false advance."""
+		early exit returns it unchanged no scan, no false advance."""
 		src = tmp_path / "fake_module.py"
 		src.write_text(
 			"line1\n"
-			"def target_fn():\n"  # 2 — already the def line
+			"def target_fn():\n"  # 2 already the def line
 			"    pass\n"
 		)
 		assert renderer._skip_decorators_to_def(
@@ -433,7 +433,7 @@ class TestSkipDecoratorsToDef:
 		src = tmp_path / "fake_module.py"
 		src.write_text(
 			"@my_decorator\n"  # 1
-			"def different_name():\n"  # 2 — name mismatch
+			"def different_name():\n"  # 2 name mismatch
 			"    pass\n"
 		)
 		assert renderer._skip_decorators_to_def(

--- a/optimus/tests/test_action_plan.py
+++ b/optimus/tests/test_action_plan.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for `renderer._build_action_plan` — the v0.7.x redesign
+"""Tests for `renderer._build_action_plan`: the v0.7.x redesign
 Phase C punch list.
 
 Top-N findings by severity → impact, each emitted as a step the

--- a/optimus/tests/test_actionable_findings_split.py
+++ b/optimus/tests/test_actionable_findings_split.py
@@ -2,10 +2,10 @@
 # For license information, please see license.txt
 
 """Tests for v0.5.2 split of findings into
-"Findings — what to fix" (actionable, concrete fixes) vs
-"Observations" (framework/system/informational — no direct fix).
+"Findings what to fix" (actionable, concrete fixes) vs
+"Observations" (framework/system/informational no direct fix).
 
-Per user feedback: "In Findings — what to fix, Show only the valid
+Per user feedback: "In Findings what to fix, Show only the valid
 fixes." The split keeps the main action-list tight and reads as a
 punchlist while the Observations section preserves full-picture
 transparency.
@@ -33,14 +33,14 @@ def test_actionable_finding_types_has_concrete_fixes_only():
 		"Slow Hot Path",
 		"Hook Bottleneck",
 		# v0.7.x: BG-job fallback finding points at the deepest
-		# user-code frame inside a slow job — a concrete callsite
+		# user-code frame inside a slow job a concrete callsite
 		# to investigate with Line-Level Drilldown.
 		"Slow Background Job",
 		"Redundant Call",
 		"Slow Frontend Render",
 		"Heavy Response",
 		# v0.6.x: Phase-2 line-profile output points at a specific line
-		# of code with a concrete refactor target — actionable.
+		# of code with a concrete refactor target actionable.
 		"Hot Line",
 	}
 	assert renderer._ACTIONABLE_FINDING_TYPES == expected_actionable, (
@@ -63,7 +63,7 @@ def test_actionable_finding_types_has_concrete_fixes_only():
 		"Network Overhead",           # client/proxy path
 	):
 		assert informational not in renderer._ACTIONABLE_FINDING_TYPES, (
-			f"{informational!r} is informational — users can't act on it "
+			f"{informational!r} is informational users can't act on it "
 			"with a shippable fix. It must NOT be in _ACTIONABLE_FINDING_TYPES."
 		)
 
@@ -73,7 +73,7 @@ def test_render_splits_findings_into_actionable_and_observational():
 	session_doc.findings into `findings` (actionable) and
 	`observational_findings` (everything else) via the allowlist.
 	Without this split, observational noise re-pollutes the main
-	'Findings — what to fix' section."""
+	'Findings what to fix' section."""
 	src = inspect.getsource(renderer.render)
 
 	# The partition must use _ACTIONABLE_FINDING_TYPES.
@@ -96,7 +96,7 @@ def test_render_splits_findings_into_actionable_and_observational():
 
 def test_template_has_observations_subsection_inside_findings():
 	"""The report template must include the Observations as a nested
-	subsection INSIDE the Findings section (v0.5.2 restructure — user
+	subsection INSIDE the Findings section (v0.5.2 restructure user
 	asked: 'If its a framework related issue then move a sub-section').
 	Without it the information disappears from the report entirely."""
 	import os
@@ -125,13 +125,13 @@ def test_template_has_observations_subsection_inside_findings():
 	subsection_marker = '<section class="subsection">'
 	assert subsection_marker in template, (
 		"Framework-level observations must be a <section class='subsection'> "
-		"block — non-collapsible by user request"
+		"block non-collapsible by user request"
 	)
 
 
 def test_render_drops_function_not_invoked_findings():
 	"""'Function Not Invoked' ("X was picked but never invoked during phase 2")
-	is non-actionable noise — the pick simply didn't run in the replay. render()
+	is non-actionable noise the pick simply didn't run in the replay. render()
 	must filter it from ``all_findings`` (not merely re-bucket it) so it leaves
 	the Findings list, the Observations subsection, AND the severity counts with
 	no phantom rows. The Line-Level Drilldown notes uninvoked picks concisely
@@ -154,11 +154,11 @@ def test_action_plan_is_built_from_actionable_findings_only():
 
 	``_build_action_plan`` is a generic top-N-by-severity/impact
 	renderer with no finding_type guard (it renders whatever it is
-	handed — see test_action_plan.py's unknown-type case). If render()
+	handed see test_action_plan.py's unknown-type case). If render()
 	feeds it ``all_findings``, an observation-only finding (Framework
 	N+1, which _action_verb_for maps to "Eliminate the N+1 query
 	(framework code)") can rank into the top-3 and print under "Fix
-	these first" with an ``est. saving`` — contradicting its own
+	these first" with an ``est. saving``: contradicting its own
 	Observations card and TL;DR hero ("not something you can change").
 	Guard the callsite at the source level so the leak can't return."""
 	src = inspect.getsource(renderer.render)
@@ -173,14 +173,14 @@ def test_action_plan_is_built_from_actionable_findings_only():
 		"observation-only findings never surface in the action plan"
 	)
 	assert "_build_action_plan(\n\t\tall_findings" not in src, (
-		"_build_action_plan must NOT be fed all_findings — that leaks "
+		"_build_action_plan must NOT be fed all_findings that leaks "
 		"observational findings into 'Fix these first'"
 	)
 
 
 def test_severity_counts_cover_all_findings():
 	"""v0.6.0: `severity_counts` (the "Issues found" stat card's sub-line)
-	must count ALL findings — actionable + observational — so the card's
+	must count ALL findings actionable + observational so the card's
 	big number (total), its sub-line, and the Summary prose's count all
 	agree. (Previously it counted actionable-only, which made the big
 	number and the breakdown disagree.)"""

--- a/optimus/tests/test_aggregate_hot_frames.py
+++ b/optimus/tests/test_aggregate_hot_frames.py
@@ -1,10 +1,10 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""D.M-S2 — hot-frames aggregation uses self_ms, not cumulative_ms.
+"""D.M-S2 hot-frames aggregation uses self_ms, not cumulative_ms.
 
 A recursive (or decorator-wrapped) function appears at multiple call-tree
-depths. Each node's ``cumulative_ms`` includes its descendants — summing
+depths. Each node's ``cumulative_ms`` includes its descendants summing
 cumulative across sibling occurrences double-counts nested self-times.
 
 The fix switched the aggregator to ``self_ms`` (exclusive per-frame), so
@@ -31,7 +31,7 @@ def _node(function, filename, cumulative, self_ms, children):
 
 def test_recursive_frame_uses_self_ms_not_cumulative():
 	"""A recursive function appearing at 3 call-tree depths must
-	contribute its self_ms once per occurrence — not its cumulative
+	contribute its self_ms once per occurrence not its cumulative
 	(which would sum nested-self-times multiple times)."""
 	# A function `rec` recursing 3 levels deep.
 	#   depth 0: cumulative=100, self=40 (inclusive of children's 60ms)
@@ -67,11 +67,11 @@ def test_recursive_frame_uses_self_ms_not_cumulative():
 	# Correct sum (self_ms): 40 + 30 + 30 = 100.
 	# Buggy sum (cumulative_ms): 100 + 60 + 30 = 190.
 	assert rec_row["total_ms"] == 100, (
-		"aggregator must sum self_ms, not cumulative_ms — got "
+		"aggregator must sum self_ms, not cumulative_ms got "
 		f"{rec_row['total_ms']} (cumulative-bug would be 190)"
 	)
 	# v0.7.x: the framework variant uses total_cumulative_ms.
-	# It IS the sum-cumulative — 100 + 60 + 30 = 190 — and that's
+	# It IS the sum-cumulative 100 + 60 + 30 = 190 and that's
 	# intentional. The framework table accepts the overlap risk in
 	# exchange for non-zero, meaningful display values.
 	assert rec_row["total_cumulative_ms"] == 190
@@ -106,21 +106,21 @@ def test_flat_function_aggregates_self_ms_across_actions():
 	# (105 + 155 + 205) = 465.
 	assert row["total_ms"] == 450
 	# v0.7.x: cumulative-sum lands separately for the framework
-	# variant display — 105 + 155 + 205 = 465.
+	# variant display 105 + 155 + 205 = 465.
 	assert row["total_cumulative_ms"] == 465
 	assert row["distinct_actions"] == 3
 
 
 # --------------------------------------------------------------------------
-# build_hot_frames_table — per-variant time metric (v0.7.x)
+# build_hot_frames_table per-variant time metric (v0.7.x)
 # --------------------------------------------------------------------------
 
-from optimus import renderer  # noqa: E402 — co-located with aggregator tests
+from optimus import renderer  # noqa: E402 co-located with aggregator tests
 
 
 def test_framework_variant_displays_cumulative_time():
-	"""``build_hot_frames_table(is_hot=False)`` — the framework
-	variant — displays ``total_cumulative_ms`` because wrapper
+	"""``build_hot_frames_table(is_hot=False)``: the framework
+	variant displays ``total_cumulative_ms`` because wrapper
 	self-time is sub-sampler-interval and aggregated rows would
 	render as 0ms otherwise."""
 	raw = [{
@@ -141,8 +141,8 @@ def test_framework_variant_displays_cumulative_time():
 
 
 def test_user_app_variant_keeps_self_time_total():
-	"""``build_hot_frames_table(is_hot=True)`` — the user-app
-	variant — continues to display ``total_ms`` (self-sum) unchanged.
+	"""``build_hot_frames_table(is_hot=True)``: the user-app
+	variant continues to display ``total_ms`` (self-sum) unchanged.
 	The A.AE1 correctness fix (immune to recursion double-count)
 	is preserved."""
 	raw = [{
@@ -186,7 +186,7 @@ def test_framework_variant_re_sorts_by_displayed_metric():
 	out = renderer.build_hot_frames_table(raw, is_hot=False)
 	displayed = [r["total_ms"] for r in out]
 	assert displayed == [1500, 800, 200], (
-		"framework variant must sort by cumulative DESC — got "
+		"framework variant must sort by cumulative DESC got "
 		f"{displayed}"
 	)
 

--- a/optimus/tests/test_ai_aerele_provider.py
+++ b/optimus/tests/test_ai_aerele_provider.py
@@ -4,7 +4,7 @@
 """``Aerele`` is the hosted/managed AI provider option (token packs bought at
 aerele.in instead of bringing your own Anthropic / OpenAI key). It is
 **TEMPORARILY DISABLED** until Aerele's billing + managed LLM gateway are
-production-ready — removed from the ``ai_provider`` Select and commented out
+production-ready removed from the ``ai_provider`` Select and commented out
 of ``_PROVIDER_DEFAULTS`` in ai_fix.py.
 
 These tests now GUARD that disabled state so the option can't reappear by
@@ -20,7 +20,7 @@ these assertions back to the originals:
     assert "Aerele" in options.split("\\n")
 
 The ``_aerele_call_metadata`` wiring is intentionally left intact in ai_fix.py
-(and still covered by test_ai_fix.py), ready for re-enable — only the
+(and still covered by test_ai_fix.py), ready for re-enable only the
 selectable provider is switched off.
 """
 
@@ -34,7 +34,7 @@ from optimus import ai_fix
 
 class TestAereleProviderDisabled:
 	def test_aerele_not_in_provider_defaults(self):
-		"""While disabled, Aerele must NOT resolve as a provider — so a
+		"""While disabled, Aerele must NOT resolve as a provider so a
 		stale ``ai_provider = "Aerele"`` setting fails cleanly with the
 		'Unknown AI provider' error rather than silently calling a
 		not-yet-ready endpoint."""

--- a/optimus/tests/test_ai_auto_suggest.py
+++ b/optimus/tests/test_ai_auto_suggest.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for analyze._enrich_findings_with_ai_suggestions — the optional
+"""Tests for analyze._enrich_findings_with_ai_suggestions the optional
 "bake AI fixes into the report" step (Optimus Settings ▸ AI Fix
 Suggestions ▸ "Suggest AI fixes by default").
 
@@ -184,7 +184,7 @@ class TestSelectionAndPersistence:
 
 
 # --------------------------------------------------------------------------
-# _backfill_ai_suggestions — the regenerate-time path for existing sessions
+# _backfill_ai_suggestions the regenerate-time path for existing sessions
 # --------------------------------------------------------------------------
 
 class _Row(SimpleNamespace):
@@ -220,7 +220,7 @@ class _FakeDB:
 
 
 def _fake_frappe():
-	"""A stand-in for analyze.py's module-global ``frappe`` — just enough
+	"""A stand-in for analyze.py's module-global ``frappe``: just enough
 	for _backfill_ai_suggestions (``frappe.db.set_value`` / ``.commit`` and
 	``frappe.log_error``). Patching ``analyze.frappe`` directly sidesteps
 	the suite's ``sys.modules['frappe']`` reload pollution."""
@@ -299,7 +299,7 @@ class TestRunAiBackfillCore:
 			_row("F4", "Memory Pressure", "High", 9),  # ineligible type
 		]
 		doc = SimpleNamespace(findings=rows)
-		# No ai_auto_suggest gate here — _run_ai_backfill only needs
+		# No ai_auto_suggest gate here _run_ai_backfill only needs
 		# is_available(). cap=0 → no cap.
 		p1, p2, p3 = _patches(_cfg(ai_auto_suggest=False))
 		with p1, p2, p3, patch.object(analyze, "frappe", _fake_frappe()) as fk:
@@ -356,12 +356,12 @@ class TestRunAiBackfillCore:
 		assert fk.db.writes == []
 
 	def test_regenerate_all_overwrites_existing(self):
-		# Two eligible findings — one already has a (stale) suggestion. With
+		# Two eligible findings one already has a (stale) suggestion. With
 		# regenerate_all=True BOTH get re-generated and overwritten.
 		rows = [
 			_row("F1", "N+1 Query", "High", 500, llm_fix_json='{"suggestion":"STALE"}'),
 			_row("F2", "Slow Query", "Medium", 200),
-			_row("F3", "Memory Pressure", "High", 9),  # ineligible — still skipped
+			_row("F3", "Memory Pressure", "High", 9),  # ineligible still skipped
 		]
 		doc = SimpleNamespace(findings=rows)
 		p1, p2, p3 = _patches(_cfg(ai_auto_suggest=False))

--- a/optimus/tests/test_ai_fix.py
+++ b/optimus/tests/test_ai_fix.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for optimus.ai_fix — the provider-agnostic LLM client
+"""Tests for optimus.ai_fix the provider-agnostic LLM client
 behind the on-demand "Suggest a fix (AI)" action.
 
 Pure-test path: ``_build_messages`` is a pure function; the HTTP layer is
@@ -30,7 +30,7 @@ class _FakeResp:
 		self._raise_on_json = raise_on_json
 		self.text = text
 
-	def json(self):  # noqa: F811 — mimics requests.Response.json()
+	def json(self):  # noqa: F811 mimics requests.Response.json()
 		if self._raise_on_json:
 			raise ValueError("not json")
 		return self._payload
@@ -68,7 +68,7 @@ def _post_sequence(*resps):
 
 
 # --------------------------------------------------------------------------
-# _build_messages — pure
+# _build_messages pure
 # --------------------------------------------------------------------------
 
 class TestBuildMessages:
@@ -117,7 +117,7 @@ class TestBuildMessages:
 		must carry an explicit, emphatic NO RAW SQL rule (not just the
 		soft "never hand-built SQL strings" mention buried in the WRITE
 		IDIOMATIC FRAPPE paragraph). The post-processing detector in
-		``_flag_raw_sql_in_fix`` backstops the prompt — but cutting raw
+		``_flag_raw_sql_in_fix`` backstops the prompt but cutting raw
 		SQL at the prompt layer is cheaper (the model never generates
 		it) and gives the reader a cleaner suggestion (no appended
 		profiler note to wade through).
@@ -125,7 +125,7 @@ class TestBuildMessages:
 		system, _ = ai_fix._build_messages(self._finding())
 		# Loud header so the rule is unmissable in the prompt.
 		assert "NO RAW SQL IN YOUR PROPOSED FIX" in system
-		# Lists every SQL verb the post-processing detector catches —
+		# Lists every SQL verb the post-processing detector catches
 		# prompt + post-processing scope must match.
 		low = system.lower()
 		for verb in ("select", "insert", "update", "delete", "replace"):
@@ -167,7 +167,7 @@ class TestBuildMessages:
 		with NO filters. Counter-example shipped to keep the model from
 		assuming every get_all replacement needs filters."""
 		system, _ = ai_fix._build_messages(self._finding())
-		# The counter-example is recognisable by its content — a raw SQL with
+		# The counter-example is recognisable by its content a raw SQL with
 		# no WHERE clause + a frappe.get_all replacement without filters=.
 		assert "SELECT name, email FROM `tabUser` LIMIT 50" in system
 		assert "frappe.get_all('User', fields=['name', 'email'], limit=50)" in system
@@ -180,7 +180,7 @@ class TestBuildMessages:
 		diff, _, _ = diff_block.partition("```")
 		assert diff.strip(), "diff fence missing in second example"
 		assert "filters=" not in diff, (
-			"counter-example DIFF must NOT contain `filters=` — that's the "
+			"counter-example DIFF must NOT contain `filters=`: that's the "
 			"entire point of showing a no-filter substitution"
 		)
 
@@ -237,7 +237,7 @@ class TestBuildMessages:
 		assert "only code you have" in c
 
 	def test_no_source_notice_when_callsite_but_no_window(self):
-		# A finding that has a callsite but no readable source — the profiler
+		# A finding that has a callsite but no readable source the profiler
 		# couldn't open the file. The user message must say so and tell the
 		# model NOT to invent a before/after.
 		f = {
@@ -284,7 +284,7 @@ class TestBuildMessages:
 
 
 # --------------------------------------------------------------------------
-# _call_openai_chat / _call_anthropic — HTTP layer with requests mocked
+# _call_openai_chat / _call_anthropic HTTP layer with requests mocked
 # --------------------------------------------------------------------------
 
 class TestOpenAiCall:
@@ -480,7 +480,7 @@ class TestHttpErrorMapping:
 
 
 # --------------------------------------------------------------------------
-# _resolve_provider — defaults + overrides
+# _resolve_provider defaults + overrides
 # --------------------------------------------------------------------------
 
 def _cfg(**kw):
@@ -516,7 +516,7 @@ class TestResolveProvider:
 
 	def test_base_url_override_ignored_for_hosted_provider(self):
 		# A hosted provider (Anthropic / OpenAI / Kimi) ALWAYS uses its default
-		# endpoint — a stored ai_base_url must NOT override it. The Settings
+		# endpoint a stored ai_base_url must NOT override it. The Settings
 		# field is hidden for hosted providers, so a stale value would
 		# otherwise silently route calls to a dead host (ConnectionError). The
 		# model override still applies (that field stays visible/editable).
@@ -540,7 +540,7 @@ class TestResolveProvider:
 
 
 # --------------------------------------------------------------------------
-# is_available — truth table
+# is_available truth table
 # --------------------------------------------------------------------------
 
 class TestIsAvailable:
@@ -574,7 +574,7 @@ class TestIsAvailable:
 
 
 # --------------------------------------------------------------------------
-# suggest_fix — end to end with provider + requests patched
+# suggest_fix end to end with provider + requests patched
 # --------------------------------------------------------------------------
 
 class TestSuggestFix:
@@ -664,7 +664,7 @@ class TestSourceAvailableFlag:
 
 	def test_true_when_only_phase2_hotline(self, monkeypatch):
 		# A hot-path finding whose source couldn't be read but that WAS
-		# line-profiled — it has the per-line numbers, so don't show the
+		# line-profiled it has the per-line numbers, so don't show the
 		# "no source" caveat.
 		out = self._suggest(monkeypatch, {
 			"finding_type": "Slow Hot Path", "title": "x", "technical_detail": {},
@@ -704,7 +704,7 @@ class TestHumanizeSteps:
 		low = system.lower()
 		assert "steps to reproduce" in low
 		assert "**summary:**" in low
-		# It's primed with ERPNext domain knowledge — the standard flows and
+		# It's primed with ERPNext domain knowledge the standard flows and
 		# how to decode the raw cmds.
 		assert "erpnext" in low
 		assert "sales order" in low and "delivery note" in low
@@ -764,11 +764,11 @@ class TestMetadataIndexGuardrail:
 		assert ai_fix._flag_metadata_column_index_advice(txt) == txt
 
 	def test_does_not_flag_negated_mention(self):
-		txt = "Do NOT index `modified` — Frappe writes it on every save."
+		txt = "Do NOT index `modified`: Frappe writes it on every save."
 		assert ai_fix._flag_metadata_column_index_advice(txt) == txt
 
 	def test_no_index_advice_is_unchanged(self):
-		txt = "**Diagnosis** — N+1.\n**Fix** — batch with frappe.get_all."
+		txt = "**Diagnosis**: N+1.\n**Fix**: batch with frappe.get_all."
 		assert ai_fix._flag_metadata_column_index_advice(txt) == txt
 
 	def test_suggest_fix_applies_the_guardrail(self, monkeypatch):
@@ -783,11 +783,11 @@ class TestMetadataIndexGuardrail:
 
 
 # ---------------------------------------------------------------------------
-# Raw `frappe.db.sql` guardrail — the model is told via system prompt to
+# Raw `frappe.db.sql` guardrail the model is told via system prompt to
 # "never hand-built SQL strings" and use the Document API or frappe.qb
 # instead. This guardrail backstops that instruction: detect raw SQL in
 # the LLM's proposed fix and append an advisory profiler note. Append-
-# only, never rewrites — same posture as the metadata-column guardrail.
+# only, never rewrites same posture as the metadata-column guardrail.
 # ---------------------------------------------------------------------------
 
 
@@ -817,10 +817,10 @@ class TestRawSqlGuardrail:
 		assert ai_fix._flag_raw_sql_in_fix("") == ""
 
 	def test_text_with_no_code_blocks_returns_unchanged(self):
-		# No code fences anywhere — the guardrail must not fire on prose
+		# No code fences anywhere the guardrail must not fire on prose
 		# alone. (Real LLM output almost always has a code block, but a
 		# diagnosis-only response with no fix block is valid.)
-		txt = "**Diagnosis** — N+1 in the loop.\n**Fix** — batch the lookup."
+		txt = "**Diagnosis**: N+1 in the loop.\n**Fix**: batch the lookup."
 		assert ai_fix._flag_raw_sql_in_fix(txt) == txt
 
 	# --- Inputs that SHOULD trip the guardrail ----------------------------
@@ -865,7 +865,7 @@ class TestRawSqlGuardrail:
 
 	def test_raw_sql_case_insensitive_verb(self):
 		# Models often produce mixed-case keywords. The detector regex is
-		# case-insensitive on the verb — pin that.
+		# case-insensitive on the verb pin that.
 		txt = (
 			"```diff\n"
 			"+frappe.db.sql(\"select email from `tabUser` where name=%s\")\n"
@@ -874,7 +874,7 @@ class TestRawSqlGuardrail:
 		assert "Profiler note" in ai_fix._flag_raw_sql_in_fix(txt)
 
 	def test_raw_sql_triple_quoted_is_flagged(self):
-		# The most common multi-line "fix" shape — previously slipped through
+		# The most common multi-line "fix" shape previously slipped through
 		# because the regex only matched a single opening quote.
 		txt = (
 			'```python\n'
@@ -886,7 +886,7 @@ class TestRawSqlGuardrail:
 		assert "Profiler note" in ai_fix._flag_raw_sql_in_fix(txt)
 
 	def test_raw_sql_cte_with_is_flagged(self):
-		# CTE-led SELECT (WITH ... SELECT) — previously not in the verb list.
+		# CTE-led SELECT (WITH ... SELECT) previously not in the verb list.
 		txt = (
 			'```python\n'
 			'frappe.db.sql("WITH t AS (SELECT 1) SELECT * FROM t")\n'
@@ -899,7 +899,7 @@ class TestRawSqlGuardrail:
 		assert "Profiler note" in ai_fix._flag_raw_sql_in_fix(txt)
 
 	def test_raw_sql_in_plain_python_code_block_flagged(self):
-		# Non-diff code block — every line is "proposed code".
+		# Non-diff code block every line is "proposed code".
 		txt = (
 			"```python\n"
 			"def replace_old_call():\n"
@@ -932,11 +932,11 @@ class TestRawSqlGuardrail:
 		assert ai_fix._flag_raw_sql_in_fix(txt) == txt
 
 	def test_raw_sql_in_prose_NOT_flagged(self):
-		# Inline-code mention in a paragraph — the model is talking ABOUT
+		# Inline-code mention in a paragraph the model is talking ABOUT
 		# the anti-pattern, not proposing it. Guardrail must stay silent.
 		txt = (
-			"**Diagnosis** — the code uses `frappe.db.sql(\"SELECT ...\")` "
-			"inside a loop. **Fix** — batch via `frappe.get_all`."
+			"**Diagnosis**: the code uses `frappe.db.sql(\"SELECT ...\")` "
+			"inside a loop. **Fix**: batch via `frappe.get_all`."
 		)
 		assert ai_fix._flag_raw_sql_in_fix(txt) == txt
 
@@ -956,7 +956,7 @@ class TestRawSqlGuardrail:
 		assert ai_fix._flag_raw_sql_in_fix(txt) == txt
 
 	def test_ddl_verb_NOT_flagged(self):
-		# CREATE / ALTER / DROP are intentionally outside scope —
+		# CREATE / ALTER / DROP are intentionally outside scope
 		# legit administrative use (e.g. ADD INDEX when Customize Form
 		# isn't an option).
 		txt = (
@@ -1026,7 +1026,7 @@ def test_eligible_finding_types_is_a_frozenset_of_known_types():
 
 
 # --------------------------------------------------------------------------
-# v0.6.x: is_available(section=...) — per-section LLM toggles (hard off)
+# v0.6.x: is_available(section=...) per-section LLM toggles (hard off)
 # --------------------------------------------------------------------------
 
 from optimus import settings as _settings

--- a/optimus/tests/test_ai_privacy.py
+++ b/optimus/tests/test_ai_privacy.py
@@ -3,7 +3,7 @@
 
 """Tests for the v0.9.0 AI privacy-hardening additions.
 
-Pure-pytest — no live Frappe site needed. Mirrors the mock patterns in
+Pure-pytest no live Frappe site needed. Mirrors the mock patterns in
 ``test_ai_fix.py`` (FakeResp + ``_post_capturing``) and
 ``test_settings_round6.py`` (direct ``OptimusConfig`` instantiation +
 ``settings.get_config`` patching).
@@ -13,17 +13,17 @@ Invariants under test (mirror the plan's Risks + Mitigations):
   * ``ai_excluded_finding_types`` parses with the same skip-list semantics
     as the existing ``skip_request_paths``: one-per-line, ``#`` comments,
     blanks dropped, exact match.
-  * ``is_finding_type_excluded`` is case-sensitive — an inert exclude
+  * ``is_finding_type_excluded`` is case-sensitive an inert exclude
     (typo, wrong case) is safer than a partial-match exclude.
   * ``suggest_fix`` short-circuits with ``AiFixError`` before any HTTP
-    call when the finding's type is on the exclusion list — the payload
+    call when the finding's type is on the exclusion list the payload
     is never built and no request leaves the host.
   * ``_http_post`` reads the configured timeout via
     ``_resolve_timeout_seconds``; clamped to ``[10, 600]``.
   * ``OptimusSettings._clamp_numeric_floors`` clamps
     ``ai_request_timeout_seconds`` below 10 up to 10.
   * The doc's enumeration of eligible finding types stays byte-for-line
-    aligned with ``ai_fix.AI_ELIGIBLE_FINDING_TYPES`` — drift fails CI.
+    aligned with ``ai_fix.AI_ELIGIBLE_FINDING_TYPES``: drift fails CI.
 """
 
 import sys
@@ -52,7 +52,7 @@ def _cfg(**over):
 
 
 # --------------------------------------------------------------------------
-# TestExcludeParsing — line-per-entry, # comments, blanks dropped
+# TestExcludeParsing line-per-entry, # comments, blanks dropped
 # --------------------------------------------------------------------------
 
 
@@ -73,7 +73,7 @@ class TestExcludeParsing:
 
 
 # --------------------------------------------------------------------------
-# TestExcludeApplied — is_finding_type_excluded semantics
+# TestExcludeApplied is_finding_type_excluded semantics
 # --------------------------------------------------------------------------
 
 
@@ -97,7 +97,7 @@ class TestExcludeApplied:
 		assert ai_fix.is_finding_type_excluded("Hot Line") is False
 
 	def test_is_case_sensitive(self, monkeypatch):
-		# Typo / wrong case is inert — safer than partial-match leaking data.
+		# Typo / wrong case is inert safer than partial-match leaking data.
 		monkeypatch.setattr(
 			"optimus.settings.get_config",
 			lambda: _cfg(ai_excluded_finding_types=("Slow Query",)),
@@ -127,7 +127,7 @@ class TestExcludeApplied:
 
 
 # --------------------------------------------------------------------------
-# TestSuggestFixRefuses — early-return before payload build
+# TestSuggestFixRefuses early-return before payload build
 # --------------------------------------------------------------------------
 
 
@@ -168,7 +168,7 @@ class TestSuggestFixRefuses:
 
 
 # --------------------------------------------------------------------------
-# TestTimeoutHonored — _http_post reads cfg.ai_request_timeout_seconds
+# TestTimeoutHonored _http_post reads cfg.ai_request_timeout_seconds
 # --------------------------------------------------------------------------
 
 
@@ -184,7 +184,7 @@ class _CaptureResp:
 
 
 def _capture_post():
-	"""Return (post_fake, captured) — when the fake is called, it stashes
+	"""Return (post_fake, captured) when the fake is called, it stashes
 	the kwargs into captured[0] for assertion."""
 	captured: list[dict] = []
 
@@ -197,7 +197,7 @@ def _capture_post():
 
 class TestTimeoutHonored:
 	def test_http_post_uses_configured_timeout(self, monkeypatch):
-		# Pure ai_fix._http_post call — patch requests.post + settings.
+		# Pure ai_fix._http_post call patch requests.post + settings.
 		monkeypatch.setattr(
 			"optimus.settings.get_config",
 			lambda: _cfg(ai_request_timeout_seconds=180),
@@ -257,7 +257,7 @@ class TestTimeoutHonored:
 		assert captured[0]["timeout"] == 600
 
 	def test_http_post_falls_back_when_settings_unreadable(self, monkeypatch):
-		# No bench / pure-pytest path — fallback to _HTTP_TIMEOUT (60).
+		# No bench / pure-pytest path fallback to _HTTP_TIMEOUT (60).
 		def _raise():
 			raise RuntimeError("no bench")
 
@@ -277,7 +277,7 @@ class TestTimeoutHonored:
 
 
 # --------------------------------------------------------------------------
-# TestSettings — defaults + retention-style floor clamp
+# TestSettings defaults + retention-style floor clamp
 # --------------------------------------------------------------------------
 
 
@@ -348,7 +348,7 @@ class TestSettings:
 
 
 # --------------------------------------------------------------------------
-# TestDocStaysFresh — the doc's eligible-types enumeration matches the code
+# TestDocStaysFresh the doc's eligible-types enumeration matches the code
 # --------------------------------------------------------------------------
 
 
@@ -380,5 +380,5 @@ class TestDocStaysFresh:
 		code_types = sorted(ai_fix.AI_ELIGIBLE_FINDING_TYPES)
 		assert doc_types == code_types, (
 			f"docs/AI-FIXING.md § 5 has {doc_types!r} but "
-			f"AI_ELIGIBLE_FINDING_TYPES has {code_types!r} — keep them in sync."
+			f"AI_ELIGIBLE_FINDING_TYPES has {code_types!r} keep them in sync."
 		)

--- a/optimus/tests/test_analyze_concurrency.py
+++ b/optimus/tests/test_analyze_concurrency.py
@@ -3,7 +3,7 @@
 
 """Concurrency guards on analyze (v0.7.x).
 
-Two analyze jobs running at once roughly double peak RAM — the OOM trigger on
+Two analyze jobs running at once roughly double peak RAM the OOM trigger on
 long flows. M2 adds a global single-flight (only one session does the heavy
 phase at a time) built on the existing re-enqueue/yield pattern, NOT a held
 lock, so it can't deadlock with run()'s self-re-enqueue and self-heals if a
@@ -129,7 +129,7 @@ class TestRunWiring:
 
 	def test_self_reenqueues_stay_anonymous(self):
 		"""Neither the bg-wait nor the single-flight re-enqueue may carry a
-		stable job_id — that would deadlock the running job against its own
+		stable job_id that would deadlock the running job against its own
 		continuation."""
 		for fn in (analyze._bg_wait_for_pending_jobs, analyze._acquire_singleflight):
 			src = inspect.getsource(fn)
@@ -166,7 +166,7 @@ class TestEnqueueAnalyzeAsync:
 
 	def test_enqueue_analyze_has_no_is_job_enqueued_dedup(self):
 		# Source guard: the dedup that stranded sessions must stay gone. Check
-		# the import + the call (not prose — the comment explains the removal).
+		# the import + the call (not prose the comment explains the removal).
 		from optimus import api
 		src = inspect.getsource(api._enqueue_analyze)
 		assert "import is_job_enqueued" not in src

--- a/optimus/tests/test_analyze_fetch.py
+++ b/optimus/tests/test_analyze_fetch.py
@@ -210,7 +210,7 @@ def test_cleanup_redis_deletes_tree_and_sidecar_keys(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# v0.13: persisted recordings bundle — re-run AI / regenerate after cleanup
+# v0.13: persisted recordings bundle re-run AI / regenerate after cleanup
 # ---------------------------------------------------------------------------
 
 
@@ -243,7 +243,7 @@ def test_fetch_recordings_rehydrates_from_bundle_when_redis_empty(monkeypatch):
 
 
 def test_fetch_recordings_prefers_redis_over_bundle(monkeypatch):
-	"""When Redis still has the recording the bundle is ignored — the initial
+	"""When Redis still has the recording the bundle is ignored the initial
 	analyze must be byte-identical regardless of any bundle."""
 	import frappe
 	from frappe.recorder import RECORDER_REQUEST_HASH
@@ -353,7 +353,7 @@ def test_load_recordings_bundle_none_without_file():
 
 def test_mark_ai_spend_session_sets_and_is_guarded(monkeypatch):
 	"""The marker is set on frappe.local for the spend recorder, and a stubbed
-	frappe (no .local) must not raise — unit tests rely on this no-op."""
+	frappe (no .local) must not raise unit tests rely on this no-op."""
 	from types import SimpleNamespace
 
 	import frappe

--- a/optimus/tests/test_analyze_memory.py
+++ b/optimus/tests/test_analyze_memory.py
@@ -83,7 +83,7 @@ class TestRunGcCollect:
 
 class TestNoRecordingDroppedForPerformance:
 	"""HARD INVARIANT (user requirement): analyze must NEVER drop a captured
-	recording — and therefore never a captured background job — for performance
+	recording and therefore never a captured background job for performance
 	reasons. If a flow captured 10 RQ jobs, all 10 must reach the report.
 
 	A v0.7.x change once added a session-wide recording cap (M4) that dropped
@@ -107,7 +107,7 @@ class TestNoRecordingDroppedForPerformance:
 
 	def test_all_captured_jobs_surface_in_report(self):
 		"""End of the pipeline: build_background_jobs must list every RQ Job
-		action — there is no cap that can drop one."""
+		action there is no cap that can drop one."""
 		from optimus import renderer
 
 		n_jobs = 10

--- a/optimus/tests/test_analyze_run_v5_wiring.py
+++ b/optimus/tests/test_analyze_run_v5_wiring.py
@@ -76,13 +76,13 @@ def test_truncate_finding_titles_clamps_overlong():
 	push past the limit. Clamping prevents CharacterLengthExceededError
 	from destroying the whole analyze pipeline."""
 	findings = [
-		# Under the limit — untouched.
+		# Under the limit untouched.
 		{"title": "Short title"},
-		# Exactly at the limit — untouched.
+		# Exactly at the limit untouched.
 		{"title": "A" * 140},
-		# One over the limit — must be clamped to 140 and end with "...".
+		# One over the limit must be clamped to 140 and end with "...".
 		{"title": "B" * 141},
-		# Far over the limit — must be clamped to exactly 140.
+		# Far over the limit must be clamped to exactly 140.
 		{"title": "C" * 500},
 		# The production payload that started this bug.
 		{
@@ -106,7 +106,7 @@ def test_truncate_finding_titles_clamps_overlong():
 	assert len(findings[3]["title"]) == 140
 	assert findings[3]["title"].endswith("...")
 
-	# Production payload — was 144 chars, must now be <= 140.
+	# Production payload was 144 chars, must now be <= 140.
 	assert len(findings[4]["title"]) <= 140
 
 

--- a/optimus/tests/test_analyze_runtime.py
+++ b/optimus/tests/test_analyze_runtime.py
@@ -4,7 +4,7 @@
 """Runtime smoothing for analyze (v0.7.x).
 
 M5: lower the analyze worker's CPU priority (os.nice) so a heavy analyze
-doesn't starve live web traffic — gated to the async path (sticky per-process).
+doesn't starve live web traffic gated to the async path (sticky per-process).
 M6: optionally throttle the EXPLAIN/sqlparse burst in _enrich_recordings so the
 DB/CPU aren't hammered continuously. Both default to inert/near-zero and are
 result-invariant.
@@ -20,7 +20,7 @@ import pytest
 from optimus import analyze
 
 # ---------------------------------------------------------------------------
-# M5 — os.nice
+# M5 os.nice
 # ---------------------------------------------------------------------------
 
 class TestApplyNice:
@@ -57,7 +57,7 @@ class TestApplyNice:
 
 
 # ---------------------------------------------------------------------------
-# M6 — enrich throttle
+# M6 enrich throttle
 # ---------------------------------------------------------------------------
 
 class FakeCache:
@@ -151,7 +151,7 @@ class TestEnrichThrottle:
 
 class TestMaxQueriesPerRecordingZeroIsUnlimited:
 	"""v0.13.x: ``max_queries_per_recording = 0`` (Strict preset) means
-	no cap — every query gets enriched. Pre-v0.13.x the ``if cap <= 0:
+	no cap every query gets enriched. Pre-v0.13.x the ``if cap <= 0:
 	cap = DEFAULT`` reset silently re-applied the 2000 default, so the
 	operator's "I want full coverage" intent was clobbered."""
 
@@ -165,7 +165,7 @@ class TestMaxQueriesPerRecordingZeroIsUnlimited:
 		)
 
 		# A recording with 3000 queries (way over the legacy 2000 default).
-		# With cap = 0, every one must be enriched — nothing truncated.
+		# With cap = 0, every one must be enriched nothing truncated.
 		big = _recording([
 			f"SELECT * FROM tab{i} WHERE x = {i}" for i in range(3000)
 		])

--- a/optimus/tests/test_analyze_source_snippet.py
+++ b/optimus/tests/test_analyze_source_snippet.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for analyze._enrich_findings_with_source_snippets — runs without
+"""Tests for analyze._enrich_findings_with_source_snippets runs without
 Frappe; takes a list of finding dicts (with technical_detail_json) and a
 real file on disk, then asserts the source_snippet shape after enrichment."""
 
@@ -38,7 +38,7 @@ def _read_snippet(finding):
 
 class TestEnrichFindingsWithSourceSnippets:
 	def test_attaches_lines_centered_on_lineno(self, tmp_path):
-		# v0.7.x: snippet window widened from ±1 to ±4 — for a 5-line file
+		# v0.7.x: snippet window widened from ±1 to ±4 for a 5-line file
 		# anchored on line 3, the window covers lines 1..5 (clipped at
 		# file boundaries).
 		src = tmp_path / "fake.py"
@@ -164,7 +164,7 @@ class TestEnrichFindingsWithSourceSnippets:
 		# The function is typed as ``list[dict]`` but defence-in-depth:
 		# a corrupted upstream payload could plant a non-dict entry
 		# (None, scalar, list, string). The whole analyze job must not
-		# crash because of one bad row — silent skip per the function's
+		# crash because of one bad row silent skip per the function's
 		# best-effort contract, valid neighbours still get enriched.
 		src = tmp_path / "fake.py"
 		src.write_text("a\nb\nc\n")
@@ -184,7 +184,7 @@ class TestEnrichFindingsWithSourceSnippets:
 
 	def test_non_dict_detail_skipped_cleanly(self, tmp_path):
 		# ``json.loads("null") -> None``, ``json.loads('"x"') -> "x"``,
-		# ``json.loads("[1,2]") -> [1, 2]`` — all valid JSON, none are
+		# ``json.loads("[1,2]") -> [1, 2]``: all valid JSON, none are
 		# the dict shape the rest of the loop assumes. Each must silent-
 		# skip; the valid neighbour still gets enriched.
 		src = tmp_path / "fake.py"
@@ -213,7 +213,7 @@ class TestEnrichFindingsWithSourceSnippets:
 		# Slow Query findings (optimus/analyzers/top_queries.py:129) store
 		# callsite as a "path:lineno" string, not the canonical
 		# {filename, lineno, function} dict every other finding type uses.
-		# The enrichment loop must not crash on that shape — renderer
+		# The enrichment loop must not crash on that shape renderer
 		# handles snippets for these findings at render time via
 		# _normalize_callsite + lazy attach in _finding_to_dict.
 		#
@@ -242,7 +242,7 @@ class TestEnrichFindingsWithSourceSnippets:
 		analyze._enrich_findings_with_source_snippets([f])
 
 		# Slow Query callsite shape preserved (string, not mutated to
-		# dict) — renderer normalizes it lazily at render time.
+		# dict) renderer normalizes it lazily at render time.
 		detail = json.loads(f["technical_detail_json"])
 		assert detail["callsite"] == f"{src}:1"
 

--- a/optimus/tests/test_analyzer_base_metrics.py
+++ b/optimus/tests/test_analyzer_base_metrics.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""D.M-S6 / D.M-S7 — sanity tests for analyzer-base metric helpers.
+"""D.M-S6 / D.M-S7 sanity tests for analyzer-base metric helpers.
 
 ``percentile`` is used by repetition-heavy analyzers (N+1, redundant
 calls) to surface the tail of the per-hit duration distribution; a
@@ -56,7 +56,7 @@ def test_percentile_monotonic_across_percentages():
 		last = current
 
 
-# D.M-S7 — fmt_ms property test (Hypothesis-driven if available).
+# D.M-S7 fmt_ms property test (Hypothesis-driven if available).
 try:
 	from hypothesis import given
 	from hypothesis import strategies as st

--- a/optimus/tests/test_analyzer_notes_section.py
+++ b/optimus/tests/test_analyzer_notes_section.py
@@ -5,14 +5,14 @@
 
 History: pre-v0.5.2 the analyzer suppression warnings ("Suppressed N SQL
 findings from framework code", "Skipped M non-SELECT statements", …) were
-concatenated into a single <p> in the header — a wall of text. v0.5.2 moved
+concatenated into a single <p> in the header a wall of text. v0.5.2 moved
 them to a collapsed-by-default section at the bottom with a short header
 pointer. v0.6.x dropped the header pointer; then the section itself was
 removed entirely (the suppression bookkeeping is debug noise the report
 doesn't need to surface). ``session_doc.analyzer_warnings`` is still computed
-and stored on the DocType — it's just no longer rendered. Truncation, the one
+and stored on the DocType it's just no longer rendered. Truncation, the one
 warning users *do* need to see, has its own prominent banner at the top
-(``truncation_banner``) — independent of this.
+(``truncation_banner``) independent of this.
 
 This test makes sure a future edit can't accidentally re-introduce the
 section, the header pointer, or the "Notes" link in the "Jump to:" nav.

--- a/optimus/tests/test_api_refill_ai_suggestions.py
+++ b/optimus/tests/test_api_refill_ai_suggestions.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for ``optimus.api.refill_ai_suggestions`` — the single-button
+"""Tests for ``optimus.api.refill_ai_suggestions``: the single-button
 entry point that replaces the five legacy AI buttons.
 
 The endpoint chains three core helpers (``_run_ai_backfill``,
@@ -41,7 +41,7 @@ def _row(name="opt-xxx", user="user@example.com", status="Ready", title="t"):
 
 
 def _fake_doc():
-	"""Minimal Optimus Session doc — only `name` is touched by the
+	"""Minimal Optimus Session doc only `name` is touched by the
 	endpoint's orchestration; the helpers are mocked, so the doc body
 	doesn't matter."""
 	return SimpleNamespace(name="opt-xxx", actions=[], findings=[], table_breakdown_json="[]")
@@ -73,7 +73,7 @@ def test_refill_runs_all_three_steps(mock_session_environment, monkeypatch):
 	"""Happy path: every toggle is on, every helper runs once, and the
 	per-step status dict surfaces the counts."""
 	from optimus import ai_fix
-	from optimus.settings import get_config  # noqa: F401 — we patch this below
+	from optimus.settings import get_config  # noqa: F401 we patch this below
 
 	monkeypatch.setattr(ai_fix, "is_available", lambda: True)
 	monkeypatch.setattr("optimus.settings.get_config", lambda: _cfg())

--- a/optimus/tests/test_api_session_permission.py
+++ b/optimus/tests/test_api_session_permission.py
@@ -3,7 +3,7 @@
 
 """_require_session_permission is the per-session ownership gate the phase-2
 (and report/AI/export) endpoints rely on. It must fail CLOSED: deny when
-has_permission returns False AND when has_permission itself raises — a
+has_permission returns False AND when has_permission itself raises a
 permission check that errors must never downgrade to the role-only gate."""
 
 from __future__ import annotations
@@ -20,7 +20,7 @@ def _throw(msg=None, exc=None, **k):
 
 
 def _patch(monkeypatch, *, has_permission):
-	# frappe.db is a Werkzeug Local proxy — replace it wholesale, never patch
+	# frappe.db is a Werkzeug Local proxy replace it wholesale, never patch
 	# its attributes (reading an unbound proxy attr raises RuntimeError). Real
 	# frappe.throw touches the unbound frappe.local, so stub it too.
 	monkeypatch.setattr(

--- a/optimus/tests/test_api_start_kwargs.py
+++ b/optimus/tests/test_api_start_kwargs.py
@@ -24,7 +24,7 @@ def test_stop_session_calls_force_stop_inflight():
 
 
 def test_start_calls_force_stop_inflight():
-	# Same property at the start path — clearing leaked state from a
+	# Same property at the start path clearing leaked state from a
 	# previous request on the same worker before reading session state.
 	src = inspect.getsource(api.start)
 	assert "_force_stop_inflight_capture" in src
@@ -42,7 +42,7 @@ def test_require_profiler_user_does_not_recurse(monkeypatch):
 	"""Regression: _require_profiler_user used to call itself instead of
 	_require_user() (pre-existing v0.2.0 typo at line 52). The infinite
 	recursion only fired in production when the widget actually called
-	api.status — never caught by tests because nothing invoked the
+	api.status never caught by tests because nothing invoked the
 	function. This test calls it directly and asserts it returns within
 	one stack frame."""
 	import frappe

--- a/optimus/tests/test_app_bucketing.py
+++ b/optimus/tests/test_app_bucketing.py
@@ -80,7 +80,7 @@ class TestBucketing:
 		findings = [
 			_finding("apps/apple/foo.py", impact=5.0),
 			_finding("apps/apple/bar.py", impact=5.0),
-			# Banana has higher total — should come first.
+			# Banana has higher total should come first.
 			_finding("apps/banana/x.py", impact=50.0),
 			_finding("apps/carrot/y.py", impact=20.0),
 		]
@@ -99,7 +99,7 @@ class TestBucketing:
 
 class TestTrackedAppsOrdering:
 	def test_tracked_apps_come_first_in_admin_order(self):
-		"""Admin listed ['my_primary', 'my_secondary'] — those must be
+		"""Admin listed ['my_primary', 'my_secondary'] those must be
 		the first two buckets regardless of their impact. The remaining
 		apps follow in impact-desc order."""
 		findings = [
@@ -128,7 +128,7 @@ class TestTrackedAppsOrdering:
 class TestHotPathBucketRename:
 	"""v0.5.2 round 4: when every finding in the no-callsite bucket is
 	a hot-path / hook / frontend-render type (these finding types
-	legitimately have no code-location callsite — they describe where
+	legitimately have no code-location callsite they describe where
 	time went within a request scope), rename the bucket from
 	"Other (no callsite)" → "Request hotspots". The word "Other"
 	undersells findings that are often the MOST valuable in the
@@ -202,7 +202,7 @@ class TestHotPathBucketRename:
 
 	def test_hotpath_bucket_ordered_last(self):
 		"""Like the Other bucket, 'Request hotspots' stays at the
-		bottom — it's secondary to user-app findings (even though
+		bottom it's secondary to user-app findings (even though
 		the contents are valuable) because the user can't directly
 		jump to a line of code from them."""
 		buckets = _bucket_findings_by_app([
@@ -224,7 +224,7 @@ class TestOtherBucketSuppressed:
 		"""v0.7.x: even when there are no-callsite findings, the
 		'Other (no callsite)' bucket is suppressed from the render
 		output. Findings still exist in the underlying list and still
-		count toward severity totals — only the per-app bucket display
+		count toward severity totals only the per-app bucket display
 		drops them. Named-app buckets render unchanged."""
 		findings = [
 			_finding(app_filename=None, impact=9999.0),  # no callsite
@@ -244,7 +244,7 @@ class TestOtherBucketSuppressed:
 class TestBucketContents:
 	def test_bucket_preserves_input_order_within_app(self):
 		"""The caller sorts globally by severity+impact. Within each
-		app, the bucketer must preserve that order — it must not
+		app, the bucketer must preserve that order it must not
 		re-sort (that would undo the global severity ordering)."""
 		findings = [
 			_finding("apps/myapp/a.py", impact=100.0, severity="High"),

--- a/optimus/tests/test_app_bucketing_render.py
+++ b/optimus/tests/test_app_bucketing_render.py
@@ -58,7 +58,7 @@ def _finding_row(*, finding_type="N+1 Query", title="t",
 
 def test_single_app_renders_flat_without_wrapper():
 	"""If every finding is in one app, don't wrap in "myapp (N findings)"
-	— just render flat. Avoids visual noise when there's nothing to
+	just render flat. Avoids visual noise when there's nothing to
 	disambiguate."""
 	from optimus import renderer
 
@@ -114,7 +114,7 @@ def test_multiple_apps_each_in_own_bucket():
 
 
 def test_app_bucket_header_shows_count_and_impact():
-	"""Header reads "myapp · 2 findings · ~30ms" — the meta numbers
+	"""Header reads "myapp · 2 findings · ~30ms" the meta numbers
 	are visible so the user sees cost per app at a glance."""
 	from optimus import renderer
 
@@ -149,7 +149,7 @@ def test_singular_finding_header_uses_singular():
 
 def test_finding_without_callsite_goes_to_other_bucket():
 	"""A finding whose technical_detail has no callsite (e.g. infra-
-	pressure observations) must still render — via the "Other" bucket."""
+	pressure observations) must still render via the "Other" bucket."""
 	from optimus import renderer
 
 	# Build a finding with NO callsite in the detail.
@@ -214,7 +214,7 @@ def test_observations_also_bucketed_by_app():
 
 
 # --------------------------------------------------------------------------
-# v0.6.x: "Ignored Apps" exclusion list — drop findings whose blame app is in
+# v0.6.x: "Ignored Apps" exclusion list drop findings whose blame app is in
 # Optimus Settings ▸ Apps ▸ Ignored Apps, from BOTH the actionable section
 # and Observations. Surfaces a "(N hidden)" note on the report.
 # --------------------------------------------------------------------------
@@ -223,7 +223,7 @@ from unittest.mock import patch  # noqa: E402
 
 
 def _three_apps_doc():
-	from optimus import renderer  # noqa: F401 — exercised via render
+	from optimus import renderer  # noqa: F401 exercised via render
 	return _fake_session_doc_with_findings(
 		_finding_row(title="FrappeFinding", callsite_filename="frappe/model/document.py"),
 		_finding_row(title="ErpnextFinding", callsite_filename="apps/erpnext/erpnext/x.py"),
@@ -237,7 +237,7 @@ class TestIgnoredAppsFilter:
 
 		# v0.13.x: the default seed (frappe + erpnext) would filter the
 		# fixture findings out. The test's intent is "empty ignored_apps
-		# = nothing filtered" — so override the setting to () explicitly.
+		# = nothing filtered" so override the setting to () explicitly.
 		with patch("optimus.settings.get_ignored_apps", return_value=()):
 			html = renderer.render(_three_apps_doc(), recordings=[])
 		assert "FrappeFinding" in html
@@ -271,7 +271,7 @@ class TestIgnoredAppsFilter:
 
 		assert "ErpnextFinding" not in html
 		assert "FrappeFinding" in html and "MyappFinding" in html
-		# "1 finding hidden" — singular noun, not "1 findings".
+		# "1 finding hidden" singular noun, not "1 findings".
 		assert re.search(r">\s*1\s*</strong>\s*finding\b", html)
 		assert "1 findings hidden" not in html
 
@@ -319,7 +319,7 @@ class TestIgnoredAppsFilter:
 	def test_severity_counts_reflect_the_kept_set(self):
 		# The "Issues found" stat card sums to the kept count, not the total.
 		# Build 3 high-severity findings (one per app); ignore frappe+erpnext;
-		# the card should show "1" (myapp survives) — not "3".
+		# the card should show "1" (myapp survives) not "3".
 		import re
 
 		from optimus import renderer

--- a/optimus/tests/test_app_priority_split.py
+++ b/optimus/tests/test_app_priority_split.py
@@ -20,7 +20,7 @@ from optimus import renderer
 from optimus.settings import OptimusConfig
 
 # --------------------------------------------------------------------------
-# _is_framework_app — the tiny classifier adapter
+# _is_framework_app the tiny classifier adapter
 # --------------------------------------------------------------------------
 
 
@@ -174,7 +174,7 @@ class TestPerActionSplit:
 
 	def test_no_split_when_tracked_apps_empty(self):
 		"""v0.7.x: when Tracked Apps is empty (default), the per-action
-		breakdown does NOT split — all actions, including those hitting
+		breakdown does NOT split all actions, including those hitting
 		Frappe endpoints, stay in the main table. Pre-v0.7 every
 		HTTP request to ``/api/method/frappe.*`` was hidden in the
 		collapsed framework subsection, leaving RQ Jobs as the
@@ -192,7 +192,7 @@ class TestPerActionSplit:
 		# Default: get_config returns OptimusConfig with tracked_apps=().
 		html = renderer.render_raw(doc, recordings=[])
 
-		# No subsection summary phrase — no split happened.
+		# No subsection summary phrase no split happened.
 		assert "framework actions (click to expand)" not in html
 		assert "framework action (click to expand)" not in html
 		# Both actions appear in the main table.
@@ -240,7 +240,7 @@ class TestTopQueriesSplit:
 	def test_framework_callsite_query_routes_to_collapsed_block(self):
 		# top_queries normally already excludes framework callsites at
 		# analyze AND render time (``_filter_top_queries_for_display``).
-		# Bypass the render-time filter so both queries reach the split —
+		# Bypass the render-time filter so both queries reach the split
 		# this exercises the framework sub-block code path for the rare
 		# case that a framework query slips through (older sessions).
 		doc = _doc(top_queries=[
@@ -251,7 +251,7 @@ class TestTopQueriesSplit:
 		])
 		# v0.10.0: ``renderer`` is now a package whose ``__init__.py``
 		# re-exports names from ``_internal``. Patching ``renderer.X``
-		# would only swap the package's attribute — the call site inside
+		# would only swap the package's attribute the call site inside
 		# ``_internal.py`` resolves the name through ``_internal``'s own
 		# globals and would see the unpatched original. Patch the actual
 		# location.

--- a/optimus/tests/test_auto_arm_phase2.py
+++ b/optimus/tests/test_auto_arm_phase2.py
@@ -5,7 +5,7 @@
 
 When ``optimus_phase2_auto_arm`` is set in site_config, analyze arms a pass on
 the recommended hot-path functions so the user just re-runs the flow once to
-get line data. Opt-in + admin-only (it instruments the next execution — only
+get line data. Opt-in + admin-only (it instruments the next execution only
 for replay-safe flows). Heavily guarded and best-effort (never fails analyze).
 """
 
@@ -76,7 +76,7 @@ def arm_env(monkeypatch):
 		lambda: types.SimpleNamespace(phase2_max_runs_per_session=10), raising=False)
 
 	# Patch the line_profile collaborators on the REAL (already-imported)
-	# modules — `from optimus.line_profile import capture` binds the package
+	# modules `from optimus.line_profile import capture` binds the package
 	# attribute, so sys.modules swapping wouldn't take effect under bench.
 	import optimus.line_profile.capture as cap_real
 	import optimus.line_profile.picker as picker_real
@@ -145,19 +145,19 @@ class TestAutoArmPhase2:
 
 	def test_zero_cap_means_unlimited(self, arm_env, monkeypatch):
 		"""v0.13.x: ``phase2_max_runs_per_session = 0`` (Strict preset)
-		means no cap — auto-arm fires even with many existing runs.
+		means no cap auto-arm fires even with many existing runs.
 		Pre-v0.13.x the ``or 10`` swallowed 0 and silently re-applied
 		the default cap, so a Strict-profile deployment got the same
 		behavior as Recommended."""
 		import optimus.settings as settings_mod
 		monkeypatch.setattr(settings_mod, "get_config",
 			lambda: types.SimpleNamespace(phase2_max_runs_per_session=0))
-		# Way over the legacy default of 10 — would normally block.
+		# Way over the legacy default of 10 would normally block.
 		arm_env.doc._tables["phase_2_runs"] = [
 			{"run_uuid": f"r{i}"} for i in range(25)
 		]
 		analyze._auto_arm_phase2("PS-1", _ctx())
-		# Arm fired — the cap didn't block.
+		# Arm fired the cap didn't block.
 		assert arm_env.start_calls, "cap = 0 must let auto-arm fire"
 
 	def test_noop_when_user_busy(self, arm_env):

--- a/optimus/tests/test_backfill_ai_fixes_api.py
+++ b/optimus/tests/test_backfill_ai_fixes_api.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Surface tests for the v0.6.0 ``backfill_ai_fixes`` API endpoint — the
+"""Surface tests for the v0.6.0 ``backfill_ai_fixes`` API endpoint the
 manual "retry the LLM" action that fills AI fix suggestions on every
 eligible finding that doesn't have one yet, then re-renders the report.
 
 Like ``test_regenerate_reports_api.py`` / ``test_suggest_fix_api.py`` this
 is a source-inspection test (the endpoint needs a live bench for a true
-integration run): we pin the contract — whitelisted, gated, AI-enabled
+integration run): we pin the contract whitelisted, gated, AI-enabled
 guard, ungated backfill core, re-render via ``regenerate_reports``.
 """
 

--- a/optimus/tests/test_background_job_capture.py
+++ b/optimus/tests/test_background_job_capture.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for the v0.6.0 background-job capture path — the bits that make the
+"""Tests for the v0.6.0 background-job capture path the bits that make the
 profiler track the jobs a profiled flow enqueued and wait for them to finish
 before analyzing:
 
@@ -10,7 +10,7 @@ before analyzing:
   * `analyze._bg_wait_for_pending_jobs` (re-enqueue-poll wait, capped, no-op
     when nothing's pending / the wait is disabled / no async worker)
   * `_stop_session` arms the draining window; `before_job` honours it
-    (source-inspection — those run a lot and need a live bench for a true run)
+    (source-inspection those run a lot and need a live bench for a true run)
   * the `background_job_wait_seconds` setting (default + clamp)
 """
 
@@ -23,7 +23,7 @@ from unittest.mock import patch
 import pytest
 
 # --------------------------------------------------------------------------
-# frappe.enqueue monkey-patch — registers the RQ job id with the session
+# frappe.enqueue monkey-patch registers the RQ job id with the session
 # --------------------------------------------------------------------------
 
 def _reset_profiler_modules():
@@ -98,7 +98,7 @@ class TestEnqueueRegistersPendingJob:
 		fake, fake_bg, calls = fake_frappe
 		fake.cache.set_value("profiler:active:alice@example.com", "sess-1")
 		_reset_profiler_modules()
-		import optimus  # noqa: F401 — triggers the patch
+		import optimus  # noqa: F401 triggers the patch
 
 		fake_bg.enqueue("myapp.tasks.go", x=1)
 		assert calls[-1]["kwargs"]["_profiler_session_id"] == "sess-1"
@@ -132,7 +132,7 @@ class TestEnqueueRegistersPendingJob:
 
 
 # --------------------------------------------------------------------------
-# session.py — pending jobs + draining window
+# session.py pending jobs + draining window
 # --------------------------------------------------------------------------
 
 @pytest.fixture
@@ -246,7 +246,7 @@ class TestBgWaitForPendingJobs:
 		monkeypatch.setattr(analyze, "_rq_job_active", lambda jid: True)
 		monkeypatch.setattr(analyze, "_publish_progress", lambda *a, **k: None)
 		monkeypatch.setattr(analyze.time, "sleep", lambda *a, **k: None)
-		# The status-set is best-effort (try/except in the SUT — frappe.db
+		# The status-set is best-effort (try/except in the SUT frappe.db
 		# being unavailable here is fine). Capture the re-enqueue.
 		enq = []
 		monkeypatch.setattr(frappe, "enqueue", lambda *a, **k: enq.append((a, k)), raising=False)
@@ -289,7 +289,7 @@ def test_stop_session_arms_the_draining_window():
 def test_before_job_honours_the_draining_window():
 	body = _fn_body(_src("hooks_callbacks.py"), "before_job")
 	assert "session.is_draining(session_uuid)" in body
-	# Only when there's NO active session — never bleed into a different one.
+	# Only when there's NO active session never bleed into a different one.
 	assert "active is None" in body
 
 

--- a/optimus/tests/test_background_jobs_section.py
+++ b/optimus/tests/test_background_jobs_section.py
@@ -64,7 +64,7 @@ def _tracked(**kw):
 
 
 # --------------------------------------------------------------------------
-# build_background_jobs — pure
+# build_background_jobs pure
 # --------------------------------------------------------------------------
 
 class TestBuildBackgroundJobs:
@@ -154,13 +154,13 @@ class TestBuildBackgroundJobs:
 		]
 		findings = [
 			{"action_ref": "1"}, {"action_ref": "1"},  # two findings from job at idx 1
-			{"action_ref": "0"},                         # one from the HTTP action — not a job
+			{"action_ref": "0"},                         # one from the HTTP action not a job
 		]
 		out = renderer.build_background_jobs(actions, {}, findings)
 		assert out["any_findings_counted"] is True
 		by_method = {j["method"]: j["findings_count"] for j in out["jobs"]}
 		assert by_method["a"] == 2
-		assert by_method["b"] == 0  # we did look (findings exist) — 0, not None
+		assert by_method["b"] == 0  # we did look (findings exist) 0, not None
 
 	def test_findings_count_none_when_no_action_refs(self):
 		actions = [_action_dict(0, action_label="Job: a", event_type="RQ Job", recording_uuid="r1")]
@@ -171,7 +171,7 @@ class TestBuildBackgroundJobs:
 
 
 # --------------------------------------------------------------------------
-# build_background_jobs — merge with persisted terminal-status rows
+# build_background_jobs merge with persisted terminal-status rows
 # --------------------------------------------------------------------------
 
 class TestBuildBackgroundJobsStatusMerge:
@@ -312,7 +312,7 @@ class TestRenderedBackgroundJobsSection:
 	def test_findings_column_only_when_mappable(self):
 		# With a finding carrying an action_ref that points at the job's
 		# original index, the Findings column appears.
-		# v0.7.x: the finding must also have a callsite — no-callsite
+		# v0.7.x: the finding must also have a callsite no-callsite
 		# findings are filtered before render, so they wouldn't trigger
 		# the Findings column either.
 		doc = _doc(
@@ -336,7 +336,7 @@ class TestRenderedBackgroundJobsSection:
 	def test_smoking_gun_block_not_duplicated_into_bg_job_embed(self):
 		"""v0.7.x: the styled smoking-gun panel (file:line header + source
 		snippet + drill-down callout) is hidden when ``finding_card`` is
-		embedded inside a BG-job row — the row already shows the entry
+		embedded inside a BG-job row the row already shows the entry
 		callsite as a compact inline link under the method name, so the
 		full panel would just duplicate that anchor inside a blue-bordered
 		box. The canonical Findings section keeps it.
@@ -362,7 +362,7 @@ class TestRenderedBackgroundJobsSection:
 			],
 		)
 		html = renderer.render_raw(doc, recordings=[])
-		# Exactly one smoking-gun panel — the one in the Findings section.
+		# Exactly one smoking-gun panel the one in the Findings section.
 		assert html.count('class="smoking"') == 1
 		# Sanity: the BG-jobs section is rendered, and the related-finding
 		# card was embedded under the job (title travels with the card).
@@ -428,8 +428,8 @@ class TestEntryCallsiteInReport:
 		"""v0.7.x: the multi-line entry-callsite snippet PANEL is dropped
 		from BG job rows. A compact inline ``file:line (function)`` line
 		remains under the job method as a navigation affordance (added
-		in a later iteration). The snippet panel — multi-line table,
-		the def line itself rendered as a yellow-highlighted row — is
+		in a later iteration). The snippet panel multi-line table,
+		the def line itself rendered as a yellow-highlighted row is
 		what's absent."""
 		doc = _doc([
 			_action(action_label="Job: " + self._DOTTED, event_type="RQ Job",
@@ -467,7 +467,7 @@ class TestEntryCallsiteInReport:
 		breakdown's HTTP API row. With a finding carrying ``action_ref``
 		pointing at the action's idx, the related finding card embeds
 		under the action row. The smoking-gun panel must NOT render
-		there — only inside the Findings section."""
+		there only inside the Findings section."""
 		import json
 		doc = _doc(
 			actions=[_action(action_label=self._DOTTED, event_type="HTTP Request",
@@ -488,14 +488,14 @@ class TestEntryCallsiteInReport:
 			],
 		)
 		html = renderer.render_raw(doc, recordings=[])
-		# Exactly one smoking-gun panel — the canonical Findings section card.
+		# Exactly one smoking-gun panel the canonical Findings section card.
 		assert html.count('class="smoking"') == 1
-		# Sanity: the embed actually happened — the title travels with the
+		# Sanity: the embed actually happened the title travels with the
 		# card, so it should appear at least twice (Findings + per-action).
 		assert html.count("duplicated-anchor probe") >= 2
 
 	def test_per_action_banner_does_not_duplicate_finding_title(self):
-		"""The per-action 'finding linked' banner is a count-only header — it
+		"""The per-action 'finding linked' banner is a count-only header it
 		must NOT inline the finding title, because the finding card renders
 		immediately below it inside the same row. Previously the banner echoed
 		the title verbatim, so it appeared twice within one per-action row."""
@@ -525,7 +525,7 @@ class TestEntryCallsiteInReport:
 		banner = m.group(1)
 		# The labelled count header stays…
 		assert "finding linked" in banner
-		# …but the banner must NOT echo the finding title — the card below it does.
+		# …but the banner must NOT echo the finding title the card below it does.
 		assert title not in banner
 		# Sanity: the embed still happened (title travels with the card).
 		assert html.count(title) >= 2
@@ -568,7 +568,7 @@ class TestEntryCallsiteInReport:
 
 
 # --------------------------------------------------------------------------
-# v0.6.x: action/finding context — target document (from form_dict) shown in
+# v0.6.x: action/finding context target document (from form_dict) shown in
 # the per-action table, on the finding card, and appended to exec-summary bullets
 # --------------------------------------------------------------------------
 
@@ -600,7 +600,7 @@ class TestActionContextInReport:
 		assert "Document:" in html
 		assert "Sales Invoice" in html
 		# v0.7.x redesign Phase B: the exec-summary bullet that
-		# augmented its text with "— Sales Invoice SINV-1" is gone
+		# augmented its text with " Sales Invoice SINV-1" is gone
 		# (exec-summary card replaced by TL;DR hero). Target-doc
 		# surfacing now lives in the per-action breakdown + finding
 		# card breadcrumb above. Drop the bullet-text assertion.
@@ -613,7 +613,7 @@ class TestActionContextInReport:
 		doc = _doc([action], findings=[])
 		recs = [{"uuid": "r0", "calls": [], "form_dict": {"fieldname": "name", "filters": "{}"}}]
 		html = renderer.render_raw(doc, recordings=recs)
-		# Anchor on the breadcrumb's structural form, not the bare arrow —
+		# Anchor on the breadcrumb's structural form, not the bare arrow
 		# v0.7.x added a Lens promo line in the header that also uses
 		# &rarr;, so the previous unanchored assertion no longer
 		# distinguishes "no target doc" from "any arrow anywhere".
@@ -632,7 +632,7 @@ class TestActionContextInReport:
 
 
 # --------------------------------------------------------------------------
-# v0.6.x: "Doc-event lifecycle" section — slow findings grouped by DocType → event
+# v0.6.x: "Doc-event lifecycle" section slow findings grouped by DocType → event
 # --------------------------------------------------------------------------
 
 class TestDocEventLifecycleSection:
@@ -659,7 +659,7 @@ class TestDocEventLifecycleSection:
 		)
 
 	def test_doc_events_hook_finding_renders_grouped_by_doctype(self):
-		# A doc_events-hook finding — inject hook_events into the JSON since
+		# A doc_events-hook finding inject hook_events into the JSON since
 		# _attach_action_context can't compute it without a running site (and
 		# won't clobber it: _finding_hook_events returns [] with an empty index).
 		finding = self._finding(
@@ -679,7 +679,7 @@ class TestDocEventLifecycleSection:
 		assert ">Doc events<" in html  # "Jump to:" nav link
 
 	def test_controller_override_finding_and_cascade_note(self):
-		# A GLEntry.validate finding (controller override — no hooks needed),
+		# A GLEntry.validate finding (controller override no hooks needed),
 		# action target = Sales Invoice → "GL Entry touched during a SI submit".
 		from unittest.mock import patch as _patch
 
@@ -714,7 +714,7 @@ class TestDocEventLifecycleSection:
 
 
 # --------------------------------------------------------------------------
-# _action_to_dict — BG-job action_label normalisation
+# _action_to_dict BG-job action_label normalisation
 # --------------------------------------------------------------------------
 
 class TestBgJobActionLabelNormalisation:
@@ -725,7 +725,7 @@ class TestBgJobActionLabelNormalisation:
 	up with ``action_label = "GET <dotted.python.path>"``. The action's
 	``event_type`` is later normalised to ``"RQ Job"`` (so the row
 	appears in the RQ Jobs section), but the persisted label still
-	carries the HTTP-shaped string — leaking "GET" into the METHOD
+	carries the HTTP-shaped string leaking "GET" into the METHOD
 	column AND into finding titles that read ``In {action_label}``.
 
 	``_action_to_dict`` is the single funnel every downstream
@@ -750,7 +750,7 @@ class TestBgJobActionLabelNormalisation:
 
 	def test_canonical_label_passes_through_untouched(self):
 		"""A label already prefixed ``"RQ Job: "`` is returned
-		unchanged — no double-prefix, no path-derived rewrite."""
+		unchanged no double-prefix, no path-derived rewrite."""
 		child = _action(
 			action_label="RQ Job: sync_customer_data",
 			event_type="RQ Job",
@@ -772,7 +772,7 @@ class TestBgJobActionLabelNormalisation:
 
 	def test_non_bg_action_label_untouched(self):
 		"""HTTP requests (event_type != "RQ Job") keep their original
-		``"GET /api/…"`` label — the rewrite only fires for jobs."""
+		``"GET /api/…"`` label the rewrite only fires for jobs."""
 		child = _action(
 			action_label="POST /api/method/save",
 			event_type="HTTP Request",
@@ -785,7 +785,7 @@ class TestBgJobActionLabelNormalisation:
 	def test_bg_job_with_no_path_falls_back_to_original_label(self):
 		"""When event_type is "RQ Job" but ``path`` is empty (degenerate
 		case), the rewrite has no source to derive the short name from
-		— leave the label as-is rather than emitting "RQ Job: " with no
+		leave the label as-is rather than emitting "RQ Job: " with no
 		body."""
 		child = _action(
 			action_label="GET something_weird",
@@ -798,7 +798,7 @@ class TestBgJobActionLabelNormalisation:
 
 
 def test_rq_jobs_table_has_method_colgroup():
-	# v0.7.x: the RQ Jobs table was cramped across 8 columns — it now carries a
+	# v0.7.x: the RQ Jobs table was cramped across 8 columns it now carries a
 	# colgroup that gives the Method column room.
 	doc = _doc([_action(action_label="Job: myapp.tasks.x", event_type="RQ Job",
 	                    path="myapp.tasks.x", recording_uuid="r1", duration_ms=500,

--- a/optimus/tests/test_bg_job_status.py
+++ b/optimus/tests/test_bg_job_status.py
@@ -3,7 +3,7 @@
 
 """analyze captures each enqueued RQ job's terminal status (Completed / Failed
 / Timeout / Stopped) from RQ, and marks jobs still active at the wait ceiling
-as Running — so failed/timed-out jobs are reported instead of vanishing.
+as Running so failed/timed-out jobs are reported instead of vanishing.
 """
 
 import datetime

--- a/optimus/tests/test_bg_job_tracking.py
+++ b/optimus/tests/test_bg_job_tracking.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Hook-time bg-job status tracking — write Running/Completed + started_at /
+"""Hook-time bg-job status tracking write Running/Completed + started_at /
 ended_at / duration_ms to the session's jobs hash from inside before_job /
 after_job, so analyze doesn't have to re-fetch the data from RQ (whose
 records may have been GC'd by the time analyze persists).
@@ -44,7 +44,7 @@ pytest.importorskip("rq")
 
 
 # ---------------------------------------------------------------------------
-# Test doubles — keep mocks lean so each test owns just what it exercises.
+# Test doubles keep mocks lean so each test owns just what it exercises.
 # ---------------------------------------------------------------------------
 
 
@@ -91,7 +91,7 @@ def fake_local(monkeypatch):
 
 	Also stubs ``frappe.utils.now_datetime`` to a fixed string because the
 	real implementation reads ``frappe.db`` for the site's system timezone
-	— which isn't wired up in a plain-pytest context. The SUT's own
+	which isn't wired up in a plain-pytest context. The SUT's own
 	``try/except: pass`` would swallow the resulting AttributeError and
 	silently skip ``set_job_status``, masking the bug behind a green-ish
 	test. Stubbing here keeps the helpers exercisable end-to-end.
@@ -118,7 +118,7 @@ def fake_rq_job(monkeypatch):
 	holder = {"job": FakeJob("J1", "started")}
 	monkeypatch.setattr(rq, "get_current_job", lambda: holder["job"], raising=False)
 	# Also patch the symbol on the SUT-side module since the helpers do a
-	# fresh ``from rq import get_current_job`` per call — monkeypatching the
+	# fresh ``from rq import get_current_job`` per call monkeypatching the
 	# rq module covers it because the lazy import reads ``rq.__dict__``.
 	return holder
 
@@ -129,7 +129,7 @@ def fake_db(monkeypatch):
 	in ``_track_bg_job_finished`` can be exercised without a real DB.
 
 	frappe.db is a Werkzeug Local proxy in production (per
-	[[feedback_frappe_db_local_proxy]]) — patching its attributes is wrong;
+	[[feedback_frappe_db_local_proxy]]) patching its attributes is wrong;
 	always replace the whole proxy with a stand-in object.
 
 	The SUT calls ``frappe.db.get_value`` in a fixed sequence:
@@ -180,7 +180,7 @@ def fake_db(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _track_bg_job_started — fires from before_job once the marker is valid
+# _track_bg_job_started fires from before_job once the marker is valid
 # ---------------------------------------------------------------------------
 
 
@@ -206,7 +206,7 @@ class TestTrackBgJobStarted:
 		assert isinstance(fake_local.optimus_bg_job_start_mono, float)
 
 	def test_callable_method_uses___name__(self, captures, fake_local, fake_rq_job):
-		"""frappe.enqueue accepts a callable too — extract its __name__ so the
+		"""frappe.enqueue accepts a callable too extract its __name__ so the
 		row doesn't render ``<function foo at 0x...>``."""
 		from optimus import hooks_callbacks
 
@@ -241,7 +241,7 @@ class TestTrackBgJobStarted:
 
 
 # ---------------------------------------------------------------------------
-# _track_bg_job_finished — fires from after_job's finally block
+# _track_bg_job_finished fires from after_job's finally block
 # ---------------------------------------------------------------------------
 
 
@@ -260,12 +260,12 @@ class TestTrackBgJobFinished:
 		assert fields["status"] == "Completed"
 		assert fields["error"] is None
 		assert "ended_at" in fields and fields["ended_at"]
-		# Wide tolerance — test runners vary; we only need to confirm a real
+		# Wide tolerance test runners vary; we only need to confirm a real
 		# value was computed, not jitter-tight precision.
 		assert 400 <= fields["duration_ms"] <= 1500
 
 	def test_failed_when_exception_in_flight(self, captures, fake_local, fake_rq_job):
-		"""after_job runs in a Frappe ``finally`` block — if the user's method
+		"""after_job runs in a Frappe ``finally`` block if the user's method
 		raised, ``sys.exc_info()`` reports it. We must capture that as
 		``status=Failed`` with a useful error string."""
 		from optimus import hooks_callbacks
@@ -284,7 +284,7 @@ class TestTrackBgJobFinished:
 
 	def test_timeout_when_jobtimeoutexception_in_flight(self, captures, fake_local, fake_rq_job):
 		"""RQ kills a job that exceeds its timeout with
-		``rq.timeouts.JobTimeoutException`` — distinguish that from a
+		``rq.timeouts.JobTimeoutException``: distinguish that from a
 		generic user-code failure so the report can flag it specifically."""
 		from optimus import hooks_callbacks
 
@@ -331,7 +331,7 @@ class TestTrackBgJobFinished:
 # Source-inspection: confirm before_job / after_job actually call the helpers
 # ---------------------------------------------------------------------------
 # Mirrors the existing ``test_before_job_honours_the_draining_window`` pattern
-# in test_background_job_capture.py — these hooks have too much real-Frappe
+# in test_background_job_capture.py these hooks have too much real-Frappe
 # dependency to call directly in a unit test, but we can prove the call site
 # is wired up correctly via source-inspection.
 
@@ -372,8 +372,8 @@ class TestHookWiring:
 		)
 
 	def test_after_job_calls_track_bg_job_finished_in_finally(self):
-		"""after_job's existing finally block — where clear_pending_job +
-		set_job_recording already fire — must also call _track_bg_job_finished
+		"""after_job's existing finally block where clear_pending_job +
+		set_job_recording already fire must also call _track_bg_job_finished
 		so the worker writes terminal status while the RQ record is still
 		alive (covers the GC'd-record case)."""
 		body = _fn_body(_src("hooks_callbacks.py"), "after_job")
@@ -487,14 +487,14 @@ class TestEndToEndPersist:
 		assert j["ended_at"] == "2026-05-24 15:20:01.500000"
 		assert j["duration_ms"] == 1500.0
 		assert j["recording_uuid"] == "REC-1"
-		# error=None must NOT clobber an existing (non-None) error — set_job_status
+		# error=None must NOT clobber an existing (non-None) error set_job_status
 		# filters None values out (see session.set_job_status implementation).
 		# Here error never got set to a string, so it's just absent.
 		assert "error" not in j or j["error"] is None
 
 
 # ---------------------------------------------------------------------------
-# Late-finish DocType fallback — for jobs that exceed background_job_wait_seconds
+# Late-finish DocType fallback for jobs that exceed background_job_wait_seconds
 # ---------------------------------------------------------------------------
 # When a bg job runs longer than ``_MAX_BG_JOB_WAIT_SECONDS`` (300s hardcap in
 # ``analyze.py``), analyze persists the row with status=Running and then
@@ -547,7 +547,7 @@ class TestLateFinishDocTypeFallback:
 
 		assert fake_db["set_value_calls"] == []
 		assert fake_db["commit_calls"] == 0
-		# But the existing Redis path still fired — sanity check.
+		# But the existing Redis path still fired sanity check.
 		assert len(captures["set_job_status"]) == 1
 		assert captures["set_job_status"][0][2]["status"] == "Completed"
 
@@ -556,7 +556,7 @@ class TestLateFinishDocTypeFallback:
 	):
 		"""Idempotency guard: if some earlier path (analyze re-run, a retry's
 		earlier attempt) already filled the row with Completed, don't overwrite
-		— only the Running placeholder is a candidate for backfill."""
+		only the Running placeholder is a candidate for backfill."""
 		from optimus import hooks_callbacks
 
 		fake_local.optimus_bg_job_start_mono = time.monotonic() - 0.1
@@ -582,7 +582,7 @@ class TestLateFinishDocTypeFallback:
 		assert fake_db["commit_calls"] == 0
 
 	def test_late_finish_noop_when_child_row_missing(self, captures, fake_local, fake_rq_job, fake_db):
-		"""Session is finalized but no child row for this job_id — analyze
+		"""Session is finalized but no child row for this job_id analyze
 		never tracked it (extremely rare: an enqueue patch failed silently, or
 		the job was enqueued from a context that the marker injection didn't
 		cover). Bail rather than INSERT a phantom row."""
@@ -621,7 +621,7 @@ class TestLateFinishDocTypeFallback:
 	def test_late_finish_swallows_db_errors(self, captures, fake_local, fake_rq_job, fake_db, monkeypatch):
 		"""Best-effort guarantee: a DB error during the fallback must NOT raise
 		out of the hook (which would break the worker's after_job dispatcher).
-		The earlier Redis set_job_status write must NOT be suppressed either —
+		The earlier Redis set_job_status write must NOT be suppressed either
 		the fallback's try/except is separate from the helper's outer try."""
 		from optimus import hooks_callbacks
 

--- a/optimus/tests/test_boot_session.py
+++ b/optimus/tests/test_boot_session.py
@@ -59,13 +59,13 @@ class TestBootSession:
 		bootinfo = _fresh_bootinfo()
 		boot.boot_session(bootinfo)
 		assert bootinfo.optimus_enabled is True, (
-			"boot_session must fail-open — a settings-read error must "
+			"boot_session must fail-open a settings-read error must "
 			"NOT hide the widget. Returning False here would silently "
 			"break the primary UI."
 		)
 
 	def test_returns_bool_not_truthy_value(self, monkeypatch):
-		"""The JS guard does strict `=== false` comparison — so this
+		"""The JS guard does strict `=== false` comparison so this
 		must always be a Python bool, not a truthy/falsy value that
 		would serialize oddly (e.g. 0, 1, None)."""
 		from optimus import boot, settings
@@ -89,7 +89,7 @@ class TestHookWired:
 		with open(hooks_path) as f:
 			content = f.read()
 		assert 'boot_session = "optimus.boot.boot_session"' in content, (
-			"hooks.py must register the boot_session hook — without "
+			"hooks.py must register the boot_session hook without "
 			"it the bootinfo.optimus_enabled flag never reaches the "
 			"client and the widget can't hide itself"
 		)
@@ -109,12 +109,12 @@ class TestWidgetGuard:
 		# The guard must reference the boot flag.
 		assert "frappe.boot.optimus_enabled" in js, (
 			"floating_widget.js must check frappe.boot.optimus_enabled "
-			"before mounting — otherwise a disabled profiler still "
+			"before mounting otherwise a disabled profiler still "
 			"shows the widget"
 		)
 		# The guard must return/skip mount when the flag is False.
 		assert "=== false" in js, (
 			"Must use strict === false so a missing/undefined boot "
 			"flag (e.g. older boot payload without this field) doesn't "
-			"hide the widget — fail-open shape"
+			"hide the widget fail-open shape"
 		)

--- a/optimus/tests/test_bump_cache_threshold_patch.py
+++ b/optimus/tests/test_bump_cache_threshold_patch.py
@@ -70,7 +70,7 @@ class TestBumpCacheThreshold:
 		assert stub._single_values["redundant_cache_threshold"] == 50
 
 	def test_does_not_overwrite_deliberate_custom_value(self, monkeypatch):
-		"""User set a custom threshold like 20 or 100 — don't touch it."""
+		"""User set a custom threshold like 20 or 100 don't touch it."""
 		for custom in [5, 20, 30, 75, 100, 500]:
 			stub = _install_frappe_stub(monkeypatch)
 			stub._single_values["redundant_cache_threshold"] = custom
@@ -133,5 +133,5 @@ class TestPatchRegistered:
 			in entries
 		), (
 			"patches.txt must register the bump_cache_threshold_default "
-			"patch — otherwise bench migrate won't run it"
+			"patch otherwise bench migrate won't run it"
 		)

--- a/optimus/tests/test_call_tree_bg_job_findings.py
+++ b/optimus/tests/test_call_tree_bg_job_findings.py
@@ -114,7 +114,7 @@ def test_walker_descends_past_rq_wrappers():
 
 
 def test_walker_skips_wrapper_function_names_regardless_of_file():
-	"""``execute_job`` in a user-app file is still skipped — the bare
+	"""``execute_job`` in a user-app file is still skipped the bare
 	function name is itself a marker of plumbing per
 	``_PURE_HELPER_FUNCTION_NAMES`` (RQ versions emit the frame under
 	various qualified / bare forms). Without this, a user happening
@@ -202,7 +202,7 @@ def test_slow_background_job_fallback_emits_on_deepest_user_frame():
 	deepest non-plumbing frame. The regular walker would emit
 	nothing; the BG-job fallback fires so the reader still gets an
 	actionable callsite instead of an unexplained 12s job."""
-	# 20% of 12s = 2400ms — below default 25% threshold but well
+	# 20% of 12s = 2400ms below default 25% threshold but well
 	# above the absolute 200ms floor. Walker won't emit; fallback
 	# should.
 	user_frame = _node(
@@ -220,7 +220,7 @@ def test_slow_background_job_fallback_emits_on_deepest_user_frame():
 		children=[user_frame],
 	)
 	# Most of the wall time is a sleep / network wait in framework
-	# plumbing — not user-actionable individually but the user-code
+	# plumbing not user-actionable individually but the user-code
 	# frame is still the right callsite to surface.
 	rq_outer = _node(
 		"execute_job",
@@ -250,7 +250,7 @@ def test_slow_background_job_fallback_emits_on_deepest_user_frame():
 	assert "In job long_running_job" in hot["title"]
 	# Action linkage preserved for the per-action table cross-link.
 	assert hot["action_ref"] == "3"
-	# Impact clamped to action wall — never claims more than the job
+	# Impact clamped to action wall never claims more than the job
 	# actually took.
 	assert hot["estimated_impact_ms"] <= 12000
 

--- a/optimus/tests/test_call_tree_findings.py
+++ b/optimus/tests/test_call_tree_findings.py
@@ -127,7 +127,7 @@ def test_self_referential_hot_path_uses_clear_phrasing():
 	"""Production bug: the title read as
 	'In erpnext.accounts.doctype.pricing_rule.pricing_rule.apply_pricing_rule,
 	 96% of the time was spent in apply_pricing_rule'
-	— tautological because the action label ends with the same
+	tautological because the action label ends with the same
 	function name. The hot spot is self-time in the function body,
 	not a subcall. We rephrase to surface that fact."""
 	tree = _node("<root>", "", 1000, [
@@ -219,7 +219,7 @@ def test_slow_hot_path_suppressed_when_dominated_by_sql():
 	findings = call_tree._emit_per_action_findings(
 		tree, action_idx=0, action_label="x", action_wall_time_ms=1000,
 	)
-	# 700/800 = 87.5% — suppressed (top_queries handles it)
+	# 700/800 = 87.5% suppressed (top_queries handles it)
 	assert findings == []
 
 
@@ -232,7 +232,7 @@ def test_repeated_hot_frame_finding_aggregates_across_actions():
 	# Same frame in 4 different actions, total 800ms self-time
 	# (v0.7.x A.AE1: hot-frames aggregator switched from cumulative
 	# to self_ms to avoid recursive double-count. Leaf fixtures now
-	# need self_ms set explicitly — cumulative alone no longer feeds
+	# need self_ms set explicitly cumulative alone no longer feeds
 	# the leaderboard.)
 	per_action_trees = []
 	for _ in range(4):
@@ -260,17 +260,17 @@ def test_repeated_hot_frame_no_finding_when_below_thresholds():
 
 def test_repeated_hot_frame_filters_wrappers_entirely():
 	"""v0.5.2 strengthens the v0.5.1 fix: the original bug was
-	'High — wrapper appeared in 11 actions and consumed 3534ms total'
+	'High wrapper appeared in 11 actions and consumed 3534ms total'
 	where each of the 11 was a different decorator wrapper from a
 	different module. v0.5.1 solved it by disambiguating per-file
 	(so each wrapper became its own leaderboard entry). That was
-	better but still noisy — every decorated method produced a
+	better but still noisy every decorated method produced a
 	'wrapper' entry with a cumulative time ≈ the wrapped function's
 	cumulative time, duplicating information.
 
 	v0.5.2 filters all 'wrapper' / 'composer' / 'runner' / 'fn' /
 	'hook' / 'compose' frames entirely. They're decorator internals
-	regardless of file — showing them adds no signal beyond what
+	regardless of file showing them adds no signal beyond what
 	the wrapped function's own leaderboard entry already provides.
 
 	This test now verifies the stronger v0.5.2 behavior: wrappers
@@ -278,7 +278,7 @@ def test_repeated_hot_frame_filters_wrappers_entirely():
 	"""
 	per_action_trees = []
 	# Four different 'wrapper' functions in four different files.
-	# All should be filtered — none should appear in the leaderboard.
+	# All should be filtered none should appear in the leaderboard.
 	for _ in range(4):
 		per_action_trees.append(_node("<root>", "", 500, [
 			_node("wrapper", "my_app/a.py", 50, []),
@@ -289,7 +289,7 @@ def test_repeated_hot_frame_filters_wrappers_entirely():
 
 	findings, leaderboard = call_tree._aggregate_hot_frames(per_action_trees)
 
-	# NO wrapper entries at all — they're decorator plumbing.
+	# NO wrapper entries at all they're decorator plumbing.
 	wrapper_entries = [r for r in leaderboard if "::wrapper" in r["function"]]
 	assert wrapper_entries == [], (
 		f"v0.5.2: wrapper frames must be filtered entirely. Got "
@@ -307,16 +307,16 @@ def test_repeated_hot_frame_skips_pure_helpers_only():
 	"""v0.5.1: Repeated Hot Frame aggregator uses the NARROWER
 	_is_pure_helper_frame filter, not the broad _is_framework_frame.
 	Pure plumbing helpers (frappe/handler.py, frappe/utils/, werkzeug,
-	rq, pyinstrument) are suppressed — those are unoptimizable.
+	rq, pyinstrument) are suppressed those are unoptimizable.
 	"""
 	per_action_trees = []
 	for _ in range(5):
 		per_action_trees.append(_node("<root>", "", 500, [
-			# frappe/handler.py — pure request-dispatch plumbing
+			# frappe/handler.py pure request-dispatch plumbing
 			_node("handle", "apps/frappe/handler.py", 250, []),
-			# frappe/utils/data.py — type conversion helper
+			# frappe/utils/data.py type conversion helper
 			_node("cint", "apps/frappe/frappe/utils/data.py", 100, []),
-			# werkzeug — infra lib
+			# werkzeug infra lib
 			_node(
 				"inner",
 				"env/lib/python3.14/site-packages/werkzeug/wsgi.py",
@@ -351,7 +351,7 @@ def test_repeated_hot_frame_keeps_frappe_application_code():
 	always ≈ the user's validate/on_submit hook times, so showing
 	it as a separate hot frame double-counts information. Users
 	see their actual hooks (erpnext/*.py::validate) as hot frames
-	— that's the actionable signal.
+	that's the actionable signal.
 
 	This test now verifies what remains actionable inside frappe/*:
 
@@ -360,20 +360,20 @@ def test_repeated_hot_frame_keeps_frappe_application_code():
 	  - naming.make_autoname: user's naming-series config can be
 	    optimized (simpler prefix, fewer SQL lookups). KEPT.
 
-	Document.run_method is NOT in this keeper list anymore — the
+	Document.run_method is NOT in this keeper list anymore the
 	user can see their hooks directly instead of the dispatcher.
 	"""
 	per_action_trees = []
 	for _ in range(5):
 		per_action_trees.append(_node("<root>", "", 2000, [
-			# permissions.has_permission — keep (user custom rules).
+			# permissions.has_permission keep (user custom rules).
 			_node(
 				"has_permission",
 				"apps/frappe/frappe/permissions.py",
 				400,
 				[],
 			),
-			# naming.make_autoname — keep (user naming series).
+			# naming.make_autoname keep (user naming series).
 			_node(
 				"make_autoname",
 				"apps/frappe/frappe/model/naming.py",
@@ -408,7 +408,7 @@ def test_repeated_hot_frame_keeps_frappe_application_code():
 
 
 # ---------------------------------------------------------------------------
-# v0.5.2: expanded plumbing filter — decorator wrappers, meta loaders,
+# v0.5.2: expanded plumbing filter decorator wrappers, meta loaders,
 # form-load, query-builder, database layer, stdlib, third-party libs
 # ---------------------------------------------------------------------------
 
@@ -443,7 +443,7 @@ def test_pure_helper_filters_decorator_wrappers():
 			f"{function_name} must be filtered as private delegation"
 		)
 
-	# Public entry points KEPT — users recognize these
+	# Public entry points KEPT users recognize these
 	for function_name in ("save", "insert", "submit", "cancel", "validate"):
 		node = {
 			"function": function_name,
@@ -451,13 +451,13 @@ def test_pure_helper_filters_decorator_wrappers():
 			"kind": "python",
 		}
 		# "validate" etc. are user-implemented hooks that run through
-		# the decorator chain — users should see these in the
+		# the decorator chain users should see these in the
 		# leaderboard. But filtering works on frame FILENAME too:
 		# frappe/model/document.py doesn't fire those here because
 		# "validate" the user wrote lives at apps/myapp/controllers/*.py.
 		# This test verifies the FUNCTION-NAME filter doesn't
 		# accidentally catch them when they happen to be in
-		# document.py (it won't — they're not in the block list).
+		# document.py (it won't they're not in the block list).
 
 
 def test_pure_helper_filters_meta_loaders():
@@ -554,7 +554,7 @@ def test_pure_helper_filters_third_party_libs():
 
 
 def test_pure_helper_filters_pyinstrument_synthetic_markers():
-	"""<built-in>, <string>, <module>, <frozen …> — synthetic
+	"""<built-in>, <string>, <module>, <frozen …> synthetic
 	function names pyinstrument emits for C builtins / compiled-
 	string frames."""
 	from optimus.analyzers.call_tree import _is_pure_helper_frame
@@ -578,21 +578,21 @@ def test_pure_helper_production_payload_all_filtered():
 	to being dominated by framework plumbing."""
 	from optimus.analyzers.call_tree import _is_pure_helper_frame
 
-	# Exact (function, filename) pairs from a production report — the
+	# Exact (function, filename) pairs from a production report the
 	# `must_filter` list below is the curated subset that this test
 	# actually asserts on. Originally recorded here for historical
 	# context; kept as a comment to avoid an unused-variable flag.
 	#   execute_query / frappe/query_builder/utils.py
 	#   save / _save / run_method / composer / runner / fn / __init__ /
-	#   load_from_db / insert / get_doc_str — all frappe/model/document.py
-	#   get_meta / __init__ — frappe/model/meta.py and frappe/desk/form/meta.py
-	#   get_values / sql / execute_query — frappe/database/database.py
-	#   getdoctype / get_meta_bundle — frappe/desk/form/load.py
-	#   execute — frappe/model/qb_query.py
-	#   load_from_db / process — frappe/model/meta.py
-	#   getouterframes / getframeinfo — inspect.py
-	#   wrapper — erpnext/__init__.py, utils/__init__.py
-	#   execute / _query — MySQLdb/cursors.py
+	#   load_from_db / insert / get_doc_str all frappe/model/document.py
+	#   get_meta / __init__ frappe/model/meta.py and frappe/desk/form/meta.py
+	#   get_values / sql / execute_query frappe/database/database.py
+	#   getdoctype / get_meta_bundle frappe/desk/form/load.py
+	#   execute frappe/model/qb_query.py
+	#   load_from_db / process frappe/model/meta.py
+	#   getouterframes / getframeinfo inspect.py
+	#   wrapper erpnext/__init__.py, utils/__init__.py
+	#   execute / _query MySQLdb/cursors.py
 
 	# v0.5.2 round 2: ALL of frappe/model/document.py is filtered
 	# (save / insert / submit / _save / run_method / __init__ /
@@ -640,7 +640,7 @@ def test_pure_helper_production_payload_all_filtered():
 		node = {"function": function_name, "filename": filename, "kind": "python"}
 		assert _is_pure_helper_frame(node) is True, (
 			f"Production noise not filtered: {filename}::{function_name} "
-			"— this frame would re-appear in the Repeated Hot Frame "
+			" this frame would re-appear in the Repeated Hot Frame "
 			"leaderboard if the filter regresses."
 		)
 
@@ -649,7 +649,7 @@ def test_pure_helper_still_keeps_application_frappe_code():
 	"""Critical negative case: user-visible APP code MUST still pass
 	through. v0.5.2 round 2 removed Document.save/insert/submit/
 	run_method from the keepers because their cumulative times
-	always duplicate the user's validate/on_submit hooks —
+	always duplicate the user's validate/on_submit hooks
 	double-counting noise. The user still sees the actual hook
 	code (erpnext/*, myapp/*) as hot frames."""
 	from optimus.analyzers.call_tree import _is_pure_helper_frame
@@ -669,7 +669,7 @@ def test_pure_helper_still_keeps_application_frappe_code():
 	for function_name, filename in keepers:
 		node = {"function": function_name, "filename": filename, "kind": "python"}
 		assert _is_pure_helper_frame(node) is False, (
-			f"{filename}::{function_name} was WRONGLY filtered — "
+			f"{filename}::{function_name} was WRONGLY filtered "
 			"users must see this in the Repeated Hot Frame leaderboard "
 			"as a legitimate optimization target."
 		)
@@ -700,13 +700,13 @@ def test_is_pure_helper_frame_matches_relative_filenames():
 		node = {"function": function, "filename": filename, "kind": "python"}
 		assert _is_pure_helper_frame(node) is True, (
 			f"{filename}::{function} must be classified as a pure helper "
-			f"— it's framework plumbing that every request passes through"
+			f" it's framework plumbing that every request passes through"
 		)
 
 
 def test_is_pure_helper_frame_matches_absolute_filenames():
 	"""Backward compatibility: some environments DO deliver absolute
-	paths from pyinstrument. Those must still match — the filter is
+	paths from pyinstrument. Those must still match the filter is
 	position-insensitive (substring / suffix)."""
 	from optimus.analyzers.call_tree import _is_pure_helper_frame
 
@@ -730,7 +730,7 @@ def test_is_pure_helper_frame_keeps_application_frappe_code():
 	document.py file is now plumbing. Document.save / insert /
 	submit / run_method all show up as hot frames with cumulative
 	times IDENTICAL to the validate / on_submit / etc. hooks
-	inside them — so the Document-level entries are redundant
+	inside them so the Document-level entries are redundant
 	double-counts. Users see their actual hook code (erpnext/…::
 	validate, myapp/…::on_submit) as separate hot frames; that's
 	where the actionable signal lives.
@@ -738,16 +738,16 @@ def test_is_pure_helper_frame_keeps_application_frappe_code():
 	from optimus.analyzers.call_tree import _is_pure_helper_frame
 
 	for filename, function in (
-		# Permissions — slow custom Permission Query Conditions
+		# Permissions slow custom Permission Query Conditions
 		# bubble here. KEPT.
 		("frappe/permissions.py", "has_permission"),
-		# Naming series — user's series config can be optimized
+		# Naming series user's series config can be optimized
 		# (simpler prefix, fewer SQL lookups). KEPT.
 		("frappe/model/naming.py", "make_autoname"),
 		# frappe.client is the REST-ish API layer; get_list is the
 		# entry point users of the REST API actually call. KEPT.
 		("frappe/client.py", "get_list"),
-		# User app code — the whole point of the hot-frames
+		# User app code the whole point of the hot-frames
 		# leaderboard.
 		("apps/erpnext/erpnext/accounts/doctype/sales_invoice/sales_invoice.py", "validate"),
 		("apps/myapp/controllers/invoice.py", "on_submit"),
@@ -755,7 +755,7 @@ def test_is_pure_helper_frame_keeps_application_frappe_code():
 	):
 		node = {"function": function, "filename": filename, "kind": "python"}
 		assert _is_pure_helper_frame(node) is False, (
-			f"{filename}::{function} must NOT be filtered — it's "
+			f"{filename}::{function} must NOT be filtered it's "
 			f"application-layer code users can optimize"
 		)
 
@@ -764,7 +764,7 @@ def test_is_pure_helper_frame_filters_entire_document_py():
 	"""v0.5.2 round 2: frappe/model/document.py is entirely
 	plumbing. save / insert / submit / _save / run_method /
 	__init__ / load_from_db / load_children_from_db /
-	get_cached_doc / get_doc_str — all show up with cumulative
+	get_cached_doc / get_doc_str all show up with cumulative
 	times identical to the user code inside them. Diagnostic
 	against a real stored call tree confirmed all of these leaked
 	before the round-2 fix."""
@@ -786,12 +786,12 @@ def test_is_pure_helper_frame_filters_entire_document_py():
 			node = {"function": function, "filename": filename, "kind": "python"}
 			assert _is_pure_helper_frame(node) is True, (
 				f"{filename}::{function} must be filtered "
-				"(Document plumbing — v0.5.2 round 2)"
+				"(Document plumbing v0.5.2 round 2)"
 			)
 
 
 def test_is_pure_helper_frame_filters_model_utils():
-	"""frappe/model/utils/* is framework plumbing — is_virtual_doctype,
+	"""frappe/model/utils/* is framework plumbing is_virtual_doctype,
 	get_parent_doc, etc. Called by document loader, no user decision
 	behind the time they consume."""
 	from optimus.analyzers.call_tree import _is_pure_helper_frame
@@ -842,7 +842,7 @@ def test_is_pure_helper_frame_keeps_user_code():
 def test_is_framework_frame_matches_relative_filenames():
 	"""Same slash-bug fix applies to the broader _is_framework_frame
 	filter used by Slow Hot Path. Production report showed 'In POST
-	/api/method/..., 99% of time was spent in application' — i.e.
+	/api/method/..., 99% of time was spent in application' i.e.
 	frappe/app.py::application. That frame should have been
 	classified as framework so Slow Hot Path descended into user
 	code below it."""
@@ -945,7 +945,7 @@ def test_strip_profiler_frames_grafts_user_code_children_up():
 	"""Edge case: a user-code frame nested BELOW a optimus
 	frame (e.g. a capture.py wrap that intercepts get_doc and then
 	user's __init__ runs under it). The user-code child must be
-	preserved — grafted up to where the profiler frame was."""
+	preserved grafted up to where the profiler frame was."""
 	tree = _node("<root>", "", 100, [
 		_node("application", "frappe/app.py", 100, [
 			_node(
@@ -1049,7 +1049,7 @@ def test_hooks_callbacks_before_request_snapshot_runs_before_pyi_start():
 
 
 def test_hooks_callbacks_before_job_snapshot_runs_before_pyi_start():
-	"""Same ordering guard for before_job — background jobs have the
+	"""Same ordering guard for before_job background jobs have the
 	same self-capture exposure as HTTP requests."""
 	import inspect
 
@@ -1101,7 +1101,7 @@ def test_production_payload_eight_plumbing_findings_all_filtered():
 		f"Got: {[f['title'] for f in repeated]}"
 	)
 
-	# And they should not be in the leaderboard either — they'd waste
+	# And they should not be in the leaderboard either they'd waste
 	# slots that could go to real user-code hot frames.
 	bad_names = {fn for fn, _, _ in plumbing_frames}
 	for row in leaderboard:
@@ -1172,7 +1172,7 @@ def test_donut_bucketing_by_top_level_module():
 def test_top_level_app_rejects_stdlib_and_third_party(monkeypatch):
 	"""v0.5.1: production donut showed Python(inspect.py),
 	Python(functools.py), Python(MySQLdb), Python(<built-in>) as
-	separate buckets — all noise. Single-segment filenames (stdlib),
+	separate buckets all noise. Single-segment filenames (stdlib),
 	site-packages paths, and angle-bracketed synthetic markers must
 	all collapse to [other]. First-segment paths that AREN'T a
 	known installed Frappe app (MySQLdb etc.) also collapse to
@@ -1193,12 +1193,12 @@ def test_top_level_app_rejects_stdlib_and_third_party(monkeypatch):
 		raising=False,
 	)
 
-	# Python stdlib — single-segment filename
+	# Python stdlib single-segment filename
 	assert _top_level_app("getmembers", "inspect.py") == "[other]"
 	assert _top_level_app("reduce", "functools.py") == "[other]"
 	assert _top_level_app("_bootstrap", "threading.py") == "[other]"
 
-	# Third-party library — pyinstrument stripped site-packages/
+	# Third-party library pyinstrument stripped site-packages/
 	# prefix and left just the lib/file form. Rejected because
 	# "MySQLdb" isn't in the installed-apps list.
 	assert _top_level_app("query", "MySQLdb/connections.py") == "[other]"
@@ -1211,7 +1211,7 @@ def test_top_level_app_rejects_stdlib_and_third_party(monkeypatch):
 		"env/lib/python3.14/site-packages/requests/api.py",
 	) == "[other]"
 
-	# Pyinstrument synthetic — angle-bracketed function name
+	# Pyinstrument synthetic angle-bracketed function name
 	assert _top_level_app("<built-in>", "<built-in>") == "[other]"
 	assert _top_level_app("<module>", "<string>") == "[other]"
 	assert _top_level_app("<lambda>", "frappe/utils.py") == "[other]"
@@ -1225,7 +1225,7 @@ def test_top_level_app_rejects_stdlib_and_third_party(monkeypatch):
 def test_top_level_app_falls_back_when_installed_apps_unavailable(monkeypatch):
 	"""When frappe.get_installed_apps fails (no site context, unit
 	test environment), accept the first-segment as the bucket name.
-	This is the legacy behavior — a conservative fallback that
+	This is the legacy behavior a conservative fallback that
 	preserves the pre-v0.5.1 unit tests, which don't mock frappe."""
 	import frappe
 
@@ -1237,7 +1237,7 @@ def test_top_level_app_falls_back_when_installed_apps_unavailable(monkeypatch):
 	monkeypatch.setattr(frappe, "get_installed_apps", _raise, raising=False)
 
 	# With the fallback, MySQLdb passes through as its first segment
-	# (acceptable for unit tests — real production always has a site).
+	# (acceptable for unit tests real production always has a site).
 	# The stdlib filters still fire: inspect.py has no / so → [other].
 	assert _top_level_app("reduce", "functools.py") == "[other]"
 	# Multi-segment path: legacy first-segment fallback.
@@ -1245,7 +1245,7 @@ def test_top_level_app_falls_back_when_installed_apps_unavailable(monkeypatch):
 
 
 def test_top_level_app_uses_filename_not_function_name():
-	"""Direct unit test — covers the bug root cause without going
+	"""Direct unit test covers the bug root cause without going
 	through the full aggregation path."""
 	from optimus.analyzers.call_tree import _top_level_app
 
@@ -1311,11 +1311,11 @@ def test_production_donut_collapses_plumbing_into_frappe_bucket():
 	breakdown = call_tree._build_session_breakdown(per_action_trees, sql_total_ms=192)
 	by_app = breakdown["by_app"]
 
-	# Before the fix: six buckets — application, init_request, call,
-	# execute_cmd, record_sql, snapshot, before_request — each near 0ms.
+	# Before the fix: six buckets application, init_request, call,
+	# execute_cmd, record_sql, snapshot, before_request each near 0ms.
 	# After the fix: two buckets (frappe + optimus) with real totals.
 	assert set(by_app.keys()) <= {"frappe", "optimus", "[other]"}, (
-		f"Unexpected buckets — should only contain frappe / "
+		f"Unexpected buckets should only contain frappe / "
 		f"optimus / [other]; got: {set(by_app.keys())}"
 	)
 
@@ -1334,7 +1334,7 @@ def test_production_donut_collapses_plumbing_into_frappe_bucket():
 	for bad in ("application", "init_request", "call", "execute_cmd",
 	            "record_sql", "before_request", "snapshot"):
 		assert bad not in by_app, (
-			f"Function name '{bad}' must not be a bucket key — "
+			f"Function name '{bad}' must not be a bucket key "
 			f"bucketing should be by app (filename), not function name. "
 			f"Got by_app: {by_app}"
 		)
@@ -1404,7 +1404,7 @@ def test_analyze_handles_missing_pyi_session():
 
 class TestTrackedAppsInclusion:
 	"""Optimus Settings ▸ Tracked Apps: when set, call_tree findings (hot frames,
-	slow paths, BG jobs) only surface frames inside the tracked apps — every other
+	slow paths, BG jobs) only surface frames inside the tracked apps every other
 	frame is out-of-scope plumbing, matching how the SQL analyzers honour inclusion
 	mode. Empty/None → profile everything (unchanged default)."""
 
@@ -1476,7 +1476,7 @@ def test_top_level_app_resolves_real_app_under_apps_ancestor():
 
 def test_pure_helper_hides_any_site_packages_lib():
 	"""A venv lib outside the hardcoded set (gevent, sentry_sdk, …) must not leak
-	into the hot-frame leaderboard — the blanket site-packages/ guard catches it
+	into the hot-frame leaderboard the blanket site-packages/ guard catches it
 	regardless of the lib name; user code under apps/ is unaffected."""
 	from optimus.analyzers.call_tree import _is_pure_helper_frame
 	for f in ("/home/x/env/lib/python3.11/site-packages/gevent/hub.py",

--- a/optimus/tests/test_call_tree_fuzz.py
+++ b/optimus/tests/test_call_tree_fuzz.py
@@ -83,7 +83,7 @@ def test_reconcile_invariants(tree, calls):
 
 	# Invariant 3: every SQL call lands as exactly one leaf, even after
 	# coalescing (coalescing only merges identical query_normalized, and
-	# Hypothesis is unlikely to generate identical queries — but if it
+	# Hypothesis is unlikely to generate identical queries but if it
 	# does, the coalesced count should still equal the original input).
 	def count_sql_query_count(node):
 		c = node.get("query_count", 0) if node.get("kind") == "sql" else 0

--- a/optimus/tests/test_call_tree_reconcile.py
+++ b/optimus/tests/test_call_tree_reconcile.py
@@ -73,7 +73,7 @@ def test_summarize_explain_reads_normalized_plantable_shape():
 	"""Regression: the live pipeline stores explain_result as normalized
 	PlanTable dicts (full_scan / sort_without_index / temp_used /
 	selectivity_pct), not raw MariaDB rows. _summarize_explain must read that
-	shape — it previously only knew the legacy type/Extra/filtered keys and so
+	shape it previously only knew the legacy type/Extra/filtered keys and so
 	returned {} for every current session."""
 	normalized = [{
 		"table": "tabGL Entry", "full_scan": True, "sort_without_index": True,
@@ -88,7 +88,7 @@ def test_summarize_explain_reads_normalized_plantable_shape():
 
 
 def test_summarize_explain_postgres_none_selectivity_does_not_fire_low_filter():
-	"""On Postgres selectivity_pct is None — low_filter must simply not fire."""
+	"""On Postgres selectivity_pct is None low_filter must simply not fire."""
 	flags = call_tree._summarize_explain([{
 		"table": "t", "full_scan": True, "sort_without_index": False,
 		"temp_used": True, "selectivity_pct": None, "raw": {},
@@ -229,9 +229,9 @@ def test_reconcile_with_no_calls_returns_tree_unchanged():
 def test_reconcile_invariant_no_python_node_exceeds_parent():
 	"""Property: cumulative_ms of any python node ≤ cumulative_ms of its parent.
 
-	SQL leaves are excluded from the invariant — their grafted self_ms is
+	SQL leaves are excluded from the invariant their grafted self_ms is
 	informational and may push a parent's *summed* children above the parent.
-	The renderer never sums children — it always uses the parent's own
+	The renderer never sums children it always uses the parent's own
 	cumulative_ms.
 	"""
 	tree_dict = _make_node("<root>", "", 100, [

--- a/optimus/tests/test_call_tree_render.py
+++ b/optimus/tests/test_call_tree_render.py
@@ -55,7 +55,7 @@ def test_other_frames_node_is_dropped():
 
 def test_more_frames_omitted_node_is_dropped():
 	# The analyzer's deep-tree pruning placeholder "[N more frames omitted]" is a
-	# synthetic collapse node with no callsite — drop it like [other: N frames].
+	# synthetic collapse node with no callsite drop it like [other: N frames].
 	tree = _node("handle", "frappe/handler.py", 100, [
 		_node("looped_validate", "ugly_code/python/common.py", 95),
 		{"function": "[208 more frames omitted]", "filename": "", "lineno": 0,
@@ -77,12 +77,12 @@ def test_ct_is_other_frame_matches_both_synthetic_formats():
 
 
 def test_sql_leaves_dropped_from_tree():
-	# ALL <sql> leaf siblings are dropped from the call-tree display — no
+	# ALL <sql> leaf siblings are dropped from the call-tree display no
 	# summary line, no rows. The call tree shows only the Python hierarchy;
 	# the queries themselves live in the Slowest-queries / per-action sections.
 	tree = _node("handle", "frappe/handler.py", 100, [
 		_node("looped_validate", "ugly_code/common.py", 50),
-		_node("<sql>", "ugly_code/common.py", 40),   # 40ms — still dropped
+		_node("<sql>", "ugly_code/common.py", 40),   # 40ms still dropped
 		_node("<sql>", "frappe/db.py", 0.3),
 		_node("<sql>", "frappe/db.py", 0.2),
 	])
@@ -166,7 +166,7 @@ def test_flat_top_action_does_not_hide_deep_action():
 	]
 	panel = renderer._render_call_tree_panel(acts)
 	assert "flat_top" in panel and "deep_second" in panel
-	# the deep action's user frame renders — its structure is no longer hidden
+	# the deep action's user frame renders its structure is no longer hidden
 	assert "looped_validate" in panel
 
 

--- a/optimus/tests/test_call_tree_severity_clamp.py
+++ b/optimus/tests/test_call_tree_severity_clamp.py
@@ -1,12 +1,12 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""D.M-S1 — gating-clamp regression.
+"""D.M-S1 gating-clamp regression.
 
 The Slow Hot Path finding's percentage is computed as
 ``cumulative_ms / action_wall_time_ms``. Pyinstrument's aggregated tree
 can sum across actions, producing pct > 100% which would render as
-"150% of the action's wall time" — a nonsensical reading.
+"150% of the action's wall time" a nonsensical reading.
 
 The fix clamps ``pct_of_action = min(1.0, raw_pct)`` before display and
 severity gating, AND clamps ``estimated_impact_ms`` to the action wall
@@ -65,7 +65,7 @@ def test_pct_display_clamped_to_100_percent():
 
 
 def test_estimated_impact_ms_clamped_to_action_wall():
-	"""estimated_impact_ms must not exceed action_wall_time_ms — a finding
+	"""estimated_impact_ms must not exceed action_wall_time_ms a finding
 	claiming to consume more than the action took is nonsensical."""
 	tree = _node(
 		"my_app.work.do_work",
@@ -80,12 +80,12 @@ def test_estimated_impact_ms_clamped_to_action_wall():
 
 
 def test_within_action_severity_unchanged():
-	"""Clamp doesn't touch findings whose pct is already <= 100% —
+	"""Clamp doesn't touch findings whose pct is already <= 100%
 	a true 80% hot path still reads as High (> high_pct=50%)."""
 	tree = _node(
 		"my_app.work.do_work",
 		"apps/my_app/work.py",
-		cumulative=800,  # 80% of a 1000ms action — legitimate
+		cumulative=800,  # 80% of a 1000ms action legitimate
 		self_ms=800,
 		children=[],
 	)
@@ -113,7 +113,7 @@ def test_absolute_impact_promotes_to_high():
 	findings = _walk_findings(tree, action_wall_ms=3000)
 	assert findings, "expected a Slow Hot Path finding"
 	assert findings[0]["severity"] == "High", (
-		"a 1.47s subtree should be High regardless of pct — without "
+		"a 1.47s subtree should be High regardless of pct without "
 		"the absolute-impact escape hatch it falls to Medium and the "
 		"TL;DR headline mis-ranks against smaller High findings"
 	)
@@ -122,7 +122,7 @@ def test_absolute_impact_promotes_to_high():
 def test_below_absolute_threshold_stays_medium():
 	"""The escape hatch shouldn't promote borderline Medium findings.
 	A 600ms subtree at 45% pct (below 50% high_pct AND below 1000ms
-	absolute floor) stays Medium — the new rule fires only on
+	absolute floor) stays Medium the new rule fires only on
 	overwhelming absolute impact."""
 	# 45% × 1333ms ≈ 600ms cumulative. Neither rule fires:
 	#   - relative: 45% < 50% high_pct
@@ -137,6 +137,6 @@ def test_below_absolute_threshold_stays_medium():
 	findings = _walk_findings(tree, action_wall_ms=1333)
 	assert findings, "expected a Slow Hot Path finding (pct=45% > med_pct=25%)"
 	assert findings[0]["severity"] == "Medium", (
-		"borderline pct + sub-1s cumulative should stay Medium — the "
+		"borderline pct + sub-1s cumulative should stay Medium the "
 		"absolute-impact rule only promotes overwhelming impact"
 	)

--- a/optimus/tests/test_callsite_deep_link.py
+++ b/optimus/tests/test_callsite_deep_link.py
@@ -4,7 +4,7 @@
 """Tests for v0.5.2 round 4 clickable callsite → editor deep-link.
 
 A finding's absolute-path callsite renders as a clickable anchor using
-the ``vscode://file`` URL scheme — VS Code, VS Code Insiders, and
+the ``vscode://file`` URL scheme VS Code, VS Code Insiders, and
 Cursor all register this handler on install, so the link jumps the
 developer straight to the file:line in their editor with one click.
 
@@ -64,7 +64,7 @@ def _fake_session_doc(callsite_filename="/abs/path/apps/myapp/foo.py",
 def test_raw_mode_wraps_callsite_in_vscode_link():
 	"""Raw mode + absolute path → clickable ``vscode://file`` anchor.
 
-	URL shape: ``vscode://file{absolute_path}:{lineno}`` — two slashes
+	URL shape: ``vscode://file{absolute_path}:{lineno}``: two slashes
 	after ``vscode:``, the authority ``file``, then the absolute path
 	(which itself starts with ``/``). Matches VS Code's documented
 	URL-handler scheme; Cursor + VS Code Insiders honor the same
@@ -82,13 +82,13 @@ def test_raw_mode_wraps_callsite_in_vscode_link():
 	)
 	# Class marker for the link (used for CSS + future JS hooks).
 	assert 'class="callsite-link"' in html
-	# Link wraps a <code> block — the actual visible callsite text.
+	# Link wraps a <code> block the actual visible callsite text.
 	assert "apps/myapp/foo.py:42" in html
 
 
 def test_bench_relative_path_does_not_emit_link():
-	"""Bench-relative (non-absolute) callsites — e.g. 'frappe/handler.py'
-	from pyinstrument's short form — can't be made into a working
+	"""Bench-relative (non-absolute) callsites e.g. 'frappe/handler.py'
+	from pyinstrument's short form can't be made into a working
 	vscode:// URL without an abs path. Render as plain code instead
 	of emitting a broken link."""
 	from unittest.mock import patch as _patch
@@ -104,7 +104,7 @@ def test_bench_relative_path_does_not_emit_link():
 		html = renderer.render(doc, recordings=[])
 
 	assert 'vscode://file/frappe/handler.py' not in html, (
-		"Non-absolute path must NOT be linked as vscode:// — the URL "
+		"Non-absolute path must NOT be linked as vscode:// the URL "
 		"scheme requires an absolute filesystem path"
 	)
 	assert "frappe/handler.py:10" in html  # still shown, just as plain code

--- a/optimus/tests/test_callsite_normalization.py
+++ b/optimus/tests/test_callsite_normalization.py
@@ -77,7 +77,7 @@ class TestNormalizeCallsite:
 		assert _normalize_callsite(None) is None
 
 	def test_unknown_type_returns_none(self):
-		# e.g. an int slipped in from somewhere — don't crash, skip.
+		# e.g. an int slipped in from somewhere don't crash, skip.
 		assert _normalize_callsite(12345) is None
 
 	def test_non_numeric_suffix_not_treated_as_lineno(self):
@@ -191,7 +191,7 @@ class TestFindingToDictNormalizes:
 class TestImpactScopeLabelBackfill:
 	"""Legacy user N+1 findings (analyzed before impact_scope_label shipped) get
 	the label backfilled from the stable finding_type so the report card's scope
-	tag agrees with the TL;DR hero on re-render — but only when the finding
+	tag agrees with the TL;DR hero on re-render but only when the finding
 	actually carries a loop-scoped magnitude (finding ⑦)."""
 
 	def _row(self, finding_type, detail):
@@ -318,10 +318,10 @@ class TestEndToEndRender:
 		#   AttributeError: 'str' object has no attribute 'get'
 		html = renderer.render(doc, recordings=[])
 
-		# Both findings rendered — titles present.
+		# Both findings rendered titles present.
 		assert "Slow query: 1374ms" in html
 		assert "Same query ran 15× at myapp/foo.py:10" in html
-		# Both attributed to myapp — since they're the only app, the
+		# Both attributed to myapp since they're the only app, the
 		# bucket-wrapper short-circuits (single-app flat rendering),
 		# but the callsite text appears in the details block.
 		assert "apps/myapp/foo.py:456" in html

--- a/optimus/tests/test_capture_pii.py
+++ b/optimus/tests/test_capture_pii.py
@@ -57,7 +57,7 @@ def test_identify_args_handles_missing_name():
 
 
 def test_identify_args_get_doc_with_dict_arg():
-	"""Regression: frappe.get_doc({"doctype": "X", "name": "Y", ...}) — dict
+	"""Regression: frappe.get_doc({"doctype": "X", "name": "Y", ...}) dict
 	form. Previously _identify_args returned the dict as-is, making the
 	bucket key unhashable and crashing the redundant_calls analyzer."""
 	doc_dict = {
@@ -86,7 +86,7 @@ def test_identify_args_get_doc_with_islocal_dict():
 		"__unsaved": 1,
 	}
 	raw, safe = capture._identify_args("get_doc", (doc_dict,), {})
-	# Name should be None — we don't want temp names polluting the buckets
+	# Name should be None we don't want temp names polluting the buckets
 	assert raw == ("Sales Invoice", None)
 	assert safe == ("Sales Invoice", None)
 

--- a/optimus/tests/test_capture_wraps.py
+++ b/optimus/tests/test_capture_wraps.py
@@ -4,7 +4,7 @@
 """Tests for the sidecar wrap factory in capture.py.
 
 These tests exercise the wrap mechanics in isolation by passing in a
-fake `frappe_local_proxy` object — they don't require a real Frappe
+fake `frappe_local_proxy` object they don't require a real Frappe
 runtime. The integration with frappe.local happens in test_capture_pipeline.py.
 """
 
@@ -14,7 +14,7 @@ from optimus import capture
 
 
 class FakeLocal:
-	"""Stand-in for frappe.local — supports getattr/setattr."""
+	"""Stand-in for frappe.local supports getattr/setattr."""
 	pass
 
 
@@ -206,7 +206,7 @@ def test_install_wraps_idempotent():
 	"""Calling install_wraps twice does not double-wrap."""
 	import frappe
 
-	# Reset to a clean state — optimus/__init__.py runs
+	# Reset to a clean state optimus/__init__.py runs
 	# install_wraps() at app-import time, so without this reset
 	# `frappe.get_doc` is already wrapped when this test starts.
 	capture.uninstall_wraps()

--- a/optimus/tests/test_collapsible_sections.py
+++ b/optimus/tests/test_collapsible_sections.py
@@ -4,7 +4,7 @@
 """Tests for the report's section structure.
 
 Top-level sections (``<section class="section">``) always render
-expanded and non-collapsible — user direction from the redesign:
+expanded and non-collapsible user direction from the redesign:
 "make all section expanded by default not collapsible".
 
 Framework subsections (the four ``actions_framework`` /
@@ -17,7 +17,7 @@ non-framework subsections remain plain ``<section class="subsection">``.
 
 Inline ``<details>`` elements elsewhere (call-tree drill-downs,
 per-row sub-finding expanders, "Slowest queries for this job"
-lookups) stay collapsible — those are row-level affordances, not
+lookups) stay collapsible those are row-level affordances, not
 sections.
 """
 
@@ -33,13 +33,13 @@ def _read_template():
 
 
 def test_top_level_sections_are_non_collapsible():
-	"""Top-level sections always render expanded — no ``<details
+	"""Top-level sections always render expanded no ``<details
 	class="section">`` allowed. The user explicitly requested
 	primary report sections render without a toggle."""
 	template = _read_template()
 	assert '<details class="section"' not in template, (
 		"Top-level sections must be plain <section class='section'> "
-		"blocks — '<details class=\"section\"' means the section is "
+		"blocks '<details class=\"section\"' means the section is "
 		"still collapsible."
 	)
 
@@ -50,9 +50,9 @@ def test_framework_subsections_are_collapsible():
 	class="subsection">`` so the reader can collapse framework noise
 	out of the way. Each one carries a ``framework`` data variable
 	in its surrounding markup. None should have an ``open`` attribute
-	— collapsed by default is the whole point."""
+	collapsed by default is the whole point."""
 	template = _read_template()
-	# Expect at least 4 <details class="subsection"> opens — one per
+	# Expect at least 4 <details class="subsection"> opens one per
 	# framework block. If a new framework subsection is added in the
 	# future this count goes up; the assertion stays ``>= 4`` so
 	# additive changes don't break the test.
@@ -68,7 +68,7 @@ def test_framework_subsections_are_collapsible():
 		r'<details class="subsection"[^>]*\sopen[\s>]',
 		template,
 	), (
-		"<details class=\"subsection\"> should be collapsed by default — "
+		"<details class=\"subsection\"> should be collapsed by default "
 		"no `open` attribute. Remove the `open` to restore the contract."
 	)
 
@@ -118,7 +118,7 @@ def test_primary_actionable_sections_render():
 			f"section heading {section_heading!r} missing from template"
 		)
 	# "Full recordings" was permanently removed (raw SQL literals / headers /
-	# form data / stack traces — sensitive, per user request).
+	# form data / stack traces sensitive, per user request).
 	assert "Full recordings" not in template
 
 
@@ -137,7 +137,7 @@ def test_report_has_navigation_aids():
 def test_section_id_aliases_for_mock_spec_names():
 	"""v0.7.x Phase G: the mock spec uses shorter section IDs (#actions,
 	#jobs, #resource, #queries, #db, #doc-events) alongside the original
-	long-form names. The template carries both — original ID on the
+	long-form names. The template carries both original ID on the
 	section tag so the Jump-to nav keeps working; alias as an empty
 	<a id="..."></a> anchor inside each section so external links /
 	docs that reference the mock names still scroll-to-anchor.
@@ -164,13 +164,13 @@ def test_section_id_aliases_for_mock_spec_names():
 
 def test_net_new_section_ids_from_mock_spec():
 	"""v0.7.x Phase I.1: the redesign mock spec introduced three
-	anchors that don't have a long-form original — they're net-new
+	anchors that don't have a long-form original they're net-new
 	IDs (not aliases). Pin their presence so a future template
 	refactor doesn't quietly drop them.
 
-	#repro    — Steps to Reproduce section
-	#summary  — Summary section (bulleted recap)
-	#hot-frames — Hot frames leaderboard section
+	#repro Steps to Reproduce section
+	#summary Summary section (bulleted recap)
+	#hot-frames Hot frames leaderboard section
 	"""
 	template = _read_template()
 	for net_new in ("repro", "summary", "hot-frames"):
@@ -293,7 +293,7 @@ def test_tldr_hero_renders_before_kpi_strip_and_summary():
 	"""v0.7.x redesign Phase B: the 'At a glance' exec-summary card
 	was replaced by the TL;DR hero (one composed headline keyed on
 	the highest-impact finding). The hero lives RIGHT AFTER the
-	masthead — first prominent block on the page. Pin: TL;DR comes
+	masthead first prominent block on the page. Pin: TL;DR comes
 	before the KPI strip, and the KPI strip comes before the
 	Summary section."""
 	template = _read_template()
@@ -333,7 +333,7 @@ def test_how_to_read_section_appears_after_main_content():
 		"database table' (it was moved to the bottom of the report)"
 	)
 	assert how_to_read_idx < footer_idx, (
-		"'How to read this report' must render BEFORE the footer — "
+		"'How to read this report' must render BEFORE the footer "
 		"don't push it past the report's closing block"
 	)
 
@@ -410,7 +410,7 @@ def test_xhr_timing_table_has_fixed_layout_class():
 
 
 def test_how_to_read_fixes_stale_refs_and_verbs():
-	"""v0.7.x: How-to-read fixed — 'Click' (not 'Hover') to open callsites, and
+	"""v0.7.x: How-to-read fixed 'Click' (not 'Hover') to open callsites, and
 	no references to sections that don't exist by those names / a non-existent
 	'index candidate per table'."""
 	template = _read_template()

--- a/optimus/tests/test_correlation_header.py
+++ b/optimus/tests/test_correlation_header.py
@@ -86,7 +86,7 @@ def test_inject_correlation_header_tokenwise_match_not_substring():
     _inject_correlation_header("rec-uuid-abc123")
 
     expose = headers["Access-Control-Expose-Headers"]
-    # Both tokens must be present — the legacy one preserved, the
+    # Both tokens must be present the legacy one preserved, the
     # real one appended as a new token.
     tokens = [t.strip() for t in expose.split(",")]
     assert "X-Optimus-Recording-Id-Legacy" in tokens
@@ -95,7 +95,7 @@ def test_inject_correlation_header_tokenwise_match_not_substring():
 
 def test_correlation_header_gated_on_profiler_session_id():
     """Pass-5 regression guard: the correlation header must only be
-    injected when an active profiler session is present — not merely
+    injected when an active profiler session is present not merely
     when there's a recording UUID. The standalone Frappe Recorder UI
     sets frappe.local._recorder for non-session traffic, and leaking
     X-Optimus-Recording-Id onto those responses would cause
@@ -121,13 +121,13 @@ def test_correlation_header_gated_on_profiler_session_id():
     preamble = src[:correlation_idx]
     assert "optimus_session_id" in preamble, (
         "_inject_correlation_header must be gated on optimus_session_id, "
-        "not just recording_uuid_for_dump — otherwise non-session "
+        "not just recording_uuid_for_dump otherwise non-session "
         "traffic (e.g. from the standalone Recorder UI) leaks the header"
     )
 
 def test_inject_correlation_header_case_insensitive_idempotency():
     """HTTP header names are case-insensitive. The token check must
-    be too — if another app set the expose header in lowercase, we
+    be too if another app set the expose header in lowercase, we
     shouldn't add our (same) header with different casing and create
     a duplicate."""
     from optimus.hooks_callbacks import _inject_correlation_header

--- a/optimus/tests/test_correlation_header_v15_compat.py
+++ b/optimus/tests/test_correlation_header_v15_compat.py
@@ -5,7 +5,7 @@
 Frappe v15 and v16.
 
 Why this exists: the Per-XHR timings section of the Frontend panel
-was empty on v15 deployments. Root cause — ``frappe.local.response_
+was empty on v15 deployments. Root cause ``frappe.local.response_
 headers`` (the staging dict our injector wrote to) does not exist
 on v15. Only v16's ``frappe/app.py`` has
 ``response.headers.update(frappe.local.response_headers)`` at
@@ -38,12 +38,12 @@ def _install_frappe_stub_with_local(monkeypatch):
 
 	Also stubs ``frappe.recorder`` and the ``optimus.session``
 	/ ``.capture`` submodules because ``hooks_callbacks.py`` imports
-	them at module top — those imports would fail when
+	them at module top those imports would fail when
 	``_fresh_module`` re-imports ``hooks_callbacks``.
 
 	All sys.modules mutations go through ``monkeypatch.setitem`` so the
 	real ``frappe`` (and related submodules) is restored at test
-	teardown — preventing the stub from polluting subsequent test files
+	teardown preventing the stub from polluting subsequent test files
 	in the same pytest session.
 	"""
 	frappe = types.ModuleType("frappe")
@@ -79,7 +79,7 @@ def _install_frappe_stub_with_local(monkeypatch):
 
 def _fresh_module(monkeypatch):
 	"""Re-import hooks_callbacks under the current frappe stub.
-	``monkeypatch.delitem`` evicts cached modules — pytest restores them
+	``monkeypatch.delitem`` evicts cached modules pytest restores them
 	at teardown so subsequent files see the originals (or the conftest
 	fence's re-imports)."""
 	for mod in list(sys.modules.keys()):

--- a/optimus/tests/test_dbdialect.py
+++ b/optimus/tests/test_dbdialect.py
@@ -3,7 +3,7 @@
 
 """Phase 2 foundation: the dialect contract + factory.
 
-Covers the dialect-neutral pieces — coercion helpers, normalized dataclass
+Covers the dialect-neutral pieces coercion helpers, normalized dataclass
 defaults, db_type detection, factory dispatch + memoization, and the
 type-classification each adapter ships with. The EXPLAIN/index/infra method
 bodies are exercised by dialect-specific tests once they're filled.

--- a/optimus/tests/test_dedup_findings_across_actions.py
+++ b/optimus/tests/test_dedup_findings_across_actions.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for analyze._dedupe_findings_across_actions — the post-analyze
+"""Tests for analyze._dedupe_findings_across_actions the post-analyze
 pass that collapses per-action duplicates of the same code path
 (Slow Hot Path / Hook Bottleneck / Self-Time Hot Path / Repeated Hot
 Frame) into a single dominant finding with an 'Also affects N other
@@ -146,7 +146,7 @@ def test_different_keys_do_not_merge():
 
 
 def test_slow_hot_path_and_hot_line_same_leaf_stay_separate():
-	"""Slow Hot Path and Hot Line are different finding types — even if
+	"""Slow Hot Path and Hot Line are different finding types even if
 	they target adjacent code, they don't merge."""
 	findings = [
 		_shp(function="_check_user_exists", filename="common.py", lineno=18, action_ref="0"),
@@ -181,7 +181,7 @@ def test_single_finding_unchanged():
 
 
 def test_hook_bottleneck_findings_are_deduped():
-	"""Hook Bottleneck is also a per-action emitter — should dedupe."""
+	"""Hook Bottleneck is also a per-action emitter should dedupe."""
 	findings = [
 		{
 			"finding_type": "Hook Bottleneck",
@@ -260,7 +260,7 @@ def test_npq_findings_are_not_deduped_by_this_pass():
 
 	_dedupe_findings_across_actions(findings, [_action(0, "Save"), _action(1, "Submit")])
 
-	# N+1 not in the dedup set — both pass through.
+	# N+1 not in the dedup set both pass through.
 	assert len(findings) == 2
 
 
@@ -269,10 +269,10 @@ def test_missing_action_label_falls_back_to_generic_count():
 	label (e.g. the actions list was rebuilt and that idx is gone),
 	the 'also affects' sentence drops the label list and uses just
 	'N other action(s)'. The dominant's label being missing doesn't
-	matter — only the others' labels are shown."""
+	matter only the others' labels are shown."""
 	findings = [
-		_shp(action_ref="99", impact_ms=400.0),  # OTHER — missing label
-		_shp(action_ref="1", impact_ms=800.0),   # DOMINANT — has label
+		_shp(action_ref="99", impact_ms=400.0),  # OTHER missing label
+		_shp(action_ref="1", impact_ms=800.0),   # DOMINANT has label
 	]
 
 	_dedupe_findings_across_actions(findings, [_action(1, "Submit")])

--- a/optimus/tests/test_dialect_mariadb.py
+++ b/optimus/tests/test_dialect_mariadb.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""MariaDBDialect adapter — the verbatim-lifted EXPLAIN / index / infra logic,
+"""MariaDBDialect adapter the verbatim-lifted EXPLAIN / index / infra logic,
 exercised with a fake ``frappe.db`` (no real site). Asserts the normalized
 mappings match what the analyzers used to read off raw rows.
 """
@@ -16,7 +16,7 @@ from optimus.dbdialect.mariadb import MariaDBDialect
 def _install_db(monkeypatch, sql_fn):
 	import frappe
 
-	# frappe.db is a Werkzeug Local proxy — replace it wholesale.
+	# frappe.db is a Werkzeug Local proxy replace it wholesale.
 	monkeypatch.setattr(frappe, "db", types.SimpleNamespace(sql=sql_fn), raising=False)
 
 

--- a/optimus/tests/test_dialect_postgres.py
+++ b/optimus/tests/test_dialect_postgres.py
@@ -6,7 +6,7 @@
 The plan-tree walk and catalog-row mapping are unit-tested here with fixtures
 (the raw introspection SQL is validated on a real --db-type postgres bench in
 phase 5). The final test feeds a Postgres-derived plan through explain_flags and
-asserts the SAME finding types come out — i.e. the analyzer is dialect-blind.
+asserts the SAME finding types come out i.e. the analyzer is dialect-blind.
 """
 
 from __future__ import annotations
@@ -24,7 +24,7 @@ def _install_db(monkeypatch, sql_fn):
 	import frappe
 
 	# _safe_sql wraps every query in savepoint / release / rollback (Postgres
-	# aborts the txn on a failed query) — provide no-ops for them.
+	# aborts the txn on a failed query) provide no-ops for them.
 	monkeypatch.setattr(frappe, "db", types.SimpleNamespace(
 		sql=sql_fn, db_type="postgres",
 		savepoint=lambda *a, **k: None,
@@ -137,7 +137,7 @@ class TestIntrospection:
 # --- dialect-blind: a Postgres plan yields the same finding types -----------
 
 def test_explain_flags_derives_findings_from_postgres_plan(monkeypatch, empty_context):
-	"""A PG Seq Scan over 12k rows must surface a Full Table Scan finding —
+	"""A PG Seq Scan over 12k rows must surface a Full Table Scan finding
 	proving explain_flags reads the normalized fields, not raw EXPLAIN rows."""
 	from optimus.analyzers import explain_flags
 
@@ -184,7 +184,7 @@ def test_ai_finding_hint_is_dialect_aware(monkeypatch):
 class TestSafeSql:
 	def test_original_error_survives_a_failing_rollback(self, monkeypatch):
 		"""If the savepoint rollback itself raises, the ORIGINAL query error must
-		still propagate (not be masked by the rollback error) — the caller's
+		still propagate (not be masked by the rollback error) the caller's
 		try/except turns the original into its safe default."""
 		import frappe
 

--- a/optimus/tests/test_disclosures_present.py
+++ b/optimus/tests/test_disclosures_present.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""B.M-S4 / D.M-S5 — regression tests for production-readiness disclosures.
+"""B.M-S4 / D.M-S5 regression tests for production-readiness disclosures.
 
 The audit graded Optimus partially trustworthy on metric integrity because
 several caveats the data deserves were absent from the rendered report
@@ -47,7 +47,7 @@ def _fake_doc(**fields):
 
 
 def test_sampler_disclosure_phrase_in_rendered_html():
-	"""B.M-S4 — the 'How to read this report' bullet that calls out the
+	"""B.M-S4 the 'How to read this report' bullet that calls out the
 	wall-clock sampler must always be present so a reader knows
 	sub-interval functions can be under-counted."""
 	doc = _fake_doc()
@@ -67,7 +67,7 @@ def test_self_time_wall_clock_disclosure_present():
 
 
 def test_frame_truncation_banner_renders_when_truncated():
-	"""D.M-S5 — when ANY action's call_tree_json is _truncated with
+	"""D.M-S5 when ANY action's call_tree_json is _truncated with
 	captured/kept counts, the Hot Frames banner must surface those
 	numbers (else readers can't tell their picture is partial)."""
 	truncated_tree = json.dumps({
@@ -125,7 +125,7 @@ def test_frame_truncation_banner_renders_when_truncated():
 
 
 def test_slow_query_cap_banner_when_more_than_max_findings():
-	"""B.DI4 — when more than MAX_FINDINGS slow queries clear the
+	"""B.DI4 when more than MAX_FINDINGS slow queries clear the
 	threshold, the Top Queries section must surface a 'N more
 	suppressed' note."""
 	# 7 user-app queries above the 200ms default slow threshold;

--- a/optimus/tests/test_display_name_for_node.py
+++ b/optimus/tests/test_display_name_for_node.py
@@ -5,7 +5,7 @@
 
 Production trigger: a Server Script with a 5M-iteration CPU loop
 produced a Slow Hot Path finding titled "In savedocs:Save, 86% of
-the time was spent in " — trailing blank because pyinstrument
+the time was spent in " trailing blank because pyinstrument
 returns ``function=""`` for Python code executed via ``exec()``.
 
 The analyzer now walks a preference chain:
@@ -77,7 +77,7 @@ class TestExecDetection:
 
 class TestFilenameFallback:
 	"""``short_filename`` returns the last 2 path segments so the
-	reader sees which app the file lives in — ``myapp/foo.py`` is
+	reader sees which app the file lives in ``myapp/foo.py`` is
 	more useful than just ``foo.py`` for navigation in a bench with
 	many apps."""
 
@@ -133,7 +133,7 @@ class TestLastResort:
 
 
 class TestProductionBug:
-	"""The exact production scenario that motivated this fix —
+	"""The exact production scenario that motivated this fix
 	Server Script containing for-loop, surfaced as empty title."""
 
 	def test_empty_function_with_serverscript_filename(self):

--- a/optimus/tests/test_doc_event_lifecycle.py
+++ b/optimus/tests/test_doc_event_lifecycle.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Unit tests for the "Doc-event lifecycle" breakdown — re-grouping the slow
+"""Unit tests for the "Doc-event lifecycle" breakdown re-grouping the slow
 call-tree findings by DocType → lifecycle event (validate / on_submit / …),
 tagging each as a registered ``doc_events`` hook vs a controller method
 override, and surfacing cascaded DocTypes. All pure functions in
-``renderer`` — no running site needed.
+``renderer``: no running site needed.
 """
 
 from optimus import renderer
@@ -18,7 +18,7 @@ class TestDoctypeFromControllerPath:
 		) == "Sales Invoice"
 
 	def test_absolute_controller_path_titlecase_limitation(self):
-		# .title() mangles multi-cap names ("gl_entry" → "Gl Entry") — same as
+		# .title() mangles multi-cap names ("gl_entry" → "Gl Entry") same as
 		# frappe.unscrub. Accepted.
 		assert renderer._doctype_from_controller_path(
 			"/Users/x/apps/erpnext/erpnext/accounts/doctype/gl_entry/gl_entry.py"
@@ -124,11 +124,11 @@ class TestBuildDocEventBreakdown:
 			   filename="ugly_code/python/common.py", lineno=6, cumulative_ms=697,
 			   hook_events=[{"doctype": "Sales Invoice", "event": "validate"}],
 			   target_doc={"doctype": "Sales Invoice", "name": "SINV-1"}),
-			# SalesInvoice.on_submit — controller override, SI/on_submit.
+			# SalesInvoice.on_submit controller override, SI/on_submit.
 			_f("Slow Hot Path", 450, severity="Medium", action_ref="1", function="SalesInvoice.on_submit",
 			   filename="erpnext/accounts/doctype/sales_invoice/sales_invoice.py", lineno=1200, cumulative_ms=450,
 			   target_doc={"doctype": "Sales Invoice", "name": "SINV-1"}),
-			# GLEntry.validate — controller override on GL Entry, touched during a SI submit.
+			# GLEntry.validate controller override on GL Entry, touched during a SI submit.
 			_f("Slow Hot Path", 22, severity="Low", action_ref="1", function="GLEntry.validate",
 			   filename="erpnext/accounts/doctype/gl_entry/gl_entry.py", lineno=50, cumulative_ms=22,
 			   target_doc={"doctype": "Sales Invoice", "name": "SINV-1"}),
@@ -161,7 +161,7 @@ class TestBuildDocEventBreakdown:
 		assert gl["events"][0]["methods"][0]["kind"] == "controller override"
 
 	def test_controller_override_supersedes_hook_kind_on_merge(self):
-		# Two findings for the same (function, filename) under the same event —
+		# Two findings for the same (function, filename) under the same event
 		# one bound via hook_events, one via controller-path → merged record's
 		# kind ends up "controller override" (the more specific one).
 		findings = [

--- a/optimus/tests/test_drilldown_chain.py
+++ b/optimus/tests/test_drilldown_chain.py
@@ -112,7 +112,7 @@ class TestWalkDrilldownChain:
 		}
 		chain = _walk_drilldown_chain(tree, callsite)
 		# Expected: _run_validations + _check_user_exists. The frappe
-		# get_doc beneath them is framework — stop.
+		# get_doc beneath them is framework stop.
 		assert [(level["function"], level["filename"].rsplit("/", 1)[-1]) for level in chain] == [
 			("_run_validations", "common.py"),
 			("_check_user_exists", "common.py"),
@@ -122,7 +122,7 @@ class TestWalkDrilldownChain:
 		assert chain[1]["pct_of_origin"] == round(530 / 689 * 100)
 
 	def test_picks_hottest_child(self):
-		"""The looped_validate origin has two children — _run_validations
+		"""The looped_validate origin has two children _run_validations
 		(620ms) and _other_branch (60ms). Walker must pick the 620ms one."""
 		tree = _screenshot_tree()
 		callsite = {
@@ -150,7 +150,7 @@ class TestWalkDrilldownChain:
 			children=[
 				_node(
 					function="cold_child", filename="apps/myapp/x.py",
-					lineno=10, cumulative_ms=50.0,  # 5% of parent — below 10% floor
+					lineno=10, cumulative_ms=50.0,  # 5% of parent below 10% floor
 					children=[],
 				),
 			],
@@ -179,7 +179,7 @@ class TestWalkDrilldownChain:
 
 	def test_tracked_apps_inclusion_mode_still_stops_at_frappe(self):
 		"""With tracked_apps=("ugly_code",), the frappe frame is framework
-		via inclusion mode — same stop."""
+		via inclusion mode same stop."""
 		tree = _screenshot_tree()
 		callsite = {
 			"filename": "apps/ugly_code/ugly_code/python/common.py",

--- a/optimus/tests/test_end_to_end_metrics.py
+++ b/optimus/tests/test_end_to_end_metrics.py
@@ -98,7 +98,7 @@ def test_analyzer_chain_with_missing_frontend_data():
 	]
 
 	ctx = AnalyzeContext(session_uuid="no-frontend", docname="e2e")
-	# ctx.frontend_data intentionally not set — simulates a session from
+	# ctx.frontend_data intentionally not set simulates a session from
 	# a worker that doesn't have v0.5.0's frontend blob in Redis yet.
 
 	infra_result = infra_pressure.analyze(recordings, ctx)
@@ -111,7 +111,7 @@ def test_analyzer_chain_with_missing_frontend_data():
 	ft_types = {f["finding_type"] for f in ctx.findings}
 	assert "Resource Contention" in ft_types
 
-	# Frontend side emits no findings and empty aggregates — clean no-op.
+	# Frontend side emits no findings and empty aggregates clean no-op.
 	assert "Slow Frontend Render" not in ft_types
 	assert "Network Overhead" not in ft_types
 	assert ctx.aggregate["frontend_xhr_matched"] == []

--- a/optimus/tests/test_enqueue_patch.py
+++ b/optimus/tests/test_enqueue_patch.py
@@ -85,7 +85,7 @@ def fake_frappe(monkeypatch):
 	monkeypatch.setitem(sys.modules, "frappe.utils", fake_utils)
 	monkeypatch.setitem(sys.modules, "frappe.utils.background_jobs", fake_bg)
 
-	# optimus.session uses frappe.cache — already stubbed above
+	# optimus.session uses frappe.cache already stubbed above
 	return fake, fake_bg, enqueue_calls
 
 
@@ -96,10 +96,10 @@ def test_patch_injects_session_id(fake_frappe, monkeypatch):
 	# Arrange: put an active session for alice in fake cache
 	fake.cache.set_value("profiler:active:alice@example.com", "test-session-uuid-abc")
 
-	# Import the patch — this triggers _patch_enqueue() at module load
+	# Import the patch this triggers _patch_enqueue() at module load
 	# We need to force a re-import since other tests may have imported it already.
 	_reset_profiler_modules()
-	import optimus  # noqa: F401 — triggers the patch
+	import optimus  # noqa: F401 triggers the patch
 
 	# Act: call frappe.utils.background_jobs.enqueue
 	fake_bg.enqueue("my_module.my_func", x=1, y=2)
@@ -117,7 +117,7 @@ def test_patch_skips_without_active_session(fake_frappe, monkeypatch):
 	"""No active session → no marker injection."""
 	fake, fake_bg, enqueue_calls = fake_frappe
 
-	# Cache is empty — no active session
+	# Cache is empty no active session
 	_reset_profiler_modules()
 	import optimus  # noqa: F401
 

--- a/optimus/tests/test_envelope_rollout_phase2.py
+++ b/optimus/tests/test_envelope_rollout_phase2.py
@@ -4,12 +4,12 @@
 """v0.12.13: continues the v0.12.0 ``wrap_value`` / ``unwrap_value``
 envelope rollout to two more values:
 
-  * ``retention_backlog`` (janitor.py) — write-only int. The janitor
+  * ``retention_backlog`` (janitor.py) write-only int. The janitor
     writes 0 (or the backlog count) once per daily sweep; there's no
     in-app reader, but operator-facing tooling could read the value
     directly from Redis, so we wrap on write to make the shape future-
     safe.
-  * ``onboarding_seen`` (api.py) — write/read pair. The dismiss
+  * ``onboarding_seen`` (api.py) write/read pair. The dismiss
     endpoint writes the string ``"1"``; the check endpoint reads
     and coerces to ``bool``. Both sides migrated.
 
@@ -27,7 +27,7 @@ from unittest import mock
 
 
 class _FakeCache:
-	"""Dict-backed ``frappe.cache`` substitute — same as the one used
+	"""Dict-backed ``frappe.cache`` substitute same as the one used
 	in ``test_settings_envelope_rollout.py``; copied here so each
 	rollout test module is self-contained."""
 
@@ -45,7 +45,7 @@ class _FakeCache:
 
 
 # ---------------------------------------------------------------------------
-# retention_backlog (write-only) — janitor writes wrap_value(int)
+# retention_backlog (write-only) janitor writes wrap_value(int)
 # ---------------------------------------------------------------------------
 
 
@@ -53,7 +53,7 @@ class TestRetentionBacklogEnvelope:
 	"""The daily janitor's two write sites for ``retention_backlog`` both
 	wrap the int value in the v0.12.0 envelope. No in-app reader exists
 	(the value is operator-visible monitoring metric only), so the
-	contract under test is write-shape — the future-proofing that lets
+	contract under test is write-shape the future-proofing that lets
 	operator dashboards / migration paths read the envelope cleanly."""
 
 	def test_janitor_writes_envelope_when_setting_backlog(self):
@@ -61,7 +61,7 @@ class TestRetentionBacklogEnvelope:
 		from optimus import redis_schema
 
 		# Synthesize the cache + frappe stub. We only exercise the
-		# write-the-counter branch — _sweep_old_sessions's full body
+		# write-the-counter branch _sweep_old_sessions's full body
 		# is out of scope (it queries Optimus Session which needs a
 		# bench). Instead we invoke the cache-write expression
 		# directly via the same code path.
@@ -115,7 +115,7 @@ class TestRetentionBacklogEnvelope:
 
 
 # ---------------------------------------------------------------------------
-# onboarding_seen (write/read pair) — both sides migrated
+# onboarding_seen (write/read pair) both sides migrated
 # ---------------------------------------------------------------------------
 
 
@@ -124,7 +124,7 @@ class TestOnboardingSeenEnvelopeReadCompat:
 	shape envelopes AND legacy bare ``"1"`` strings (left behind by
 	pre-v0.12.13 writers) resolve to the same truthy result.
 
-	Catches a regression where the read path drops the unwrap call —
+	Catches a regression where the read path drops the unwrap call
 	an OLD reader of a NEW envelope would see the dict as truthy and
 	keep returning ``seen: True``, but a NEW reader of an OLD bare
 	string MUST also return truthy."""

--- a/optimus/tests/test_envelope_rollout_phase3.py
+++ b/optimus/tests/test_envelope_rollout_phase3.py
@@ -8,7 +8,7 @@ result cache in ``analyze.py``).
 The previous phases shipped settings_cache (v0.12.11),
 retention_backlog + onboarding_seen (v0.12.13). This phase adds
 ``explain_cache``, whose payload is a list of dicts (EXPLAIN row
-results) — the most complex shape rolled out so far. Exercising the
+results) the most complex shape rolled out so far. Exercising the
 envelope on a non-primitive collection validates that ``unwrap_value``
 preserves nested structure cleanly.
 """
@@ -17,13 +17,13 @@ from __future__ import annotations
 
 
 class TestExplainCacheEnvelopeRoundTrip:
-	"""End-to-end on the envelope helpers alone — the analyze.py call
+	"""End-to-end on the envelope helpers alone the analyze.py call
 	site uses the same two-line pattern (wrap on write, unwrap on
 	read), so a unit test on the helpers + a source-grep canary
 	together cover the rollout."""
 
 	def test_list_of_dicts_roundtrip(self):
-		"""EXPLAIN results are list[dict] — wrap + unwrap must preserve
+		"""EXPLAIN results are list[dict] wrap + unwrap must preserve
 		the shape, including the inner dict's value types."""
 		from optimus import redis_schema
 

--- a/optimus/tests/test_envelope_rollout_phase4.py
+++ b/optimus/tests/test_envelope_rollout_phase4.py
@@ -7,18 +7,18 @@ in ``optimus.session``).
 
 The previous phases covered settings_cache (v0.12.11),
 retention_backlog + onboarding_seen (v0.12.13), and explain_cache
-(v0.12.17). This phase adds ``session_meta`` — the session-scoped
+(v0.12.17). This phase adds ``session_meta``: the session-scoped
 context dict written by ``api.start`` (and updated throughout the
 session's life) and read on every recording's before_request /
 before_job hook.
 
 The contract under test:
 
-  1. **Write path** — ``set_session_meta`` wraps via ``wrap_value``.
-  2. **Read path** — ``get_session_meta`` unwraps via ``unwrap_value``.
-  3. **Legacy compat** — pre-v0.12.21 cached values (bare dict) still
+  1. **Write path**: ``set_session_meta`` wraps via ``wrap_value``.
+  2. **Read path**: ``get_session_meta`` unwraps via ``unwrap_value``.
+  3. **Legacy compat**: pre-v0.12.21 cached values (bare dict) still
      return cleanly through the legacy-detection branch.
-  4. **Defensive non-dict guard** — if a future-version envelope or
+  4. **Defensive non-dict guard**: if a future-version envelope or
      a corrupt write returns a non-dict payload, ``get_session_meta``
      returns ``None`` rather than crashing downstream callers.
 """
@@ -31,7 +31,7 @@ from unittest import mock
 
 
 class _FakeCache:
-	"""Dict-backed ``frappe.cache`` substitute — same shape as the
+	"""Dict-backed ``frappe.cache`` substitute same shape as the
 	other envelope-rollout test modules use."""
 
 	def __init__(self) -> None:
@@ -133,7 +133,7 @@ class TestSessionMetaEnvelopeRead:
 			assert session.get_session_meta("never-written") is None
 
 	def test_get_session_meta_returns_none_for_corrupt_non_dict(self):
-		"""Defensive guard — if a corrupt write stored a non-dict /
+		"""Defensive guard if a corrupt write stored a non-dict /
 		non-envelope value, get_session_meta returns None rather than
 		passing it through to callers (which would crash on
 		``.get(...)``)."""

--- a/optimus/tests/test_executive_summary.py
+++ b/optimus/tests/test_executive_summary.py
@@ -66,7 +66,7 @@ class TestHeadlinePace:
 		assert "action" not in es["headline"]
 
 	def test_headline_below_threshold_keeps_ms(self):
-		"""Below the threshold the duration must stay as plain ms — no
+		"""Below the threshold the duration must stay as plain ms no
 		highlight span. Same behaviour as fmt_ms() everywhere else."""
 		es = _build_executive_summary(
 			findings=[], session_doc=_doc(total_ms=800, queries=10, actions=2),
@@ -235,16 +235,16 @@ class TestEndToEndRender:
 		# (used by the Action plan section), so the data assertions
 		# below hold via the TL;DR composition + the KPI strip.
 		assert 'class="tldr"' in html, "TL;DR hero must render"
-		# Duration crosses the 1000ms threshold — rendered as seconds
+		# Duration crosses the 1000ms threshold rendered as seconds
 		# with .time-high (timing rule applies everywhere).
 		assert '<span class="time-high">6.00s</span>' in html
 		assert "operation" in html
-		# Top finding title surfaced — TL;DR fallback branch wraps it.
+		# Top finding title surfaced TL;DR fallback branch wraps it.
 		assert "Same query ran 50× at myapp/foo.py:10" in html
 		# Infra note no longer rendered as a separate exec-summary line
 		# (moved into the Server resource section in a later phase).
-		# Sanity: it's still computed (data layer) — just not shown here.
-		# v0.7.x: KPI strip (replaces stat cards) — plainly-labelled cells,
+		# Sanity: it's still computed (data layer) just not shown here.
+		# v0.7.x: KPI strip (replaces stat cards) plainly-labelled cells,
 		# and the "Issues found" cell's big number is the TOTAL finding
 		# count (not the High count), with a severity breakdown that sums
 		# to it.
@@ -289,7 +289,7 @@ class TestEndToEndRender:
 		html = renderer.render(doc, recordings=[])
 
 		# v0.7.x redesign Phase B: the exec-summary card was replaced
-		# by the TL;DR hero. The hero ALWAYS renders — clean sessions
+		# by the TL;DR hero. The hero ALWAYS renders clean sessions
 		# get a "Nothing to fix" branch instead of being hidden.
 		assert 'class="exec-summary' not in html, (
 			"Old exec-summary card markup must not be present"

--- a/optimus/tests/test_explain_flags.py
+++ b/optimus/tests/test_explain_flags.py
@@ -263,14 +263,14 @@ def test_malformed_row_is_isolated_not_crashing(empty_context):
 # A real production run flagged "Filesort on tabCustom DocPerm" from a
 # single-row parent lookup:
 #   SELECT * FROM `tabCustom DocPerm` WHERE `parent`=? ORDER BY `creation` ASC
-# with explain rows=1, type=ref, key=parent. The filesort is on ONE row —
+# with explain rows=1, type=ref, key=parent. The filesort is on ONE row
 # free in practice, and the user can't act on it anyway because `parent` is
 # already the ref key. Flagging it was pure noise. These tests cover the
 # MIN_ROWS_TO_FLAG_SORT row floor that suppresses the false positive.
 
 
 def test_filesort_on_single_row_is_not_flagged(empty_context):
-	"""Regression guard — exact payload from the production report:
+	"""Regression guard exact payload from the production report:
 	a ref lookup on tabCustom DocPerm.parent with rows=1 that happens
 	to filesort the result. Must NOT emit a Filesort finding."""
 	recording = {
@@ -299,7 +299,7 @@ def test_filesort_on_single_row_is_not_flagged(empty_context):
 	result = explain_flags.analyze([recording], empty_context)
 	filesorts = [f for f in result.findings if f["finding_type"] == "Filesort"]
 	assert filesorts == [], (
-		"Filesort on a 1-row result is free — must not emit a finding. "
+		"Filesort on a 1-row result is free must not emit a finding. "
 		f"Got: {filesorts}"
 	)
 
@@ -400,7 +400,7 @@ def test_filesort_above_floor_still_flagged(empty_context):
 
 
 def test_full_scan_from_framework_callsite_is_suppressed(empty_context):
-	"""The query lives inside frappe/model/document.py — user can't
+	"""The query lives inside frappe/model/document.py user can't
 	add an index to fix a Frappe framework query. Skip the findings
 	for this call entirely (Full Scan + whatever else)."""
 	recording = {
@@ -428,7 +428,7 @@ def test_full_scan_from_framework_callsite_is_suppressed(empty_context):
 	scans = [f for f in result.findings if f["finding_type"] == "Full Table Scan"]
 	assert scans == [], (
 		"Full Table Scan finding from a frappe/* callsite must be "
-		"suppressed — user can't add an index to fix a framework "
+		"suppressed user can't add an index to fix a framework "
 		f"query. Got: {[f['title'] for f in scans]}"
 	)
 	# And the suppression surfaces as a warning so the user knows
@@ -441,7 +441,7 @@ def test_full_scan_from_framework_callsite_is_suppressed(empty_context):
 def test_alias_table_name_is_suppressed(empty_context):
 	"""EXPLAIN rows for JOIN queries often have the table field as
 	a single-letter alias ('a', 'c', 'ap'). 'Full table scan on a'
-	isn't actionable — the user can't index an alias."""
+	isn't actionable the user can't index an alias."""
 	recording = {
 		"uuid": "alias-scan",
 		"path": "/", "cmd": None, "method": "GET",
@@ -458,7 +458,7 @@ def test_alias_table_name_is_suppressed(empty_context):
 				 "function": "sync_prices"},
 			],
 			"explain_result": [
-				# Alias "a" and "c" — both should be dropped.
+				# Alias "a" and "c" both should be dropped.
 				{"table": "a", "type": "ALL", "rows": 50000, "Extra": ""},
 				{"table": "c", "type": "ALL", "rows": 50000, "Extra": ""},
 			],
@@ -480,7 +480,7 @@ def test_alias_helper_distinguishes_real_tables_from_aliases():
 	"""Direct unit test of the _is_likely_alias helper."""
 	from optimus.analyzers.explain_flags import _is_likely_alias
 
-	# REAL tables — kept
+	# REAL tables kept
 	for real in (
 		"tabItem", "tabSales Invoice", "tabCustom Field", "tabDocType",
 		"MyCustomTable",       # capital letters → real
@@ -490,7 +490,7 @@ def test_alias_helper_distinguishes_real_tables_from_aliases():
 			f"{real!r} is a real table and must NOT be classified as alias"
 		)
 
-	# ALIASES — filtered
+	# ALIASES filtered
 	for alias in ("a", "c", "p", "ap", "cd", "addr", "d"):
 		assert _is_likely_alias(alias) is True, (
 			f"{alias!r} is a SQL alias and should be filtered"
@@ -500,10 +500,10 @@ def test_alias_helper_distinguishes_real_tables_from_aliases():
 	for synthetic in ("<derived2>", "<subquery1>", "<union3,4>"):
 		assert _is_likely_alias(synthetic) is True
 
-	# v0.5.2 round 4: INFORMATION_SCHEMA / MariaDB metadata views —
+	# v0.5.2 round 4: INFORMATION_SCHEMA / MariaDB metadata views
 	# they're real tables but the user can't add indexes to them. A
-	# production report showed "Full table scan on columns — ~129ms"
-	# and "Full table scan on tables — ~21ms" cluttering actionable
+	# production report showed "Full table scan on columns ~129ms"
+	# and "Full table scan on tables ~21ms" cluttering actionable
 	# findings; these are INFORMATION_SCHEMA.columns / .tables, not
 	# user-addressable. Treat them as aliases (suppressed).
 	for system_table in (
@@ -513,7 +513,7 @@ def test_alias_helper_distinguishes_real_tables_from_aliases():
 	):
 		assert _is_likely_alias(system_table) is True, (
 			f"{system_table!r} is an INFORMATION_SCHEMA view; user "
-			"cannot add an index — must be filtered as alias/noise"
+			"cannot add an index must be filtered as alias/noise"
 		)
 
 	# Edge cases
@@ -524,7 +524,7 @@ def test_alias_helper_distinguishes_real_tables_from_aliases():
 def test_user_code_callsite_still_emits_findings(empty_context):
 	"""Positive case: a Full Scan from genuine user-app code
 	(apps/myapp/...) must still produce a finding. The filter is
-	narrow — it only removes framework + alias noise, not real
+	narrow it only removes framework + alias noise, not real
 	findings."""
 	recording = {
 		"uuid": "user-scan",
@@ -567,7 +567,7 @@ def test_no_stack_falls_through_to_legacy_behavior(empty_context):
 			"query": "SELECT * FROM tabItem WHERE name = ?",
 			"normalized_query": "SELECT * FROM tabItem WHERE name = ?",
 			"duration": 150.0,
-			# NOTE: no "stack" field — pre-v0.5.2 recording.
+			# NOTE: no "stack" field pre-v0.5.2 recording.
 			"explain_result": [{
 				"table": "tabItem",
 				"type": "ALL",
@@ -579,7 +579,7 @@ def test_no_stack_falls_through_to_legacy_behavior(empty_context):
 	result = explain_flags.analyze([recording], empty_context)
 	scans = [f for f in result.findings if f["finding_type"] == "Full Table Scan"]
 	assert len(scans) == 1, (
-		"Missing stack must not drop findings — legacy recordings "
+		"Missing stack must not drop findings legacy recordings "
 		"should emit findings as before. "
 		f"Got: {[f['title'] for f in result.findings]}"
 	)

--- a/optimus/tests/test_explain_flags_noise_floor.py
+++ b/optimus/tests/test_explain_flags_noise_floor.py
@@ -10,8 +10,8 @@ tabWorkspace, tabCustom Field, ...). App developers can't add an
 index to those, and the ~0ms impact means even if they could the
 cost wouldn't be measurable. Two filters now suppress these:
 
-1. Noise floor — findings with impact < 5ms AND count < 5 drop
-2. Framework DocType filter — scans on stock DocTypes drop
+1. Noise floor findings with impact < 5ms AND count < 5 drop
+2. Framework DocType filter scans on stock DocTypes drop
 """
 
 from optimus.analyzers import explain_flags
@@ -51,7 +51,7 @@ def _recording_with(calls):
 
 def test_below_noise_floor_single_occurrence_tiny_impact_is_dropped():
 	"""A Full Scan on a custom app's DocType that ran ONCE for 0.5ms
-	is not worth reporting — the user can't measurably improve it."""
+	is not worth reporting the user can't measurably improve it."""
 	recording = _recording_with([
 		_build_call("tabMyAppThing", query_duration=0.5),
 	])
@@ -85,7 +85,7 @@ def test_high_count_above_noise_floor_is_kept():
 
 def test_high_impact_low_count_is_kept():
 	"""One full scan that cost 100ms is actionable even though it
-	only ran once — the single query is slow enough to investigate."""
+	only ran once the single query is slow enough to investigate."""
 	recording = _recording_with([
 		_build_call("tabMyAppThing", query_duration=100.0),
 	])
@@ -98,7 +98,7 @@ def test_high_impact_low_count_is_kept():
 def test_framework_doctype_scan_is_dropped_regardless_of_impact(monkeypatch):
 	"""A Full Scan on a stock Frappe DocType is NOT actionable
 	regardless of impact. The user can't add an index to
-	tabDocField — that requires an upstream patch.
+	tabDocField that requires an upstream patch.
 
 	Monkeypatch the DocType-app cache so the test doesn't need a
 	live bench."""
@@ -115,7 +115,7 @@ def test_framework_doctype_scan_is_dropped_regardless_of_impact(monkeypatch):
 	scans = [f for f in result.findings if f["finding_type"] == "Full Table Scan"]
 	assert scans == [], (
 		"Scan on framework-owned tabDocField must be suppressed even "
-		"with high impact — the user can't add an upstream index. "
+		"with high impact the user can't add an upstream index. "
 		f"Got: {[f['title'] for f in scans]}"
 	)
 	# Warning explains the suppression.
@@ -124,7 +124,7 @@ def test_framework_doctype_scan_is_dropped_regardless_of_impact(monkeypatch):
 
 
 def test_user_app_doctype_scan_is_kept(monkeypatch):
-	"""Mirror of above — a scan on `tabMyAppCustomDocType` (NOT in
+	"""Mirror of above a scan on `tabMyAppCustomDocType` (NOT in
 	the framework set) must NOT be suppressed by the DocType filter."""
 	monkeypatch.setattr(
 		explain_flags, "_framework_doctypes_cache",

--- a/optimus/tests/test_finding_card_ai_fix.py
+++ b/optimus/tests/test_finding_card_ai_fix.py
@@ -88,14 +88,14 @@ _GOOD_SUGGESTION = (
 
 
 # --------------------------------------------------------------------------
-# renderer._markdown_to_safe_html — unit (markdown → sanitized HTML)
+# renderer._markdown_to_safe_html unit (markdown → sanitized HTML)
 # --------------------------------------------------------------------------
 
 class TestMarkdownToSafeHtml:
 	def test_converts_basic_markdown(self):
 		out = renderer._markdown_to_safe_html("**bold** and a list:\n\n- one\n- two\n")
-		# Either the real converter ran (preferred) or — under module
-		# pollution — the escaped <pre> fallback; both are non-empty and
+		# Either the real converter ran (preferred) or under module
+		# pollution the escaped <pre> fallback; both are non-empty and
 		# never contain a live <script>.
 		assert out
 		assert "<script" not in out.lower()
@@ -160,7 +160,7 @@ class TestAiFixBlockRendering:
 		assert "Suggested fix" in html
 		assert "claude-sonnet-4-6" in html
 		# The suggestion text made it into the page (converted-markdown or
-		# escaped-pre fallback — both contain the words).
+		# escaped-pre fallback both contain the words).
 		assert "Diagnosis" in html and "Why it works" in html
 		assert "batch the lookups" in html
 		# Disclaimer footer.
@@ -169,7 +169,7 @@ class TestAiFixBlockRendering:
 	def test_no_block_when_llm_fix_absent(self):
 		doc = _doc([_finding(llm_fix=None)])
 		html = renderer.render_raw(doc, recordings=[])
-		# The AI-fix block uses class="fix-box" — check that specifically
+		# The AI-fix block uses class="fix-box" check that specifically
 		# instead of "Suggested fix" prose, which is also used by the
 		# Performance Gap Analysis section's `.gap-fix-label`.
 		assert 'class="fix-box"' not in html
@@ -204,7 +204,7 @@ class TestAiFixBlockRendering:
 	def test_no_block_when_llm_fix_json_is_empty_object(self):
 		doc = _doc([_finding(llm_fix={})])
 		html = renderer.render_raw(doc, recordings=[])
-		# Check for the AI-fix box marker specifically — the
+		# Check for the AI-fix box marker specifically the
 		# Gap Analysis section also emits a "Suggested fix" label.
 		assert 'class="fix-box"' not in html
 
@@ -256,7 +256,7 @@ class TestAiFixBlockRendering:
 
 	def test_canned_fix_hint_hidden_when_ai_fix_present(self):
 		"""When an AI 'Suggested fix' renders, the canned 'How to fix' hint is
-		redundant and suppressed (user request) — the AI box stands alone."""
+		redundant and suppressed (user request) the AI box stands alone."""
 		doc = _doc([_finding(
 			fix_hint=self._CANNED_HINT,
 			llm_fix={"suggestion": _GOOD_SUGGESTION, "model": "m",
@@ -283,7 +283,7 @@ class TestAiFixBlockRendering:
 		assert "directional guidance" in html
 
 	def test_no_caution_when_source_available_or_legacy_row(self):
-		# Explicit True — no caution div (the CSS rule is always in <style>,
+		# Explicit True no caution div (the CSS rule is always in <style>,
 		# so match on the element, not the class name).
 		doc = _doc([_finding(llm_fix={
 			"suggestion": _GOOD_SUGGESTION, "model": "m", "provider": "OpenAI",

--- a/optimus/tests/test_finding_card_smoking_gun.py
+++ b/optimus/tests/test_finding_card_smoking_gun.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for the v0.6.0 finding-card 'smoking gun' block — exercises the
+"""Tests for the v0.6.0 finding-card 'smoking gun' block exercises the
 new prominent callsite + source snippet + Phase 2 hot-line callout above
 the existing technical_detail rows. Uses renderer.render_raw end-to-end
 so we verify the macro within its real context.
@@ -204,7 +204,7 @@ class TestPhase2Crosslink:
 
 	def test_phase2_callout_renders_when_function_match(self):
 		"""When a finding's callsite function was instrumented in Phase 2,
-		the card shows 'Phase 2: hottest line N — Mms / X hits'."""
+		the card shows 'Phase 2: hottest line N Mms / X hits'."""
 		snippet = [{"lineno": 42, "content": "    do_thing()"}]
 		finding = _finding_child(
 			filename="/different/path/myapp/x.py",  # different prefix, same basename
@@ -269,13 +269,13 @@ class TestPhase2Crosslink:
 		from ``looped_validate`` to ``_check_user_exists`` (via the
 		intermediate ``_run_validations``) should re-anchor the
 		smoking-gun snippet on the **call site** of ``_check_user_exists``
-		inside its parent ``_run_validations`` — that's the line in
+		inside its parent ``_run_validations``: that's the line in
 		``_run_validations``'s body that invokes the leaf (e.g.
 		``    _check_user_exists(doc)``), not the leaf's own ``def``.
 
 		The wrapper (``looped_validate``) is preserved as a breadcrumb
 		caption. Phase-2's actually-hot internal line (line 20) still
-		surfaces in the separate Phase 2 callout — and the drill-down
+		surfaces in the separate Phase 2 callout and the drill-down
 		narrative is rooted on ``looped_validate``."""
 		src = tmp_path / "common.py"
 		src.write_text(
@@ -394,7 +394,7 @@ class TestPhase2Crosslink:
 		# call lives at line 13 (``    _check_user_exists(doc)``), not
 		# at the leaf's def line 18. v0.7.x redesign Phase D: the
 		# file:line callsite header moved from inside `.smoking` to
-		# the `.finding-meta` row under the title — slice the broader
+		# the `.finding-meta` row under the title slice the broader
 		# `.finding` card up to the Drill-down chain so both the meta
 		# row AND the smoking-gun snippet are inside the scope.
 		finding_start = html.find('class="finding severity-')
@@ -424,13 +424,13 @@ class TestPhase2Crosslink:
 	def test_retarget_falls_back_to_leaf_def_when_call_site_not_findable(self, tmp_path):
 		"""When the leaf's call can't be located in the parent's body
 		(unparseable source, leaf name not present, etc.), the retarget
-		falls back to the leaf's own def line — the previous behavior.
+		falls back to the leaf's own def line the previous behavior.
 		Anchors are still better than the wrapper's def line."""
 		src = tmp_path / "common.py"
 		# Source where _run_validations doesn't actually contain a call
 		# to _check_user_exists (intentional mismatch to exercise the
-		# fallback). The drill-down chain — built from a pre-cooked
-		# pyinstrument tree, NOT from this source — still has the chain.
+		# fallback). The drill-down chain built from a pre-cooked
+		# pyinstrument tree, NOT from this source still has the chain.
 		src.write_text(
 			"line1\n"
 			"line2\n"
@@ -444,7 +444,7 @@ class TestPhase2Crosslink:
 			"\n"
 			"\n"
 			"def _run_validations(doc):\n"  # 12
-			"    pass\n"  # 13 — NO call to _check_user_exists here
+			"    pass\n"  # 13 NO call to _check_user_exists here
 			"\n"
 			"\n"
 			"\n"
@@ -509,7 +509,7 @@ class TestPhase2Crosslink:
 
 		# Fallback: anchor on the leaf's def line.
 		assert "common.py:18" in html
-		# The parent's body wasn't useful — the call line couldn't be
+		# The parent's body wasn't useful the call line couldn't be
 		# located, so the retarget falls back, NOT to the wrapper's
 		# def line (line 6).
 		assert "common.py:6" not in html or "looped_validate" in html  # 6 may appear in breadcrumb caption text
@@ -520,7 +520,7 @@ class TestPhase2Crosslink:
 		"""When the drill-down chain's deepest entry is the same
 		function as the finding's callsite (single-frame chain or
 		framework-boundary immediately below), the smoking-gun snippet
-		stays on the wrapper — there's nowhere deeper in user code to
+		stays on the wrapper there's nowhere deeper in user code to
 		go. The breadcrumb caption should NOT appear."""
 		src = tmp_path / "x.py"
 		src.write_text(
@@ -548,7 +548,7 @@ class TestPhase2Crosslink:
 			}),
 		)
 		# Call tree where my_func has no eligible user-code descendants
-		# (child is in framework — drill-down walker stops there).
+		# (child is in framework drill-down walker stops there).
 		action = SimpleNamespace(
 			idx=0,
 			action_label="submit",
@@ -575,7 +575,7 @@ class TestPhase2Crosslink:
 
 		# Callsite stays at line 3 (the wrapper itself).
 		assert "x.py:3" in html
-		# No breadcrumb caption — no retargeting happened.
+		# No breadcrumb caption no retargeting happened.
 		assert "Time entered through" not in html
 
 	def test_picks_hottest_line_across_runs(self):
@@ -647,7 +647,7 @@ def _hot_line_finding(file_path, lineno, line_content):
 	return SimpleNamespace(
 		finding_type="Hot Line",
 		severity="High",
-		title=f"some.module:{lineno} consumed 100ms (1 hits) — single hottest line",
+		title=f"some.module:{lineno} consumed 100ms (1 hits) single hottest line",
 		customer_description="dominant time sink",
 		estimated_impact_ms=100.0,
 		affected_count=1,
@@ -666,7 +666,7 @@ def _hot_line_finding(file_path, lineno, line_content):
 
 class TestSlowHotPathLegacyShape:
 	"""call_tree's Slow Hot Path / Hook Bottleneck / Repeated Hot Frame
-	store filename/lineno at top level — the renderer must synthesize a
+	store filename/lineno at top level the renderer must synthesize a
 	callsite from those so the smoking-gun block renders."""
 
 	def test_smoking_gun_renders_for_top_level_filename(self, tmp_path):
@@ -686,7 +686,7 @@ class TestSlowHotPathLegacyShape:
 
 class TestHotLineLegacyShape:
 	"""line_profile.analyzer's Hot Line finding stores `file` (not
-	`filename`) at top level — synthesize and use line_content as the
+	`filename`) at top level synthesize and use line_content as the
 	source snippet (no file read needed)."""
 
 	def test_smoking_gun_renders_with_line_content(self):
@@ -737,7 +737,7 @@ class TestHotLineLegacyShape:
 
 		html = renderer.render_raw(doc, recordings=[])
 
-		# The callout's distinctive HTML — `<strong …>Phase 2:</strong>` —
+		# The callout's distinctive HTML `<strong …>Phase 2:</strong>`:
 		# must NOT appear (the title text "single hottest line" is part
 		# of the Hot Line finding's own title, so we can't filter on
 		# that phrase alone).
@@ -797,7 +797,7 @@ class TestLazySnippetRead:
 		)
 		doc = _fake_doc([finding])
 
-		# Must not crash — best-effort silent skip.
+		# Must not crash best-effort silent skip.
 		html = renderer.render_raw(doc, recordings=[])
 
 		# Callsite line still rendered (file:lineno + function visible).
@@ -806,7 +806,7 @@ class TestLazySnippetRead:
 
 
 # ---------------------------------------------------------------------------
-# v0.6.x: findings that carry no callsite get one resolved at render time —
+# v0.6.x: findings that carry no callsite get one resolved at render time
 # Repeated Hot Frame (from its "path::func" key), Function Not Invoked (from
 # its dotted_path), and SQL red-flag findings (a representative callsite from
 # the recordings).
@@ -814,7 +814,7 @@ class TestLazySnippetRead:
 
 # Same constraint as test_action_entry_callsite: walk_callsite excludes any
 # path containing "frappe/" or "optimus/", so the "user code" frame
-# must be a path with neither — a stdlib module's absolute file works.
+# must be a path with neither a stdlib module's absolute file works.
 _USER_FRAME_FILE = inspect.__file__
 
 
@@ -876,7 +876,7 @@ class TestRenderTimeCallsiteResolution:
 	def test_repeated_hot_frame_unresolvable_is_filtered(self):
 		"""v0.7.x: a Repeated Hot Frame whose ``function`` key can't be
 		resolved to a real file:line is dropped entirely from rendering
-		— it had no callsite to act on. Pre-v0.7 the card rendered
+		it had no callsite to act on. Pre-v0.7 the card rendered
 		title-only; the user opted to suppress no-callsite findings."""
 		doc = _fake_doc([_repeated_hot_frame("nope_xyzq/foo.py::bar")])
 		html = renderer.render_raw(doc, recordings=[])
@@ -886,7 +886,7 @@ class TestRenderTimeCallsiteResolution:
 
 	def test_function_not_invoked_is_filtered_out(self):
 		# v0.7.x: "X was picked but never invoked during phase 2" is
-		# non-actionable noise — render() drops these findings entirely (the
+		# non-actionable noise render() drops these findings entirely (the
 		# Line-Level Drilldown notes uninvoked picks in one concise line).
 		doc = _fake_doc([_function_not_invoked("optimus.renderer.render")])
 		html = renderer.render_raw(doc, recordings=[])
@@ -910,7 +910,7 @@ class TestRenderTimeCallsiteResolution:
 			}],
 		}]
 		html = renderer.render_raw(doc, recordings=recs)
-		# v0.7.x Phase D: smoking-gun label wording trimmed —
+		# v0.7.x Phase D: smoking-gun label wording trimmed
 		# "Most-called from:" / "Representative callsite" prose collapsed
 		# into a single `.smoking-label` line ("most-called from this
 		# callsite ..."). Anchor on the new wording.
@@ -921,7 +921,7 @@ class TestRenderTimeCallsiteResolution:
 	def test_missing_index_without_matching_recording_is_filtered(self):
 		"""v0.7.x: a Missing Index without a representative callsite (no
 		recording matched the normalized query) has no actionable
-		file:line anchor — it's dropped from the render entirely along
+		file:line anchor it's dropped from the render entirely along
 		with the rest of the no-callsite suppression."""
 		doc = _fake_doc([_missing_index("tabUser", "SELECT ... FROM `tabUser`")])
 		# Recording has a different query → no representative callsite.
@@ -946,7 +946,7 @@ class TestDocEventHookInsideSmokingGun:
 		callouts), not in a separate finding-detail box below.
 
 		v0.7.x: the supporting-context box (``.finding-detail``) is
-		now suppressed entirely when no inner row applies — so for
+		now suppressed entirely when no inner row applies so for
 		this finding (callsite + target_doc + hook_events, no other
 		detail fields) it shouldn't render at all. The hook breadcrumb
 		appearing inside the smoking-gun is verified by its presence
@@ -970,13 +970,13 @@ class TestDocEventHookInsideSmokingGun:
 		sg_open = html.find('class="smoking"', 0)
 		assert hook_pos > 0, "Doc-event hook line missing from output"
 		assert sg_open > 0
-		# Hook appears AFTER smoking-gun's opening marker — i.e. inside it.
+		# Hook appears AFTER smoking-gun's opening marker i.e. inside it.
 		assert hook_pos > sg_open, (
 			"Doc-event hook breadcrumb must render INSIDE the smoking-gun "
 			f"block (after sg_open={sg_open}), got {hook_pos}"
 		)
 		# A fix-less finding carries no generic "Where to start" box (removed per
-		# user request) — its meaningful content is the smoking-gun block above.
+		# user request) its meaningful content is the smoking-gun block above.
 		assert "Where to start" not in html
 
 	def test_target_doc_appears_with_hook(self):
@@ -995,7 +995,7 @@ class TestDocEventHookInsideSmokingGun:
 		doc = _fake_doc([finding])
 		html = renderer.render_raw(doc, recordings=[])
 
-		# Both the document chip and the hook chip render — single span line.
+		# Both the document chip and the hook chip render single span line.
 		assert "Document:" in html
 		assert "<strong>Sales Invoice</strong>" in html
 		assert "SI-0001" in html
@@ -1036,7 +1036,7 @@ class TestDrilldownPlaceholder:
 	floor), the template renders a 'no deeper user-code frame'
 	placeholder instead of a silent gap. Findings without an
 	``action_ref`` / tree skip the attachment entirely and show
-	nothing — the placeholder only appears when the walk was attempted
+	nothing the placeholder only appears when the walk was attempted
 	and produced no eligible descendants."""
 
 	def test_empty_chain_renders_placeholder(self, tmp_path):
@@ -1093,7 +1093,7 @@ class TestDrilldownPlaceholder:
 				"cumulative_ms": 955.0,
 				"children": [{
 					"function": "get_doc",
-					# Framework path — walker stops here.
+					# Framework path walker stops here.
 					"filename": "apps/frappe/frappe/__init__.py",
 					"lineno": 100,
 					"kind": "python",
@@ -1115,7 +1115,7 @@ class TestDrilldownPlaceholder:
 
 	def test_finding_without_drilldown_attribute_renders_no_placeholder(self, tmp_path):
 		"""A finding without ``action_ref`` skips _attach_drilldown_chains
-		entirely — no ``drilldown_chain`` key on technical_detail. The
+		entirely no ``drilldown_chain`` key on technical_detail. The
 		template must NOT render the placeholder in this case (otherwise
 		every SQL red-flag finding would show 'no deeper user-code')."""
 		snippet = [{"lineno": 42, "content": "    do_thing()"}]
@@ -1136,7 +1136,7 @@ class TestDrilldownPlaceholder:
 
 	def test_non_empty_chain_renders_chain_not_placeholder(self, tmp_path):
 		"""When the drill-down chain has entries, the existing chain
-		rendering shows them — the placeholder branch is skipped."""
+		rendering shows them the placeholder branch is skipped."""
 		src = tmp_path / "common.py"
 		src.write_text(
 			"line1\n"
@@ -1198,8 +1198,8 @@ class TestDrilldownPlaceholder:
 		# Chain rendered (existing behavior).
 		assert "Drill-down" in html
 		# v0.7.x Phase D: chain steps render as `function:lineno` pills
-		# (filename is dropped from each pill — the meta row above
-		# carries the file path). The inner def line is line 6 — its
+		# (filename is dropped from each pill the meta row above
+		# carries the file path). The inner def line is line 6 its
 		# function name appears as a chain step.
 		assert "inner:6" in html or ":6" in html
 		# Placeholder branch NOT taken.
@@ -1209,7 +1209,7 @@ class TestDrilldownPlaceholder:
 
 def test_phase2_callout_renders_for_empty_drilldown_self_time_finding():
 	"""User's exact case: a Slow Hot Path finding with NO deeper user-code
-	frame (empty drilldown_chain) — e.g. bg_recheck_users — plus a completed
+	frame (empty drilldown_chain) e.g. bg_recheck_users plus a completed
 	phase-2 run on that function. The card MUST show the Line-Level callout."""
 	import json as _json
 	from types import SimpleNamespace as _NS
@@ -1256,7 +1256,7 @@ class TestFindingsRefinements:
 
 	def test_actionable_finding_without_fix_hint_has_no_fallback(self):
 		# Removed per user request: a Slow Hot Path with no fix_hint shows no
-		# generic "Where to start" box — the smoking-gun block already says
+		# generic "Where to start" box the smoking-gun block already says
 		# where the time went, and a boilerplate next-step only added noise.
 		doc = _fake_doc([_finding_child(finding_type="Slow Hot Path")])
 		html = renderer.render_raw(doc, recordings=[])

--- a/optimus/tests/test_finding_impact_invariants.py
+++ b/optimus/tests/test_finding_impact_invariants.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""D.M-S3 — finding impact cannot exceed parent action wall.
+"""D.M-S3 finding impact cannot exceed parent action wall.
 
 Every Slow Hot Path / Hook Bottleneck finding rooted in an action carries
 ``action_ref`` (the action_idx as a string) and ``estimated_impact_ms``.
@@ -30,7 +30,7 @@ def _node(function, filename, cumulative, self_ms, children):
 
 def test_slow_hot_path_estimated_impact_bounded_by_action_wall():
 	"""Use a synthetic tree where the hot subtree's cumulative_ms
-	exceeds the action wall (cross-action inflation) — the emitted
+	exceeds the action wall (cross-action inflation) the emitted
 	finding's estimated_impact_ms must still be clamped."""
 	tree = _node(
 		"my_app.work.do",
@@ -59,7 +59,7 @@ def test_slow_hot_path_estimated_impact_bounded_by_action_wall():
 def test_findings_with_action_ref_respect_action_wall():
 	"""Cross-check: for every finding produced by walking a tree, the
 	finding's estimated_impact_ms must not exceed the action wall it
-	was rooted in — regardless of how the subtree's cumulative scales."""
+	was rooted in regardless of how the subtree's cumulative scales."""
 	# Realistic-ish tree: top-level user code with two slow children.
 	tree = _node(
 		"my_app.views.handler",

--- a/optimus/tests/test_finding_types_allowlist.py
+++ b/optimus/tests/test_finding_types_allowlist.py
@@ -9,7 +9,7 @@ updated, Frappe's Select-field validation raises ValidationError at
 doc.save() time, destroying the whole analyze run.
 
 This caught v0.5.1's ``Framework N+1`` type after it had already
-shipped — once a session produced a Framework N+1 finding, analyze
+shipped once a session produced a Framework N+1 finding, analyze
 crashed with:
 
     frappe.exceptions.ValidationError: Row #1: Type cannot be
@@ -89,7 +89,7 @@ def test_framework_n_plus_one_is_in_options():
 	options = _load_doctype_options()
 	assert "Framework N+1" in options, (
 		"'Framework N+1' must be in Optimus Finding's select options "
-		"— n_plus_one.py emits this finding type for pure-frappe "
+		" n_plus_one.py emits this finding type for pure-frappe "
 		"stacks and Frappe's DocType validation will reject it "
 		"otherwise"
 	)

--- a/optimus/tests/test_fixture_builders.py
+++ b/optimus/tests/test_fixture_builders.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Smoke tests for the fixture builders — verify they produce shapes
+"""Smoke tests for the fixture builders verify they produce shapes
 that match the analyzers' expectations and can replace hand-written
 JSON fixtures in most cases.
 """

--- a/optimus/tests/test_format_duration_ms.py
+++ b/optimus/tests/test_format_duration_ms.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Pure-Python unit tests for ``_format_duration_ms`` — the threshold-aware
+"""Pure-Python unit tests for ``_format_duration_ms``: the threshold-aware
 duration formatter that powers the ``fmt_ms`` Jinja-callable. Below the
 threshold, render as ms (with caller-controlled decimals); at or above,
 render as seconds with 2 decimals.
@@ -9,7 +9,7 @@ render as seconds with 2 decimals.
 v0.7.x: the formatter returns ``markupsafe.Markup`` so the seconds
 branch can wrap the output in a ``<span class="time-high">`` for visual
 emphasis when rendered by Jinja. ``Markup`` subclasses ``str`` so
-equality comparisons against plain strings still work — we just have
+equality comparisons against plain strings still work we just have
 to match against the wrapped form when ≥1000ms."""
 
 from optimus.renderer import _format_duration_ms
@@ -73,7 +73,7 @@ class TestDisabled:
 		# negative would otherwise convert; the abs(v) >= threshold check
 		# would always be true).
 		# Actual behaviour: threshold=-1 is truthy and abs(v) >= -1 is
-		# always true, so 5234 → "5.23s". Documenting actual semantics —
+		# always true, so 5234 → "5.23s". Documenting actual semantics
 		# admins should never set a negative threshold.
 		assert _format_duration_ms(5234, threshold_ms=-1) == _seconds("5.23s")
 

--- a/optimus/tests/test_framework_apps_classifier.py
+++ b/optimus/tests/test_framework_apps_classifier.py
@@ -9,7 +9,7 @@ insights, crm, builder, wiki, drive) so findings rooted inside those
 apps route into the collapsed Observations subsection instead of the
 actionable Findings list. Triggered by a production Sales Invoice
 Save+Submit session that surfaced 10 'Redundant cache lookup'
-findings landing in apps/erpnext/.../sales_invoice.py:300 — the
+findings landing in apps/erpnext/.../sales_invoice.py:300 the
 application developer can't patch ERPNext from their bench.
 
 These tests pin the classifier's behavior so regressions (e.g. an
@@ -98,7 +98,7 @@ class TestThirdPartyLibraryDetection:
 
 	@pytest.mark.parametrize("path", [
 		# A lib name MID-PATH in a relative (recorder-stripped) path is a user
-		# submodule, not the library — recorder callsites are ``<app>/<app>/…``.
+		# submodule, not the library recorder callsites are ``<app>/<app>/…``.
 		"something/werkzeug/routing.py",
 		"something/gunicorn/app.py",
 		"myapp/myapp/rq/worker.py",
@@ -126,7 +126,7 @@ class TestWidenedLibraryCoverage:
 	])
 	def test_widened_libs_are_framework(self, path):
 		assert is_framework_callsite(path) is True, (
-			f"{path} is un-patchable library code — must be an Observation, not a user N+1"
+			f"{path} is un-patchable library code must be an Observation, not a user N+1"
 		)
 
 	def test_sql_and_hotframe_classifiers_agree_on_widened_libs(self):
@@ -141,7 +141,7 @@ class TestWidenedLibraryCoverage:
 
 	def test_user_app_named_near_a_lib_still_user(self):
 		"""A user app whose name merely contains a lib token (not the lib itself)
-		is still user code — the fragments carry a trailing slash."""
+		is still user code the fragments carry a trailing slash."""
 		assert is_framework_callsite("apps/pandas_tools/pandas_tools/api.py") is False
 		assert is_framework_callsite("apps/my_redis_app/handlers.py") is False
 
@@ -173,7 +173,7 @@ class TestBoundaryCases:
 	def test_lookalike_erpnext(self):
 		# Fork of erpnext with renamed top-level should still be user code.
 		assert is_framework_callsite("apps/myerpnext_fork/foo.py") is False
-		# But the jewellery_erpnext case — which is a DIFFERENT app —
+		# But the jewellery_erpnext case which is a DIFFERENT app
 		# must also be user code (it's not in the official list even
 		# though its name ends with 'erpnext').
 		assert is_framework_callsite("apps/jewellery_erpnext/foo.py") is False
@@ -205,7 +205,7 @@ class TestInclusionMode:
 
 	def test_not_in_allowlist_returns_true(self):
 		"""Even erpnext, which is in FRAMEWORK_APPS, still returns
-		True in inclusion mode — the inclusion check is the ONLY
+		True in inclusion mode the inclusion check is the ONLY
 		check when tracked_apps is set."""
 		tracked = ("myapp",)
 		assert is_framework_callsite(
@@ -232,7 +232,7 @@ class TestInclusionMode:
 		) is False
 
 	def test_empty_tracked_apps_falls_back_to_exclusion(self):
-		"""Empty tuple means 'no allowlist configured' — fall back to
+		"""Empty tuple means 'no allowlist configured' fall back to
 		the built-in FRAMEWORK_APPS exclusion list."""
 		assert is_framework_callsite(
 			"apps/erpnext/erpnext/foo.py", tracked_apps=(),
@@ -273,7 +273,7 @@ class TestInclusionMode:
 class TestInclusionModeUnderAppsAncestor:
 	"""Issue C: Tracked Apps (inclusion mode) must resolve the real app even when
 	the bench is nested under a folder named 'apps' (/opt/apps/…, multi-bench
-	servers) — else a tracked app's own findings get hidden as framework."""
+	servers) else a tracked app's own findings get hidden as framework."""
 
 	def test_tracked_app_matches_under_apps_ancestor(self):
 		tracked = ("erpnext",)
@@ -289,10 +289,10 @@ class TestInclusionModeUnderAppsAncestor:
 
 class TestFrameworkNameMatchedOnAppRootNotMidPath:
 	"""A framework/lib name counts only as the resolved app ROOT, not a folder
-	deeper in the path — so a user app's submodule named like a framework app, the
+	deeper in the path so a user app's submodule named like a framework app, the
 	standard /home/frappe/ server home, and a vendored lib under a user app all stay
 	the user's own code. Regression for the mid-path substring false-positive (which
-	main — and this branch before the fix — got wrong)."""
+	main and this branch before the fix got wrong)."""
 
 	@pytest.mark.parametrize("path", [
 		"mybiz/mybiz/crm/lead_utils.py",       # submodule named like a framework app
@@ -302,7 +302,7 @@ class TestFrameworkNameMatchedOnAppRootNotMidPath:
 		"apps/myapp/myapp/werkzeug/util.py",   # vendored lib under a user app
 		"apps/acme/acme/requests/client.py",
 		# recorder-stripped user modules named like a common library (the exact
-		# shape frappe's recorder produces — apps/ stripped) must stay actionable.
+		# shape frappe's recorder produces apps/ stripped) must stay actionable.
 		"myapp/myapp/requests/api.py",
 		"myapp/myapp/redis/cache.py",
 		"billing/billing/celery/jobs.py",
@@ -310,7 +310,7 @@ class TestFrameworkNameMatchedOnAppRootNotMidPath:
 	])
 	def test_mid_path_framework_or_lib_name_is_user_code(self, path):
 		assert is_framework_callsite(path) is False, (
-			f"{path} — the framework/lib name is only mid-path, not the app root"
+			f"{path} the framework/lib name is only mid-path, not the app root"
 		)
 
 	@pytest.mark.parametrize("path", [
@@ -326,7 +326,7 @@ class TestFrameworkNameMatchedOnAppRootNotMidPath:
 
 class TestSitePackagesGuardInBothModes:
 	"""A venv library is un-patchable framework code in BOTH default and Tracked
-	Apps mode — a lib vendored under a tracked app's own .venv must not be reported
+	Apps mode a lib vendored under a tracked app's own .venv must not be reported
 	as an actionable user finding just because its top segment is the tracked app."""
 
 	@pytest.mark.parametrize("path", [
@@ -344,7 +344,7 @@ class TestSitePackagesGuardInBothModes:
 class TestUserAppWithAppsSubpackage:
 	"""A user app that itself contains a subpackage literally named 'apps'
 	(``myapp/apps/foo.py``) must resolve to the real app 'myapp', not the segment
-	after the mid-path 'apps' — a relative mid-path '/apps/' is a user subpackage,
+	after the mid-path 'apps' a relative mid-path '/apps/' is a user subpackage,
 	not the bench apps dir (the recorder strips the bench prefix)."""
 
 	def test_apps_subpackage_resolves_to_real_app_in_inclusion_mode(self):
@@ -374,14 +374,14 @@ class TestInstalledAppsAllowlist:
 	"""Exclusion mode with the ground-truth installed-apps allowlist (what a real
 	site passes). This is the fix that ends the denylist churn: application-vs-
 	library is decided by 'is it an installed Frappe app', not by guessing from a
-	name. Off-bench (installed_apps=None) the hardcoded heuristic still applies —
+	name. Off-bench (installed_apps=None) the hardcoded heuristic still applies
 	the rest of this file exercises that path."""
 
 	INSTALLED = frozenset({"frappe", "erpnext", "myapp", "redis", "requests"})
 
 	def test_installed_app_named_like_a_library_is_user_code(self):
 		# The whole point: an app literally named `redis`/`requests` that IS
-		# installed is the developer's code — the denylist wrongly hid it.
+		# installed is the developer's code the denylist wrongly hid it.
 		assert is_framework_callsite("redis/redis/api.py", installed_apps=self.INSTALLED) is False
 		assert is_framework_callsite("requests/requests/foo.py", installed_apps=self.INSTALLED) is False
 
@@ -418,7 +418,7 @@ class TestInstalledAppsAllowlist:
 		# installed_apps=None → the hardcoded denylist path (unchanged behavior).
 		# This is EXACTLY the false-positive the allowlist fixes: off-bench, an app
 		# named `redis` is indistinguishable from the library, so the denylist hides
-		# it as framework. On-bench (installed_apps set) it is correctly user code —
+		# it as framework. On-bench (installed_apps set) it is correctly user code
 		# see test_installed_app_named_like_a_library_is_user_code above.
 		assert is_framework_callsite("redis/redis/api.py", installed_apps=None) is True
 		assert is_framework_callsite("pandas/core/frame.py", installed_apps=None) is True
@@ -435,7 +435,7 @@ class TestInstalledAppsAllowlist:
 
 class TestPureHelperFrameAllowlistOnBench:
 	"""_is_pure_helper_frame (hot-frame leaderboard + Slow Hot Path walker) with a
-	populated installed-apps set — the ON-BENCH path the pure-Python suite otherwise
+	populated installed-apps set the ON-BENCH path the pure-Python suite otherwise
 	never hits (every other test passes installed_apps=None). Regression guard for
 	the drop-user-frames bug: the allowlist must key on the RESOLVED app root, not
 	the raw first path segment ('apps'/'home'), and must not fire in inclusion mode."""

--- a/optimus/tests/test_frontend_assets.py
+++ b/optimus/tests/test_frontend_assets.py
@@ -33,7 +33,7 @@ LIST_JS = os.path.join(
 def _node_check(js_path: str) -> None:
 	"""Run `node --check` to validate JS syntax.
 
-	Skips if node isn't installed — that's fine, frappe benches ship with
+	Skips if node isn't installed that's fine, frappe benches ship with
 	node so in practice this will run everywhere that matters.
 	"""
 	if not shutil.which("node"):
@@ -78,7 +78,7 @@ def test_widget_has_visibility_listener():
 	with open(WIDGET_JS) as f:
 		src = f.read()
 	assert "visibilitychange" in src
-	# v0.5.1: no more stopPolling — the handler just re-fetches
+	# v0.5.1: no more stopPolling the handler just re-fetches
 	# state on visibility return. The polling-pause machinery was
 	# removed; see test_realtime_session_events for the new
 	# realtime contract.
@@ -108,7 +108,7 @@ def test_form_js_does_not_render_analyzer_warnings_intro():
 	from the Optimus Session form view. The warning text (about
 	suppressed framework callsites, skipped non-SELECT statements,
 	below-threshold suggestions, etc.) was diagnostic noise that the
-	developer doesn't need to act on — it pushed the actionable
+	developer doesn't need to act on it pushed the actionable
 	findings count below the fold. The data is still stored on the
 	hidden ``analyzer_warnings`` field for offline inspection."""
 	with open(FORM_JS) as f:
@@ -137,7 +137,7 @@ def test_form_js_has_report_buttons():
 	assert "Download Report" in src
 	assert "Open Report" in src
 	assert "raw_report_file" in src
-	# The PDF button is gone — confirm no stale reference leaked
+	# The PDF button is gone confirm no stale reference leaked
 	# into the form JS.
 	assert "Download Report (PDF)" not in src
 	assert "optimus.api.download_pdf" not in src
@@ -156,7 +156,7 @@ def test_widget_start_has_error_callback():
 	"""v0.5.1 regression guard: the Start dialog's frappe.call must
 	include an error callback. Without it, any server-side failure of
 	api.start (permission error, concurrent session, server exception)
-	silently closes the dialog with no feedback to the user — the
+	silently closes the dialog with no feedback to the user the
 	exact 'widget not working as expected' failure mode reported by
 	users who lacked the Optimus User role. The stop API already had
 	an error callback added in an earlier fix; this test forces start
@@ -174,7 +174,7 @@ def test_widget_start_has_error_callback():
 	window = src[start_call_idx : start_call_idx + 2000]
 	assert "error:" in window or "error: " in window, (
 		"openStartDialog's frappe.call(api.start) must have an error "
-		"callback — without it, permission errors and server exceptions "
+		"callback without it, permission errors and server exceptions "
 		"leave the widget silently unresponsive after the dialog closes"
 	)
 
@@ -185,7 +185,7 @@ def test_widget_stop_has_error_callback():
 
 	We look at the entire confirmAndStop function body (finding it
 	from the 'function confirmAndStop' keyword to the closing brace)
-	rather than a fixed-size window after the stop call site — the
+	rather than a fixed-size window after the stop call site the
 	callback body grew in v0.5.1 to handle the 'no active session'
 	reset path and a couple of console.log diagnostics, and a fixed
 	window was both brittle and too narrow.
@@ -223,7 +223,7 @@ def test_widget_stop_has_error_callback():
 
 def test_widget_stop_handles_no_active_session():
 	"""v0.5.1 regression guard: when the stop API returns
-	{stopped: false} (session already gone — auto-stopped, janitor-
+	{stopped: false} (session already gone auto-stopped, janitor-
 	swept, or a retried click after a network blip on the first
 	stop), the widget must reset to inactive, NOT transition to
 	'Analyzing…' (which would hang forever because no session is
@@ -251,7 +251,7 @@ def test_widget_stop_handles_no_active_session():
 	assert "data.stopped === false" in body, (
 		"confirmAndStop's success callback must handle the "
 		"{stopped: false} response (session already gone) and reset "
-		"to inactive — without this check, the widget falls through "
+		"to inactive without this check, the widget falls through "
 		"to the 'Analyzing…' branch and hangs forever"
 	)
 

--- a/optimus/tests/test_frontend_timings_analyzer.py
+++ b/optimus/tests/test_frontend_timings_analyzer.py
@@ -47,7 +47,7 @@ def test_orphans_are_separated():
 
 
 def test_lcp_dedup_picks_last_per_page():
-    """LCP fires multiple times — analyzer should keep the last value
+    """LCP fires multiple times analyzer should keep the last value
     per page_url, matching the Web Vitals library convention."""
     from optimus.analyzers import frontend_timings
 
@@ -166,14 +166,14 @@ def test_missing_frontend_data_attribute_is_safe():
 # ---------------------------------------------------------------------------
 # v0.5.1 regression guards: action_label + backend_ms come from
 # context.actions, not from the raw recording dict. Real production
-# recordings don't have either field — they have `path`, `method`,
-# `cmd`, `duration` — so the pre-v0.5.1 code fell through to the
+# recordings don't have either field they have `path`, `method`,
+# `cmd`, `duration`: so the pre-v0.5.1 code fell through to the
 # synthetic "action_N" label and `backend_ms = 0` every time.
 # ---------------------------------------------------------------------------
 
 
 def _production_shape_recordings():
-	"""Mimics the dict shape Frappe's recorder actually produces — no
+	"""Mimics the dict shape Frappe's recorder actually produces no
 	action_label, no duration_ms, just path/method/cmd/duration."""
 	return [
 		{
@@ -200,7 +200,7 @@ def _production_shape_recordings():
 def _context_with_per_action_output(recordings):
 	"""Simulate what context.actions looks like AFTER per_action.analyze
 	has run. v0.5.2: action_label on context.actions is the TECHNICAL
-	label (raw cmd with optional :Action suffix, or METHOD+path) —
+	label (raw cmd with optional :Action suffix, or METHOD+path)
 	humanization moved to per_action.humanized_label() and is used
 	only by the Steps-to-Reproduce section. The frontend XHR panel
 	mirrors whatever context.actions holds, so these fixtures match
@@ -230,7 +230,7 @@ def test_action_label_comes_from_context_actions(monkeypatch):
 	recording dict (which never carries it in production). The
 	specific label format evolved across versions (v0.5.1
 	humanized, v0.5.2 technical with :Action suffix), but the
-	routing through context.actions is invariant — that's what
+	routing through context.actions is invariant that's what
 	this test guards.
 	"""
 	from optimus.analyzers import frontend_timings

--- a/optimus/tests/test_function_body_snippet.py
+++ b/optimus/tests/test_function_body_snippet.py
@@ -152,7 +152,7 @@ class TestDecoratorThroughDefRows:
 		assert dl == 2
 
 	def test_multiline_decorator_args_span_to_def(self, tmp_path):
-		# A decorator whose args wrap across lines — every continuation line is
+		# A decorator whose args wrap across lines every continuation line is
 		# included through the def.
 		text = (
 			"@frappe.whitelist(\n"      # 1
@@ -197,7 +197,7 @@ class TestDecoratorThroughDefRows:
 
 	def test_class_before_def_is_not_grabbed(self, tmp_path):
 		# A decorated class (no def in its header) must NOT sweep up the first
-		# method's def — fall back to the single recorded line.
+		# method's def fall back to the single recorded line.
 		text = (
 			"@register\n"        # 1  <- recorded
 			"class Widget:\n"    # 2
@@ -246,7 +246,7 @@ class TestDecoratorThroughDefRows:
 
 	def test_idempotent_when_re_fed_the_def_line(self, tmp_path):
 		# Feeding the def line (as a re-render on a CPython<=3.10 anchor would)
-		# still yields the function name — never a crash or an empty snippet.
+		# still yields the function name never a crash or an empty snippet.
 		text = "@frappe.whitelist()\ndef foo():\n    return 1\n"
 		rows, dl = self._rows(tmp_path, text, 2)  # 2 == the def line
 		assert [r["content"] for r in rows] == ["def foo():"]

--- a/optimus/tests/test_hmac_envelope_versioning.py
+++ b/optimus/tests/test_hmac_envelope_versioning.py
@@ -9,7 +9,7 @@ still verify on read via the backward-compat branch.
 
 The redis_schema.wrap_value envelope (v0.12.0) lives one layer up at
 the cache-value boundary. This module is the equivalent migration-
-safety net at the bytes-on-the-wire boundary — the layer where
+safety net at the bytes-on-the-wire boundary the layer where
 ``unsign_blob`` produces the payload that gets pickle.loads'd or
 JSON.loads'd downstream.
 
@@ -48,7 +48,7 @@ def _ensure_test_secret() -> bytes:
 
 
 # Each test runs in this module's pure-pytest context where frappe.conf
-# is unconfigured, so `_has_stable_hmac_secret()` returns False — which
+# is unconfigured, so `_has_stable_hmac_secret()` returns False which
 # would cause sign_blob to skip signing entirely. Force the stable-secret
 # path by monkey-patching the helper.
 def _force_stable_secret(monkeypatch) -> bytes:
@@ -76,7 +76,7 @@ class TestSignUnsignRoundTrip:
 		assert session.unsign_blob(signed) == b""
 
 	def test_v1_round_trip_pickle_shaped_payload(self, monkeypatch):
-		"""A realistic payload — pickle bytes starting with \\x80
+		"""A realistic payload pickle bytes starting with \\x80
 		(protocol 2-5 PROTO opcode). Confirms the marker doesn't
 		collide with the most common payload shape."""
 		import pickle
@@ -193,7 +193,7 @@ class TestEdgeCases:
 
 	def test_no_secret_path_passes_through_unsigned(self, monkeypatch):
 		"""When _has_stable_hmac_secret returns False (no encryption_key
-		in frappe.conf), sign_blob returns the raw blob unchanged —
+		in frappe.conf), sign_blob returns the raw blob unchanged
 		preserves the existing Phase K behaviour."""
 		monkeypatch.setattr(session, "_has_stable_hmac_secret", lambda: False)
 		payload = b"raw unsigned"

--- a/optimus/tests/test_hot_line_snippet.py
+++ b/optimus/tests/test_hot_line_snippet.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 """The Phase-2 'single hottest line' (Hot Line) finding should show the hot
-line WITH surrounding context, like call-tree findings — not a lone line.
+line WITH surrounding context, like call-tree findings not a lone line.
 
 _finding_to_dict used to fold the persisted ``line_content`` into a 1-row
 snippet (skipping the file read). v0.7.x reads a ±2 window around the hot line
@@ -20,7 +20,7 @@ def _hot_line_row(file, lineno, line_content):
 	row = types.SimpleNamespace()
 	row.finding_type = "Hot Line"
 	row.severity = "High"
-	row.title = f"myapp.mod.func:{lineno} consumed 378ms (100 hits) — single hottest line"
+	row.title = f"myapp.mod.func:{lineno} consumed 378ms (100 hits) single hottest line"
 	row.customer_description = "the dominant time sink"
 	row.estimated_impact_ms = 378.0
 	row.affected_count = 100

--- a/optimus/tests/test_humanize_steps_api.py
+++ b/optimus/tests/test_humanize_steps_api.py
@@ -1,11 +1,11 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Surface tests for the v0.6.0 ``humanize_steps`` API endpoint — the manual
+"""Surface tests for the v0.6.0 ``humanize_steps`` API endpoint the manual
 "rewrite the Steps to Reproduce with the LLM" action on a Optimus Session.
 
 Like ``test_backfill_ai_fixes_api.py`` this is a source-inspection test (the
-endpoint needs a live bench for a true integration run): we pin the contract —
+endpoint needs a live bench for a true integration run): we pin the contract
 whitelisted, permission-gated, Ready-only, AI-enabled guard, re-fetches the
 recordings, calls ``ai_fix.humanize_steps``, persists ``notes``, re-renders.
 
@@ -90,8 +90,8 @@ def test_persists_notes_and_re_renders():
 	assert '"notes"' in core_body
 	assert "_assemble_humanized_notes(" in core_body
 	# v0.6.x: explicit commits now route through ``safe_commit`` (rollback
-	# guard added in the audit-response round). The intent — commit after
-	# the set_value — is preserved.
+	# guard added in the audit-response round). The intent commit after
+	# the set_value is preserved.
 	assert ("frappe.db.commit()" in core_body) or ("safe_commit()" in core_body)
 	endpoint_body = _fn_body("humanize_steps")
 	assert "regenerate_reports(session_uuid)" in endpoint_body

--- a/optimus/tests/test_index_recommendation.py
+++ b/optimus/tests/test_index_recommendation.py
@@ -24,12 +24,12 @@ import pytest
 
 # Imported at module top (collection time) so a later test that swaps
 # sys.modules['frappe'] / drops optimus.* can't trigger a *re-import*
-# of analyze.py — whose `from frappe.recorder import RECORDER_REQUEST_HASH`
+# of analyze.py whose `from frappe.recorder import RECORDER_REQUEST_HASH`
 # blows up under that pollution. The module object stays usable via this name.
 from optimus import analyze as _analyze  # noqa: E402
 
 # --------------------------------------------------------------------------
-# table_breakdown — co-occurrence → recommended_index
+# table_breakdown co-occurrence → recommended_index
 # --------------------------------------------------------------------------
 
 def _rec(calls):
@@ -61,7 +61,7 @@ class TestRecommendedIndex:
 		assert rec["read_count"] == 4
 
 	def test_columns_ordered_by_usage_frequency(self):
-		# customer in the most reads, then posting_date, then status — all
+		# customer in the most reads, then posting_date, then status all
 		# three filtered together in 2 reads (the dominant combo). The
 		# composite is ordered by per-column hit frequency.
 		bd = self._analyze([_rec([
@@ -118,7 +118,7 @@ class TestRecommendedIndex:
 
 
 # --------------------------------------------------------------------------
-# analyzers.base — write-hot table truth table
+# analyzers.base write-hot table truth table
 # --------------------------------------------------------------------------
 
 def test_is_write_hot_table_truth_table():
@@ -131,7 +131,7 @@ def test_is_write_hot_table_truth_table():
 
 
 # --------------------------------------------------------------------------
-# report.html — the "Index candidate" panel
+# report.html the "Index candidate" panel
 # --------------------------------------------------------------------------
 
 def _doc(table_breakdown):
@@ -186,7 +186,7 @@ class TestRenderedIndexCandidatePanel:
 
 		entry = _table_entry()
 		entry["ai_index"] = {
-			"suggestion": "**Recommendation**\n\nNothing — `idx_customer_date` already covers it.",
+			"suggestion": "**Recommendation**\n\nNothing `idx_customer_date` already covers it.",
 			"model": "claude-sonnet-4-6", "provider": "Anthropic",
 			"generated_at": "2026-05-12T00:00:00+00:00",
 		}
@@ -227,7 +227,7 @@ class TestRenderedIndexCandidatePanel:
 
 
 # --------------------------------------------------------------------------
-# ai_fix — _build_index_messages / suggest_index
+# ai_fix _build_index_messages / suggest_index
 # --------------------------------------------------------------------------
 
 class _FakeResp:
@@ -309,12 +309,12 @@ class TestAiSuggestIndex:
 
 
 # --------------------------------------------------------------------------
-# analyze — helpers + auto-enrich gating
+# analyze helpers + auto-enrich gating
 # --------------------------------------------------------------------------
 
 class TestAnalyzeIndexHelpers:
 	def test_table_existing_indexes_handles_unreadable_table(self):
-		# In the test env frappe.db is unavailable / the table doesn't exist —
+		# In the test env frappe.db is unavailable / the table doesn't exist
 		# the helper must swallow it and return [].
 		assert _analyze._table_existing_indexes("tabDefinitelyNotARealTable") == []
 
@@ -325,7 +325,7 @@ class TestAnalyzeIndexHelpers:
 			{"Key_name": "idx_cust_date", "Seq_in_index": 1, "Column_name": "customer", "Non_unique": 1},
 		]
 		# _table_existing_indexes now delegates to the dialect adapter, which
-		# reads the global ``frappe.db`` — patch that (the dialect tests' shape).
+		# reads the global ``frappe.db``: patch that (the dialect tests' shape).
 		import frappe
 		monkeypatch.setattr(
 			frappe, "db",
@@ -342,7 +342,7 @@ class TestAnalyzeIndexHelpers:
 	def test_table_index_sample_queries_picks_selects_on_table(self):
 		recs = [{"calls": [
 			{"query": "SELECT name FROM `tabSales Invoice` WHERE customer = ? AND status = ?"},
-			{"query": "SELECT name FROM `tabSales Invoice` WHERE customer = ? AND status = ?"},  # dupe — deduped
+			{"query": "SELECT name FROM `tabSales Invoice` WHERE customer = ? AND status = ?"},  # dupe deduped
 			{"query": "UPDATE `tabSales Invoice` SET status = ? WHERE name = ?"},                 # not a SELECT
 			{"query": "SELECT name FROM `tabItem` WHERE item_code = ?"},                          # other table
 		]}]
@@ -377,7 +377,7 @@ class TestAnalyzeIndexHelpers:
 
 
 # --------------------------------------------------------------------------
-# api.suggest_index — source-inspection contract
+# api.suggest_index source-inspection contract
 # --------------------------------------------------------------------------
 
 def _api_src():

--- a/optimus/tests/test_index_suggestions.py
+++ b/optimus/tests/test_index_suggestions.py
@@ -88,7 +88,7 @@ def test_single_suggestion_per_table_column(monkeypatch, empty_context):
 
 def test_optimizer_skipped_when_dialect_unsupported(monkeypatch, empty_context):
 	"""On a dialect whose ``supports_query_optimizer`` is False (Postgres),
-	the analyzer must NOT invoke Frappe's DBOptimizer at all — it returns a
+	the analyzer must NOT invoke Frappe's DBOptimizer at all it returns a
 	single explanatory warning and no findings, and never calls
 	``_optimize_query``.
 
@@ -132,7 +132,7 @@ def test_optimizer_skipped_when_dialect_unsupported(monkeypatch, empty_context):
 def test_parser_limitation_valueerror_gets_soft_warning(monkeypatch, empty_context):
 	"""v0.5.1: ValueError from sql_metadata is a parser limitation, not
 	a bug we should scream about. It must produce the soft "Skipped N
-	queries whose shape exceeds the parser" warning — NOT the loud
+	queries whose shape exceeds the parser" warning NOT the loud
 	"Could not analyze" warning that tells users to check Error Log.
 	And it must NOT write to frappe.log_error."""
 
@@ -141,7 +141,7 @@ def test_parser_limitation_valueerror_gets_soft_warning(monkeypatch, empty_conte
 
 	_install_fake_recorder_module(monkeypatch, fake_optimize)
 
-	# Track whether log_error was called — parser limitations must NOT
+	# Track whether log_error was called parser limitations must NOT
 	# end up in Frappe's Error Log.
 	log_error_calls = []
 	import frappe
@@ -182,7 +182,7 @@ def test_parser_limitation_valueerror_gets_soft_warning(monkeypatch, empty_conte
 		f"Expected soft parser-limit warning; got: {result.warnings}"
 	)
 	assert "Could not analyze" not in result.warnings[0], (
-		"ValueError is a parser limitation — must not use the "
+		"ValueError is a parser limitation must not use the "
 		"loud 'Could not analyze / see Error Log' phrasing"
 	)
 	# And crucially: no Error Log entry for parser limitations.
@@ -194,7 +194,7 @@ def test_parser_limitation_valueerror_gets_soft_warning(monkeypatch, empty_conte
 
 def test_real_error_still_produces_loud_warning_and_logs(monkeypatch, empty_context):
 	"""Unexpected exception types (not ValueError/TypeError) may indicate
-	a profiler bug — those still get the loud warning + Error Log entries
+	a profiler bug those still get the loud warning + Error Log entries
 	so the team can investigate."""
 
 	def fake_optimize(query: str):
@@ -284,7 +284,7 @@ def _install_fake_frappe_db(monkeypatch, indexed_columns_by_table, column_types_
             cols = indexed_columns_by_table.get(table, set())
             # Realistic SHOW INDEX rows: each leftmost-indexed column is the
             # seq-1 column of its own single-column index. Real MariaDB always
-            # returns Key_name / Non_unique — the dialect groups on them.
+            # returns Key_name / Non_unique the dialect groups on them.
             return [
                 {"Key_name": f"idx_{c}", "Column_name": c, "Seq_in_index": 1, "Non_unique": 1}
                 for c in cols
@@ -319,7 +319,7 @@ def test_already_indexed_column_is_suppressed(monkeypatch, empty_context):
     """v0.5.1 architect-review finding: Missing Index must check
     existing indexes before suggesting one. A suggestion for a
     column that's already the leftmost of an existing index is a
-    false positive — the DB already has the index the user would
+    false positive the DB already has the index the user would
     'add.' Suppress it and surface a warning."""
 
     def fake_optimize(query):
@@ -351,7 +351,7 @@ def test_already_indexed_column_is_suppressed(monkeypatch, empty_context):
     missing = [f for f in result.findings if f["finding_type"] == "Missing Index"]
     assert missing == [], (
         "Already-indexed column must NOT produce a Missing Index finding. "
-        "The DBOptimizer heuristic doesn't check existing indexes — that's "
+        "The DBOptimizer heuristic doesn't check existing indexes that's "
         "our job before emitting."
     )
     # And a warning must explain the suppression.
@@ -424,7 +424,7 @@ def test_text_column_gets_prefix_index_ddl(monkeypatch, empty_context):
     missing = [f for f in result.findings if f["finding_type"] == "Missing Index"]
     assert len(missing) == 1
     detail = json.loads(missing[0]["technical_detail_json"])
-    # DDL must include a prefix length — something like `body`(255).
+    # DDL must include a prefix length something like `body`(255).
     ddl = detail["suggested_ddl"]
     assert "`body`(" in ddl or "body(" in ddl, (
         f"TEXT column DDL must include prefix length; got: {ddl}"
@@ -568,7 +568,7 @@ def test_classifier_caches_per_table(monkeypatch, empty_context):
     # Two distinct findings (col_a, col_b on same table).
     missing = [f for f in result.findings if f["finding_type"] == "Missing Index"]
     assert len(missing) == 2
-    # But only ONE SHOW INDEX call and ONE information_schema call —
+    # But only ONE SHOW INDEX call and ONE information_schema call
     # the classifier cached per-table.
     assert len(show_index_calls) == 1, (
         f"Expected 1 SHOW INDEX call (cached per table), got {len(show_index_calls)}"
@@ -623,7 +623,7 @@ def test_non_select_statements_are_skipped_without_failures(monkeypatch, empty_c
 
 	Pre-v0.5.1, these were counted as 'parse failures' and polluted the
 	report with a warning saying 'Could not analyze 47% of your queries',
-	which was misleading — the queries weren't optimization targets to
+	which was misleading the queries weren't optimization targets to
 	begin with.
 	"""
 	optimize_call_count = {"n": 0}
@@ -667,7 +667,7 @@ def test_non_select_statements_are_skipped_without_failures(monkeypatch, empty_c
 
 	result = index_suggestions.analyze([recording], empty_context)
 
-	# The optimizer must not have been called at all — everything was
+	# The optimizer must not have been called at all everything was
 	# filtered by query type first.
 	assert optimize_call_count["n"] == 0, (
 		f"Non-SELECT statements must be skipped before reaching "
@@ -683,7 +683,7 @@ def test_non_select_statements_are_skipped_without_failures(monkeypatch, empty_c
 		f"Expected a 'Skipped N non-SELECT' warning; got: {result.warnings}"
 	)
 
-	# And crucially — there must NOT be a "Could not analyze" parse-failure
+	# And crucially there must NOT be a "Could not analyze" parse-failure
 	# warning, because nothing actually failed.
 	assert not any("Could not analyze" in w for w in result.warnings), (
 		f"Non-SELECT skips must not be reported as parse failures; "
@@ -770,8 +770,8 @@ def test_select_with_leading_comment_is_still_recognised(monkeypatch, empty_cont
 #   ValueError: too many values to unpack (expected 2, got 4)
 #
 # Pre-fix: this showed up as an Error Log entry ("optimus optimizer
-# failure") AND a loud "Could not analyze 1 of N queries — see Error Log"
-# warning. Neither is actionable — the user cannot rewrite the ERPNext
+# failure") AND a loud "Could not analyze 1 of N queries see Error Log"
+# warning. Neither is actionable the user cannot rewrite the ERPNext
 # core query and cannot add an index to fix a parse failure. v0.5.1
 # classifies these as parser limitations (soft informational warning, no
 # Error Log noise).
@@ -818,7 +818,7 @@ def test_erpnext_item_search_valueerror_is_soft_skip(monkeypatch, empty_context)
 	sql_metadata. The analyzer must:
 
 	  1. Not crash (continue processing other queries)
-	  2. Not write to frappe.log_error — it's not a profiler bug
+	  2. Not write to frappe.log_error it's not a profiler bug
 	  3. Emit the soft 'Skipped N queries whose shape exceeds…' warning
 	  4. Still produce index suggestions for OTHER queries in the same
 	     session that DO parse cleanly
@@ -864,7 +864,7 @@ def test_erpnext_item_search_valueerror_is_soft_skip(monkeypatch, empty_context)
 				"stack": [],
 			},
 			# A clean query that DOES produce a suggestion, alongside
-			# the problematic one — verifies mixed behavior.
+			# the problematic one verifies mixed behavior.
 			{
 				"query": "SELECT * FROM tabLead WHERE status = 'Open'",
 				"normalized_query": "SELECT * FROM tabLead WHERE status = ?",
@@ -937,11 +937,11 @@ def test_typeerror_from_optimizer_is_also_a_soft_skip(monkeypatch, empty_context
 
 
 def test_modified_column_is_never_suggested(monkeypatch, empty_context):
-	"""'modified' is a Frappe metadata column — updated on every save.
+	"""'modified' is a Frappe metadata column updated on every save.
 	Indexing it causes write amplification that outweighs any read-side
 	gain. Must never be suggested, even when the DBOptimizer heuristic
 	points at it. (Origin: a production report surfaced 'Add index on
-	tabDocType(modified)' — user feedback: 'Modified fields can't be
+	tabDocType(modified)' user feedback: 'Modified fields can't be
 	indexed as it would affect the system performance.' We use a non-meta
 	table here so it's the *column* blacklist being exercised, not the
 	separate meta-table rule that also covers tabDocType.)
@@ -982,7 +982,7 @@ def test_modified_column_is_never_suggested(monkeypatch, empty_context):
 	result = index_suggestions.analyze([recording], empty_context)
 	missing = [f for f in result.findings if f["finding_type"] == "Missing Index"]
 	assert missing == [], (
-		"Suggestion on tabSales Invoice.modified must be suppressed — "
+		"Suggestion on tabSales Invoice.modified must be suppressed "
 		f"modified is a Frappe metadata column. Got: {missing}"
 	)
 
@@ -1070,7 +1070,7 @@ def test_never_suggest_skips_schema_lookup(monkeypatch, empty_context):
 	result = index_suggestions.analyze([recording], empty_context)
 	assert result.findings == []
 	# Classifier's schema lookups must not have run for blacklisted
-	# columns — we can drop without checking anything else.
+	# columns we can drop without checking anything else.
 	for sql in sql_calls:
 		assert "SHOW INDEX" not in sql, (
 			f"Classifier ran SHOW INDEX for a blacklisted column: {sql}"
@@ -1082,7 +1082,7 @@ def test_never_suggest_skips_schema_lookup(monkeypatch, empty_context):
 
 def test_frappe_metadata_columns_are_never_suggested(monkeypatch, empty_context):
 	"""v0.6.0: the blacklist now covers the WHOLE Frappe standard-metadata
-	column set — `creation`, `owner`, `idx`, `parent`, `docstatus`, … —
+	column set `creation`, `owner`, `idx`, `parent`, `docstatus`, …
 	not just the per-save-mutated `modified`/`modified_by`. Even though
 	`creation`/`owner` are insert-only (no write amplification), surfacing
 	them nudges developers toward a class of change they should make
@@ -1139,7 +1139,7 @@ def test_frappe_metadata_columns_are_never_suggested(monkeypatch, empty_context)
 
 def test_frappe_meta_tables_are_never_suggested(monkeypatch, empty_context):
 	"""v0.6.0: no index suggestion is emitted on a Frappe framework "meta"
-	table (tabDocType / tabCustom Field / tabSingles / …) — `bench migrate`
+	table (tabDocType / tabCustom Field / tabSingles / …) `bench migrate`
 	owns those tables' schema, so a hand-added index is pointless. The
 	suggestion is dropped before it's even bucketed (no schema lookup), and
 	a single warning names the tables."""
@@ -1153,7 +1153,7 @@ def test_frappe_meta_tables_are_never_suggested(monkeypatch, empty_context):
 
 	_install_fake_recorder_module(monkeypatch, fake_optimize)
 	# A fake DB so a stray classify lookup would be visible (it must NOT
-	# happen — the meta-table check runs before classify).
+	# happen the meta-table check runs before classify).
 	import frappe
 	sql_calls: list[str] = []
 
@@ -1224,12 +1224,12 @@ def test_low_per_query_savings_suggestion_is_suppressed(monkeypatch, empty_conte
 
 	result = index_suggestions.analyze([recording], empty_context)
 
-	# No Missing Index finding despite 892ms cumulative — per-query savings
+	# No Missing Index finding despite 892ms cumulative per-query savings
 	# are below the floor.
 	missing = [f for f in result.findings if f["finding_type"] == "Missing Index"]
 	assert missing == [], (
 		"A suggestion with 0.58ms average savings per query must be "
-		f"suppressed — individual queries are already fast enough. "
+		f"suppressed individual queries are already fast enough. "
 		f"Got findings: {[f['title'] for f in missing]}"
 	)
 
@@ -1309,7 +1309,7 @@ def test_high_per_query_savings_still_emits(monkeypatch, empty_context):
 		{
 			"query": f"SELECT * FROM tabReport WHERE department = 'd{i}'",
 			"normalized_query": "SELECT * FROM tabReport WHERE department = ?",
-			"duration": 55.0,  # 55ms per query — well above 2ms floor
+			"duration": 55.0,  # 55ms per query well above 2ms floor
 			"stack": [],
 		}
 		for i in range(10)
@@ -1371,7 +1371,7 @@ def test_per_query_floor_boundary_at_exactly_2ms(monkeypatch, empty_context):
 
 
 def test_get_query_type_helper_direct():
-	"""Direct unit test of the _get_query_type helper — covers the
+	"""Direct unit test of the _get_query_type helper covers the
 	regex edge cases without the full analyzer path."""
 	from optimus.analyzers.index_suggestions import _get_query_type
 
@@ -1394,7 +1394,7 @@ def test_get_query_type_helper_direct():
 
 def test_classify_column_blacklists_every_frappe_metadata_column():
 	"""v0.6.0: `_classify_column` returns `never_suggest` for every column in
-	the Frappe standard-metadata set — checked before any DB lookup, so it
+	the Frappe standard-metadata set checked before any DB lookup, so it
 	works in a no-site test env."""
 	from optimus.analyzers.base import FRAPPE_METADATA_COLUMNS
 	from optimus.analyzers.index_suggestions import _classify_column
@@ -1406,7 +1406,7 @@ def test_classify_column_blacklists_every_frappe_metadata_column():
 	# Case-insensitive.
 	assert _classify_column("tabFoo", "Creation", {}, {})[0] == "never_suggest"
 	assert _classify_column("tabFoo", "  MODIFIED ", {}, {})[0] == "never_suggest"
-	# A business column is NOT blacklisted — in a no-DB env it falls through
+	# A business column is NOT blacklisted in a no-DB env it falls through
 	# to the legacy "unknown" path (plain DDL kept, not suppressed).
 	assert _classify_column("tabFoo", "customer", {}, {})[0] == "unknown"
 
@@ -1415,7 +1415,7 @@ class TestIsSafeTableName:
 	"""v0.6.x: ``_is_safe_table_name`` whitelists the only two table-name
 	shapes ``_get_indexed_columns`` is allowed to interpolate into raw
 	``SHOW INDEX FROM`` SQL. Everything else routes to an empty-set
-	fallback before the DB is touched — fixes the Lens audit's SQL-
+	fallback before the DB is touched fixes the Lens audit's SQL-
 	injection finding at index_suggestions.py:198."""
 
 	def test_accepts_tab_doctype_names(self):
@@ -1450,13 +1450,13 @@ class TestIsSafeTableName:
 
 	def test_rejects_non_tab_table_names(self):
 		from optimus.analyzers.index_suggestions import _is_safe_table_name
-		# Anything outside the tab<…>/information_schema.<…> shapes — no
+		# Anything outside the tab<…>/information_schema.<…> shapes no
 		# legitimate caller passes these, so they must be rejected.
 		assert _is_safe_table_name("user") is False  # no tab prefix
 		assert _is_safe_table_name("mysql.user") is False  # other schema
 		assert _is_safe_table_name("performance_schema.events_statements_summary") is False
 		assert _is_safe_table_name("foo.tabUser") is False  # schema-prefixed
-		# Unicode oddities — conservative reject.
+		# Unicode oddities conservative reject.
 		assert _is_safe_table_name("tabUser™") is False
 
 	def test_defensive_against_non_string_input(self):
@@ -1471,7 +1471,7 @@ class TestIsSafeTableName:
 class TestGetIndexedColumnsGuard:
 	"""The SHOW INDEX FROM call routes through ``_is_safe_table_name``
 	before touching the DB. An unsafe name must not reach ``frappe.db.sql``
-	at all — proven by raising loudly from the patched stub."""
+	at all proven by raising loudly from the patched stub."""
 
 	def test_unsafe_table_name_returns_empty_set_without_sql(self):
 		import sys
@@ -1481,7 +1481,7 @@ class TestGetIndexedColumnsGuard:
 		stub = types.ModuleType("frappe")
 		def _explode(*args, **kwargs):
 			raise AssertionError(
-				"SHOW INDEX FROM reached frappe.db.sql with an unsafe name — "
+				"SHOW INDEX FROM reached frappe.db.sql with an unsafe name "
 				"the guard at index_suggestions._get_indexed_columns is broken"
 			)
 		stub.db = types.SimpleNamespace(sql=_explode)

--- a/optimus/tests/test_infra_capture.py
+++ b/optimus/tests/test_infra_capture.py
@@ -16,7 +16,7 @@ def test_redis_source_uses_frappe_cache_directly(monkeypatch):
 	code must call .info() directly on frappe.cache.
 
 	We check by actually running _read_redis against a stub that
-	rejects the broken access pattern — more robust than source-string
+	rejects the broken access pattern more robust than source-string
 	matching which can match explanatory comments.
 	"""
 	import frappe
@@ -39,7 +39,7 @@ def test_redis_source_uses_frappe_cache_directly(monkeypatch):
 		def __getattr__(self, name):
 			if name == "redis":
 				raise AssertionError(
-					"_read_redis must not access frappe.cache.redis — "
+					"_read_redis must not access frappe.cache.redis "
 					"frappe.cache IS the redis.Redis instance. Call "
 					"frappe.cache.info() directly."
 				)
@@ -53,14 +53,14 @@ def test_redis_source_uses_frappe_cache_directly(monkeypatch):
 	out = {"redis_instantaneous_ops_per_sec": None}
 	infra_capture._read_redis(out)
 	assert tripwire.info_called_on_root, (
-		"_read_redis never called frappe.cache.info() — the metric "
+		"_read_redis never called frappe.cache.info() the metric "
 		"is silently missing from every production snapshot"
 	)
 	assert out["redis_instantaneous_ops_per_sec"] == 99
 
 
 def test_rq_source_uses_frappe_cache_directly():
-	"""Companion guard for _read_rq — it must pass frappe.cache as the
+	"""Companion guard for _read_rq it must pass frappe.cache as the
 	rq.Queue connection, not getattr(frappe.cache, 'redis', None) which
 	would pass None and fall through to rq's default connection logic."""
 	import inspect
@@ -272,7 +272,7 @@ def _install_infra_stubs(monkeypatch, break_psutil=False):
             return []
 
     # frappe.cache IS a redis.Redis subclass in production (RedisWrapper),
-    # not a wrapper with a .redis child. The stub mirrors this — info()
+    # not a wrapper with a .redis child. The stub mirrors this info()
     # is a method directly on the cache instance, not on a child object.
     class FakeCache:
         def info(self, section=None):

--- a/optimus/tests/test_infra_pressure_analyzer.py
+++ b/optimus/tests/test_infra_pressure_analyzer.py
@@ -71,7 +71,7 @@ def test_memory_pressure_does_not_fire_on_small_delta():
 
 
 def test_memory_pressure_fires_on_large_rss_delta():
-    """Synthetic recordings where RSS grows by 300MB — must fire Medium
+    """Synthetic recordings where RSS grows by 300MB must fire Medium
     (delta > 200MB threshold but < 500MB critical)."""
     from optimus.analyzers import infra_pressure
 
@@ -260,7 +260,7 @@ def test_recordings_without_infra_are_ignored():
         {"uuid": "r2", "action_label": "b", "infra": _synth_infra(sys_cpu_percent=95)},
     ]
     result = infra_pressure.analyze(recordings, _empty_context())
-    # Only one action had infra — no sustained-breach finding possible.
+    # Only one action had infra no sustained-breach finding possible.
     rc = [f for f in result.findings if f["finding_type"] == "Resource Contention"]
     assert rc == []
     # Timeline should only include the action with infra.
@@ -350,7 +350,7 @@ def test_infra_timeline_falls_back_to_method_path_without_context():
 def test_infra_timeline_synthetic_only_as_last_resort():
     """If the recording truly has no method/path/cmd AND no matching
     context.actions entry, fall back to synthetic 'action_N'. This
-    is the only path that should produce the old noise — and only
+    is the only path that should produce the old noise and only
     when the analyzer has zero useful data to work with."""
     from optimus.analyzers import infra_pressure
     from optimus.analyzers.base import AnalyzeContext

--- a/optimus/tests/test_install_auto_role.py
+++ b/optimus/tests/test_install_auto_role.py
@@ -78,7 +78,7 @@ def test_auto_assign_role_adds_to_system_managers(monkeypatch):
 	assert users_in_db["bob@example.com"].added_roles == []
 	# Carol (already has both) → not touched
 	assert users_in_db["carol@example.com"].added_roles == []
-	# Critical perf assertion: only Alice was loaded as a full doc — NOT
+	# Critical perf assertion: only Alice was loaded as a full doc NOT
 	# Bob (doesn't qualify) and NOT Carol (already has the role).
 	assert get_doc_calls == ["alice@example.com"], (
 		f"expected ONLY alice loaded as doc, got {get_doc_calls!r}"
@@ -114,7 +114,7 @@ class _FakeSettings:
 
 	def __init__(self, ignored_apps_rows=None):
 		# ignored_apps mirrors how Frappe represents a child table on a
-		# Single — a list (truthy if rows exist, falsy if empty).
+		# Single a list (truthy if rows exist, falsy if empty).
 		self.ignored_apps = list(ignored_apps_rows or [])
 		self.appended = []
 		self.save_count = 0
@@ -133,7 +133,7 @@ def _stub_seeder_frappe(monkeypatch, *, settings, doctype_exists=True, installed
 	to run end-to-end without a real bench.
 
 	``frappe.db`` is a Werkzeug ``LocalProxy`` ([[feedback_frappe_db_local_proxy]])
-	— patching attributes on it raises ``RuntimeError: object is not bound``
+	patching attributes on it raises ``RuntimeError: object is not bound``
 	outside a request context. Replace it wholesale with a SimpleNamespace
 	carrying just the ``exists`` method the seeder calls.
 
@@ -167,7 +167,7 @@ def _stub_seeder_frappe(monkeypatch, *, settings, doctype_exists=True, installed
 		lambda: list(installed_apps),
 		raising=False,
 	)
-	# safe_commit is imported into install.py at module top — patch the
+	# safe_commit is imported into install.py at module top patch the
 	# local binding so the seeder doesn't reach the real one.
 	monkeypatch.setattr(install, "safe_commit", lambda: None, raising=False)
 
@@ -195,7 +195,7 @@ class TestSeedIgnoredAppsWithFrameworkApps:
 			{"app_name": "payments"},
 			{"app_name": "wiki"},
 		]
-		# Single save call — the seeder must not save per-row.
+		# Single save call the seeder must not save per-row.
 		assert settings.save_count == 1
 
 	def test_non_empty_table_is_NOT_overwritten(self, monkeypatch):
@@ -214,7 +214,7 @@ class TestSeedIgnoredAppsWithFrameworkApps:
 		assert settings.ignored_apps == existing
 
 	def test_no_doctype_yet_is_a_silent_noop(self, monkeypatch):
-		# Migration hasn't run yet — DocType doesn't exist. Seeder must
+		# Migration hasn't run yet DocType doesn't exist. Seeder must
 		# return cleanly (mirrors the tracked-apps seed's early-return).
 		settings = _FakeSettings(ignored_apps_rows=[])
 		_stub_seeder_frappe(monkeypatch, settings=settings, doctype_exists=False)
@@ -226,7 +226,7 @@ class TestSeedIgnoredAppsWithFrameworkApps:
 
 	def test_only_installed_apps_get_seeded(self, monkeypatch):
 		# The seeder intersects _DEFAULT_IGNORED_APPS with what's actually
-		# installed — seeding an app that isn't installed is pure UI
+		# installed seeding an app that isn't installed is pure UI
 		# clutter (it can't produce findings). Typical custom-app stack:
 		# frappe + the operator's own app.
 		settings = _FakeSettings(ignored_apps_rows=[])
@@ -239,7 +239,7 @@ class TestSeedIgnoredAppsWithFrameworkApps:
 
 		# Only frappe (the only _DEFAULT_IGNORED_APPS member that's
 		# installed) lands. The custom app ``ugly_code`` is not in the
-		# defaults so it's left alone — that's the tracked-apps seeder's
+		# defaults so it's left alone that's the tracked-apps seeder's
 		# job.
 		assert settings.appended == [{"app_name": "frappe"}]
 		assert settings.save_count == 1
@@ -259,7 +259,7 @@ class TestSeedIgnoredAppsWithFrameworkApps:
 		assert settings.save_count == 0
 
 	def test_partial_install_preserves_alphabetical_order(self, monkeypatch):
-		# A handful of defaults installed — the seeded rows preserve the
+		# A handful of defaults installed the seeded rows preserve the
 		# _DEFAULT_IGNORED_APPS tuple order (alphabetical), not the order
 		# of frappe.get_installed_apps's return value.
 		settings = _FakeSettings(ignored_apps_rows=[])

--- a/optimus/tests/test_janitor_batched_updates.py
+++ b/optimus/tests/test_janitor_batched_updates.py
@@ -7,7 +7,7 @@ a loop now calls it ONCE with a ``{"name": ("in", [...])}`` filter, and
 ``_sweep_old_sessions`` preloads every File-doc name in a single
 ``frappe.get_all`` instead of looking each up per row.
 
-We stub ``frappe`` so these tests run pure (no bench / no MariaDB) — via
+We stub ``frappe`` so these tests run pure (no bench / no MariaDB) via
 ``monkeypatch.setitem(sys.modules, ...)`` so the real ``frappe`` (plus
 the lazy submodules) is restored at teardown. Without that, every test
 running AFTER one of these in the same pytest session inherits our
@@ -22,7 +22,7 @@ def _install_frappe_stub(monkeypatch):
 	"""Build a minimal ``frappe`` stub the janitor module can import.
 
 	All ``sys.modules`` mutations go through ``monkeypatch.setitem`` so
-	pytest restores the originals at teardown — that's the entire point
+	pytest restores the originals at teardown that's the entire point
 	of routing through this helper instead of bare assignments."""
 	stub = types.ModuleType("frappe")
 	stub._set_value_calls = []
@@ -83,8 +83,8 @@ def _install_frappe_stub(monkeypatch):
 	session_mod.clear_active_session = lambda user: None
 	session_mod.get_active_session_for = lambda user: stub._active_pointers.get(user)
 	monkeypatch.setitem(sys.modules, "optimus.session", session_mod)
-	# janitor binds via ``from optimus import session`` — that reads the package
-	# ATTRIBUTE, not just sys.modules — so patch the attribute too or the reload
+	# janitor binds via ``from optimus import session``: that reads the package
+	# ATTRIBUTE, not just sys.modules so patch the attribute too or the reload
 	# picks up the real session module (which needs a live frappe.cache).
 	import optimus as _optimus_pkg
 	monkeypatch.setattr(_optimus_pkg, "session", session_mod, raising=False)
@@ -120,7 +120,7 @@ def _reload_janitor(monkeypatch):
 
 
 # --------------------------------------------------------------------------
-# Stale Recording sweep — single batched UPDATE.
+# Stale Recording sweep single batched UPDATE.
 # --------------------------------------------------------------------------
 
 class TestSweepStaleRecording:
@@ -142,7 +142,7 @@ class TestSweepStaleRecording:
 		assert filters == {"name": ("in", ["PS-1", "PS-2", "PS-3"])}
 		assert fields["status"] == "Stopping"
 		assert "stopped_at" in fields
-		# Per-row enqueue side effects still fire — once per row.
+		# Per-row enqueue side effects still fire once per row.
 		assert len(stub._enqueue_calls) == 3
 
 	def test_no_set_value_when_no_stale_rows(self, monkeypatch):
@@ -154,7 +154,7 @@ class TestSweepStaleRecording:
 
 	def test_live_recording_with_active_pointer_is_not_stopped(self, monkeypatch):
 		"""A long but LIVE recording (its Redis active pointer still points to it)
-		must not be force-stopped just because started_at crossed the cutoff —
+		must not be force-stopped just because started_at crossed the cutoff
 		only rows whose pointer expired / moved are stopped."""
 		stub = _install_frappe_stub(monkeypatch)
 		stub._get_all_return["Optimus Session"] = [
@@ -173,7 +173,7 @@ class TestSweepStaleRecording:
 
 
 # --------------------------------------------------------------------------
-# Stuck Analyzing sweep — single batched UPDATE.
+# Stuck Analyzing sweep single batched UPDATE.
 # --------------------------------------------------------------------------
 
 class TestSweepStuckAnalyzing:
@@ -202,7 +202,7 @@ class TestSweepStuckAnalyzing:
 	def test_live_singleflight_holder_is_not_failed(self, monkeypatch):
 		"""A long-but-live analyze (still heartbeating the single-flight flag)
 		must NOT be force-failed even though its row crossed the staleness
-		threshold — only the genuinely-wedged row is failed."""
+		threshold only the genuinely-wedged row is failed."""
 		stub = _install_frappe_stub(monkeypatch)
 		stub._get_all_return["Optimus Session"] = [
 			{"name": "PS-LIVE", "session_uuid": "u-live"},   # still heartbeating
@@ -221,7 +221,7 @@ class TestSweepStuckAnalyzing:
 
 
 # --------------------------------------------------------------------------
-# Stale Stopping sweep — re-enqueue analyze for sessions stranded at Stopping.
+# Stale Stopping sweep re-enqueue analyze for sessions stranded at Stopping.
 # --------------------------------------------------------------------------
 
 class TestSweepStaleStopping:
@@ -263,14 +263,14 @@ class TestSweepStaleStopping:
 
 
 # --------------------------------------------------------------------------
-# Stale Phase-2 sweep — one batched UPDATE per branch (Recording + Analyzing).
+# Stale Phase-2 sweep one batched UPDATE per branch (Recording + Analyzing).
 # --------------------------------------------------------------------------
 
 class TestSweepStalePhase2Runs:
 	def test_one_set_value_call_per_branch(self, monkeypatch):
 		stub = _install_frappe_stub(monkeypatch)
 		# The janitor calls get_all twice on "Optimus Phase Two Run" (formerly
-		# "Optimus Phase 2 Run" before the v0.6.x Title-Case rename) — once for
+		# "Optimus Phase 2 Run" before the v0.6.x Title-Case rename) once for
 		# Recording rows, once for Analyzing. We return DIFFERENT row sets on
 		# each call, so the side-effect channel needs an index counter.
 		rec_rows = [
@@ -298,9 +298,9 @@ class TestSweepStalePhase2Runs:
 		set_value_calls = [c for c in stub._set_value_calls if c[0] == "Optimus Phase Two Run"]
 		# Exactly 2 batched set_values (one per branch).
 		assert len(set_value_calls) == 2
-		# Recording branch — first call.
+		# Recording branch first call.
 		assert set_value_calls[0][1] == {"name": ("in", ["PR-rec-1", "PR-rec-2"])}
-		# Analyzing branch — second call.
+		# Analyzing branch second call.
 		assert set_value_calls[1][1] == {"name": ("in", ["PR-ana-1"])}
 
 	def test_no_set_value_when_no_phase2_rows(self, monkeypatch):
@@ -313,7 +313,7 @@ class TestSweepStalePhase2Runs:
 
 
 # --------------------------------------------------------------------------
-# _delete_older_than_days (a.k.a. _sweep_old_sessions) — ONE bulk File fetch.
+# _delete_older_than_days (a.k.a. _sweep_old_sessions) ONE bulk File fetch.
 # --------------------------------------------------------------------------
 
 class TestSweepOldSessionsBulkFileFetch:
@@ -345,7 +345,7 @@ class TestSweepOldSessionsBulkFileFetch:
 		janitor = _reload_janitor(monkeypatch)
 		janitor._sweep_old_sessions()
 
-		# EXACTLY one get_all call against "File" — not 6.
+		# EXACTLY one get_all call against "File" not 6.
 		file_calls = [c for c in stub._get_all_calls if c[0] == "File"]
 		assert len(file_calls) == 1, (
 			f"expected ONE batched File lookup, got {len(file_calls)}: {file_calls}"
@@ -357,14 +357,14 @@ class TestSweepOldSessionsBulkFileFetch:
 			"/private/files/r1.html", "/private/files/r1.pdf",
 			"/private/files/r2.html", "/private/files/r2.pdf",
 		}
-		# Session deletion fires per row (that part isn't batched — it's a
+		# Session deletion fires per row (that part isn't batched it's a
 		# delete with permissions + lifecycle events).
 		ps_delete_calls = [c for c in stub._delete_doc_calls if c[0][0] == "Optimus Session"]
 		assert len(ps_delete_calls) == 3
 
 
 # --------------------------------------------------------------------------
-# v0.13.x: ``session_retention_days = 0`` means keep forever — the daily
+# v0.13.x: ``session_retention_days = 0`` means keep forever the daily
 # sweep early-returns without deleting anything. Closes the gap where the
 # pre-v0.13.x ``or DEFAULT_RETENTION_DAYS`` silently fell back to 90 and
 # made the field description's "Set to 0 to keep forever" promise a lie.
@@ -394,7 +394,7 @@ class TestSweepOldSessionsForeverRetention:
 
 		janitor._sweep_old_sessions()
 
-		# No queries at all — the early-return fired before the
+		# No queries at all the early-return fired before the
 		# Optimus Session get_all.
 		session_calls = [c for c in stub._get_all_calls if c[0] == "Optimus Session"]
 		assert session_calls == [], (

--- a/optimus/tests/test_lens_promo.py
+++ b/optimus/tests/test_lens_promo.py
@@ -5,7 +5,7 @@
 
 A small one-line promo block sits right under the Jump-to nav in the
 report header area, pointing at lens.aerele.in. It's hardcoded in the
-template (no Optimus Settings toggle by design — single focused
+template (no Optimus Settings toggle by design single focused
 mention, not a configurable list).
 
 These tests pin the block's presence, position relative to the Jump-to
@@ -50,7 +50,7 @@ def _doc():
 
 class TestLensPromoRendering:
 	def test_block_renders_exactly_once(self):
-		"""Promo is hardcoded — should appear on every report, exactly once."""
+		"""Promo is hardcoded should appear on every report, exactly once."""
 		html = renderer.render_raw(_doc(), recordings=[])
 		assert html.count('class="section lens-promo"') == 1
 
@@ -91,7 +91,7 @@ class TestLensPromoRendering:
 
 	def test_block_is_self_contained(self):
 		"""The Lens block must be inert text + a single <a> tag. No
-		<img>, <link rel="...">, or <script> — those would break the
+		<img>, <link rel="...">, or <script> those would break the
 		saved-HTML offline guarantee on click-free render."""
 		html = renderer.render_raw(_doc(), recordings=[])
 		start = html.find('<aside class="section lens-promo"')
@@ -102,5 +102,5 @@ class TestLensPromoRendering:
 		assert "<img " not in block
 		assert "<link " not in block
 		assert "<script" not in block.lower()
-		# The single anchor element is fine — it's inert until clicked.
+		# The single anchor element is fine it's inert until clicked.
 		assert block.count("<a ") == 1

--- a/optimus/tests/test_line_drilldown_matching.py
+++ b/optimus/tests/test_line_drilldown_matching.py
@@ -4,9 +4,9 @@
 """The finding-card "Line-Level Drilldown" callout links a finding to its
 phase-2 hot line via (file-basename, function-name). The index is keyed on the
 phase-2 result's ``qualname``; the lookup uses the finding's callsite
-``function``. These can disagree on the prefix — ``resolve_freeform`` may emit
+``function``. These can disagree on the prefix ``resolve_freeform`` may emit
 ``common.bg_recheck_users`` (module/class walked) while call_tree stores the
-bare ``bg_recheck_users`` — which silently breaks the callout even though the
+bare ``bg_recheck_users``: which silently breaks the callout even though the
 function WAS profiled (and shows in the panel). Matching must be robust to that
 on both sides; this pins it.
 """

--- a/optimus/tests/test_line_profile_analyzer.py
+++ b/optimus/tests/test_line_profile_analyzer.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for optimus.line_profile.analyzer.analyze — the pure
+"""Tests for optimus.line_profile.analyzer.analyze the pure
 function that turns aggregated line-profile results into findings + per-
 function aggregate."""
 
@@ -109,7 +109,7 @@ class TestHotLineFinding:
 
 	def test_below_threshold_total_ms_no_finding(self):
 		# Even though one line is 100% of the function's time, total is
-		# only 30ms — below the 50ms Medium floor → no finding.
+		# only 30ms below the 50ms Medium floor → no finding.
 		fn = _function("my_app.x", [
 			_line(1, "trivial()", 1, 30.0),
 			_line(2, "more = 2", 1, 0.0),
@@ -141,7 +141,7 @@ class TestHotLineFinding:
 class TestFunctionNotInvoked:
 	# v0.7.x: a picked-but-uninvoked function no longer emits a per-function
 	# "Function Not Invoked" finding (it cluttered the Findings list). It's
-	# folded into ONE consolidated warning instead — the report stays clean.
+	# folded into ONE consolidated warning instead the report stays clean.
 	def test_empty_lines_emits_warning_not_finding(self):
 		fn = _function("my_app.never_runs", [])
 
@@ -236,7 +236,7 @@ class TestLeafPickAndChain:
 		result = analyzer.analyze([outer, inner])
 
 		hot = [f for f in result.findings if f["finding_type"] == "Hot Line"]
-		# Only one finding — the leaf.
+		# Only one finding the leaf.
 		assert len(hot) == 1
 		td = _json.loads(hot[0]["technical_detail_json"])
 		assert td["dotted_path"] == "my_app.common._check_user_exists"
@@ -279,7 +279,7 @@ class TestLeafPickAndChain:
 		assert [step["lineno"] for step in chain] == [2, 11, 21]
 
 	def test_leaf_only_function_finding_unchanged(self):
-		# Single function with a real leaf hot line — no chain, no hint.
+		# Single function with a real leaf hot line no chain, no hint.
 		fn = _function("my_app.x", [
 			_line(1, "for x in items:", 1000, 10.0),
 			_line(2, "    cache[x] = expensive(x)", 1000, 800.0),
@@ -294,7 +294,7 @@ class TestLeafPickAndChain:
 		assert "phase1_hint" not in td
 
 	def test_recursive_self_call_is_not_suppressed(self):
-		# A function that calls itself recursively — hot line is the
+		# A function that calls itself recursively hot line is the
 		# recursive call. Self-recursion shouldn't trigger pass-through
 		# suppression; the finding stands.
 		fn = _function("my_app.recur", [
@@ -361,7 +361,7 @@ class TestLeafPickAndChain:
 		assert "_check_user_exists" in hot[0]["customer_description"]
 
 	def test_no_phase1_hint_when_no_eligible_descendant(self):
-		# Hot line content doesn't look like a call site — no hint.
+		# Hot line content doesn't look like a call site no hint.
 		fn = _function("my_app.common.heavy_arith", [
 			_line(1, "def heavy_arith(n):", 1, 0.0),
 			_line(2, "    return sum(i*i for i in range(n))", 1, 600.0),  # not a call site
@@ -385,7 +385,7 @@ class TestLeafPickAndChain:
 
 
 # ---------------------------------------------------------------------------
-# Realtime targeting — phase-2 events must reach the session OWNER's Desk tab.
+# Realtime targeting phase-2 events must reach the session OWNER's Desk tab.
 # run_analyze runs in an RQ worker with no browser socket, so publish_realtime
 # needs an explicit user (a None target won't reach the form). This pins that
 # _publish forwards the payload's "user" as the target.

--- a/optimus/tests/test_line_profile_budget.py
+++ b/optimus/tests/test_line_profile_budget.py
@@ -6,7 +6,7 @@
 A time-budget watchdog auto-disengages line tracing mid-request so a hot-loop
 function can't freeze the user's flow. These tests pin the watchdog wiring and
 the budget-hit flag deterministically (fake profiler for the hooks; raw
-sys.monitoring registration for the disengage path — no real line_profiler
+sys.monitoring registration for the disengage path no real line_profiler
 enable, so line_profiler's process-global manager can't desync across tests).
 """
 
@@ -90,7 +90,7 @@ def test_budget_flag_roundtrip(env):
 
 
 def test_disengage_stops_events_without_freeing_tool(env):
-	"""The watchdog disengages line tracing by zeroing events — it must NOT
+	"""The watchdog disengages line tracing by zeroing events it must NOT
 	free_tool_id. Freeing the tool from the timer thread, mid-request, yanks it
 	out from under line_profiler's still-active manager; its own
 	``disable_by_count`` then fails ("tool 2 is not in use"), leaving an
@@ -159,7 +159,7 @@ def test_started_watchdog_disengages_after_budget(env):
 
 
 # --------------------------------------------------------------------------
-# hook wiring (fake profiler — deterministic)
+# hook wiring (fake profiler deterministic)
 # --------------------------------------------------------------------------
 
 def _arm_before(env, budget):

--- a/optimus/tests/test_line_profile_capture.py
+++ b/optimus/tests/test_line_profile_capture.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for optimus.line_profile.capture.aggregate_samples — the
+"""Tests for optimus.line_profile.capture.aggregate_samples the
 pure merge step that turns per-request line_profiler stats into the
 analyzer's input shape."""
 
@@ -141,7 +141,7 @@ class TestAggregateSamplesMultiplePicks:
 
 
 class _FakeStats:
-	"""Stand-in for ``line_profiler.LineStats`` — same attribute surface but
+	"""Stand-in for ``line_profiler.LineStats``: same attribute surface but
 	no install dependency on the package."""
 
 	def __init__(self, timings: dict, unit: float = 1e-6):
@@ -196,7 +196,7 @@ class TestSerializeStats:
 
 	def test_three_or_more_tuple_fields_handled(self):
 		# line_profiler may emit (lineno, hits, time, time_per_hit) or
-		# similar — serializer reads only the first three.
+		# similar serializer reads only the first three.
 		stats = _FakeStats(
 			timings={("/p/x.py", 1, "fn"): [(1, 4, 800, 200, "extra")]},
 		)

--- a/optimus/tests/test_line_profile_diff.py
+++ b/optimus/tests/test_line_profile_diff.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for optimus.line_profile.diff — content-hash line alignment
+"""Tests for optimus.line_profile.diff content-hash line alignment
 across phase-2 runs."""
 
 from optimus.line_profile import diff

--- a/optimus/tests/test_line_profile_job_capture.py
+++ b/optimus/tests/test_line_profile_job_capture.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 """End-to-end reproduction of Phase-2 line capture for a BACKGROUND-JOB
-function — the path P2/P3 assumed works but was never tested.
+function the path P2/P3 assumed works but was never tested.
 
 Drives the real capture functions in-process (no bench/worker): arm a pass,
 run the picked function through the before/after_job hooks, aggregate, and
@@ -83,7 +83,7 @@ def test_bg_job_line_capture_end_to_end(lp_env):
 	ugly_hot.bg_recheck_users(**job_kwargs)
 	lp_hooks.after_job_line_profile(method="ugly_hot.bg_recheck_users", kwargs=job_kwargs, result=None)
 
-	# 3. Aggregate — THE capture assertion: at least one line has real timing.
+	# 3. Aggregate THE capture assertion: at least one line has real timing.
 	samples = cap.read_all_samples(run_uuid)
 	picks = cap.read_picks_meta(run_uuid)
 	results = cap.aggregate_samples(samples, picks)
@@ -91,11 +91,11 @@ def test_bg_job_line_capture_end_to_end(lp_env):
 	lines = results[0]["lines"]
 	hot = [ln for ln in lines if (ln["hits"] or 0) > 0 and (ln["total_ms"] or 0) > 0]
 	assert hot, (
-		"Phase-2 captured NO per-line timing for the bg-job function — "
+		"Phase-2 captured NO per-line timing for the bg-job function "
 		f"samples={samples!r} results={results!r}"
 	)
 
-	# 4. Linking — the (basename, qualname) lookup the finding card uses.
+	# 4. Linking the (basename, qualname) lookup the finding card uses.
 	from optimus import renderer
 	doc = types.SimpleNamespace(phase_2_runs=[
 		types.SimpleNamespace(status="Ready", results_json=__import__("json").dumps(results)),

--- a/optimus/tests/test_line_profile_monitoring.py
+++ b/optimus/tests/test_line_profile_monitoring.py
@@ -37,7 +37,7 @@ def _hot():
 
 
 def _leak_tool():
-	"""Register tool 2 as ``line_profiler`` with line events on — exactly the
+	"""Register tool 2 as ``line_profiler`` with line events on exactly the
 	state a botched line_profiler teardown leaves behind. Done via raw
 	``sys.monitoring`` (not ``LineProfiler.enable_by_count``) so it can't desync
 	line_profiler's process-global manager across tests."""
@@ -116,7 +116,7 @@ def test_after_request_releases_tool_even_when_disable_fails(monkeypatch):
 	# and left tool 2 registered → process-wide tracing leak. Simulate that
 	# leaked state, then drive after_request with a profiler whose disable
 	# raises; the hook's finally-release must STILL clear tool 2.
-	# (Pre-fix this assertion fails — the leak survives.)
+	# (Pre-fix this assertion fails the leak survives.)
 	_leak_tool()
 	assert sys.monitoring.get_tool(PID) == "line_profiler"
 
@@ -137,7 +137,7 @@ def test_after_request_releases_tool_even_when_disable_fails(monkeypatch):
 # A worker that died mid-Phase-2 leaves tool 2 owned by ``line_profiler``;
 # on respawn, the next request inherits the orphan AND immediately gets
 # line-traced. The per-arm self-heal in line_profile/hooks.py catches it,
-# but ONLY when the next Phase 2 request fires — every interim request
+# but ONLY when the next Phase 2 request fires every interim request
 # pays the trace tax. The startup probe in optimus/__init__.py runs at
 # app-import and reclaims the orphan immediately. The pre-arm self-heal
 # stays as a per-request safety net, now with a LOUD log so the operator
@@ -195,7 +195,7 @@ def test_startup_probe_warns_about_unknown_owner_without_reclaiming(monkeypatch)
 
 	try:
 		optimus._startup_probe_tool2()
-		# Still owned — the probe must NOT touch a non-line_profiler tool.
+		# Still owned the probe must NOT touch a non-line_profiler tool.
 		assert sys.monitoring.get_tool(PID) == "some_other_profiler"
 		# Warning logged.
 		assert any(
@@ -228,7 +228,7 @@ def test_startup_probe_silent_when_no_owner(monkeypatch):
 
 
 def test_startup_probe_silent_on_python_without_sys_monitoring(monkeypatch):
-	"""Python 3.11 and earlier have no sys.monitoring — the probe must
+	"""Python 3.11 and earlier have no sys.monitoring the probe must
 	be a clean no-op (no exception, no warning)."""
 	import optimus
 
@@ -243,7 +243,7 @@ def test_startup_probe_silent_on_python_without_sys_monitoring(monkeypatch):
 
 def test_per_request_pre_arm_logs_when_reclaiming_orphan(monkeypatch):
 	"""The per-request self-heal in line_profile.hooks must log a WARN
-	when it actually reclaims an orphan — silent reclaim hid the leak
+	when it actually reclaims an orphan silent reclaim hid the leak
 	class in production for months."""
 	cap = _patch_logger(monkeypatch)
 
@@ -251,7 +251,7 @@ def test_per_request_pre_arm_logs_when_reclaiming_orphan(monkeypatch):
 	# no profiler on frappe.local.
 	_leak_tool()
 	# Drive just the self-heal block. We don't need a full before_request
-	# call (which would also need an active session) — exercising the
+	# call (which would also need an active session) exercising the
 	# inline check + log is sufficient for the regression invariant.
 	mon = sys.monitoring
 	if mon is not None and mon.get_tool(mon.PROFILER_ID) == "line_profiler":
@@ -270,7 +270,7 @@ def test_per_request_pre_arm_logs_when_reclaiming_orphan(monkeypatch):
 
 def test_pyproject_pins_line_profiler_5_x():
 	"""pyproject.toml must require line_profiler >= 5.x. The 4.x line
-	uses the legacy sys.settrace path which doesn't go through tool 2 —
+	uses the legacy sys.settrace path which doesn't go through tool 2
 	the leak fix in 6f66a43 only protects the 5.x sys.monitoring path."""
 	import os
 	import re
@@ -283,7 +283,7 @@ def test_pyproject_pins_line_profiler_5_x():
 	m = re.search(r'"line_profiler\s*(?P<spec>[^"]*)"', text)
 	assert m, "line_profiler dependency line not found in pyproject.toml"
 	spec = m.group("spec")
-	# Accept >=5.0, >=5.1, ==5.x, ~=5.0, etc. — anything that doesn't
+	# Accept >=5.0, >=5.1, ==5.x, ~=5.0, etc. anything that doesn't
 	# permit 4.x. The bare ">=4.0" historical value should fail here.
 	assert ">=5" in spec or "==5" in spec or "~=5" in spec, (
 		f"line_profiler must be pinned to >=5.x; pyproject has: {spec!r}"
@@ -312,7 +312,7 @@ class TestActiveProfilerCountGate:
 
 	def test_after_request_keeps_tool_while_sibling_active(self, monkeypatch):
 		"""Two concurrent profilers (count==2). When the first finishes, tool 2
-		must NOT be freed — the sibling is still tracing. Only the last one out
+		must NOT be freed the sibling is still tracing. Only the last one out
 		frees it."""
 		cap._active_profiler_count = 2  # two gthread requests profiling at once
 		_leak_tool()                    # tool 2 registered (a profiler is active)

--- a/optimus/tests/test_line_profile_picker.py
+++ b/optimus/tests/test_line_profile_picker.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for optimus.line_profile.picker — candidate generation and
+"""Tests for optimus.line_profile.picker candidate generation and
 free-form dotted-path resolution for the phase-2 line-profile picker UI.
 
 pyinstrument captures the *bare* function name in ``function`` and the
@@ -72,7 +72,7 @@ class TestDeriveModulePath:
 	def test_relative_dotdot_segments_stripped(self):
 		# pyinstrument's file_path_short is os.path.relpath(file, <sys.path
 		# entry>); on some benches that yields leading "../" segments. They
-		# are relpath artifacts, NOT module components — if left in,
+		# are relpath artifacts, NOT module components if left in,
 		# ".".join turns ".." into a leading dot ("...pkg"), which then
 		# resolves as a (broken) relative import and 500'd the line-profile
 		# pass. They must be stripped so a clean, importable-shaped path
@@ -90,7 +90,7 @@ class TestDeriveModulePath:
 	def test_build_dotted_path_from_relative_filename_resolvable_shape(self):
 		# End-to-end regression for the reported crash: a curated pick whose
 		# file_path_short carried "../" segments made _build_dotted_path
-		# emit "...acme.acme.acme.report...execute" — a relative-import path
+		# emit "...acme.acme.acme.report...execute" a relative-import path
 		# that crashed. It must now emit a clean, importable-shaped dotted
 		# path.
 		dotted = picker._build_dotted_path(
@@ -140,7 +140,7 @@ class TestBuildCandidatesFromTrees:
 
 	def test_same_function_name_different_files_does_not_collapse(self):
 		# Two unrelated `validate` methods in different modules must remain
-		# separate candidates — that's the whole point of including the
+		# separate candidates that's the whole point of including the
 		# filename in the dedup key.
 		tree = _root(
 			_frame("validate", "apps/erpnext/erpnext/selling/sales_invoice.py", 10, 100.0),
@@ -347,8 +347,8 @@ class TestResolveFreeform:
 	def test_leading_dot_path_degrades_to_picker_error(self):
 		# Regression: a stored/curated dotted_path with a leading "..."
 		# (so split(".") yields empty leading segments) made the import
-		# loop call importlib.import_module("...pkg...") — a RELATIVE
-		# import — which raises TypeError ("the 'package' argument is
+		# loop call importlib.import_module("...pkg...") a RELATIVE
+		# import which raises TypeError ("the 'package' argument is
 		# required to perform a relative import"), NOT ImportError. That
 		# escaped the loop's narrow except and 500'd the request. It must
 		# now degrade to a clean PickerError the caller already handles.
@@ -522,7 +522,7 @@ class TestExpandHotChain:
 		assert [c["depth"] for c in chain] == [0, 1, 2]
 
 	def test_max_depth_zero_walks_to_leaf(self):
-		"""v0.13.x: ``max_depth = 0`` means unbounded — walk to the leaf
+		"""v0.13.x: ``max_depth = 0`` means unbounded walk to the leaf
 		instead of the legacy "0 = no descent" sentinel that the pre-
 		v0.13.x ``while depth < max_depth`` loop accidentally
 		implemented. The Strict Sensitivity Profile uses 0 here so
@@ -539,12 +539,12 @@ class TestExpandHotChain:
 			[tree], "my_app.x.level1", max_depth=0,
 		)
 
-		# 0 (pick) + 4 descendants — walked all the way to ``level5``.
+		# 0 (pick) + 4 descendants walked all the way to ``level5``.
 		assert len(chain) == 5
 		assert [c["depth"] for c in chain] == [0, 1, 2, 3, 4]
 
 	def test_min_ms_zero_includes_every_measurable_child(self):
-		"""v0.13.x: ``min_ms = 0`` means no minimum — every measurable
+		"""v0.13.x: ``min_ms = 0`` means no minimum every measurable
 		child is eligible. Closes the gap where pre-v0.13.x the
 		``or 50.0`` fallback in api.py silently re-applied the default
 		floor and skipped any child < 50ms even when the operator
@@ -602,7 +602,7 @@ class TestExpandHotChain:
 
 	def test_finds_hottest_match_across_trees(self):
 		# Same function appears in two action trees with different
-		# cumulative_ms — picker should pick the hotter instance and
+		# cumulative_ms picker should pick the hotter instance and
 		# walk its children.
 		hot_child = _frame(
 			"hot_descendant", "apps/my_app/my_app/x.py", 5, 100.0,
@@ -696,7 +696,7 @@ class TestResolveFreeformClassMethodFallback:
 class TestRecommendedFlag:
 	"""v0.7.x (P2): candidates carry a ``recommended`` flag so the picker can
 	pre-tick the real hot paths (non-framework user code above a time
-	threshold) — one click to line-profile them, no manual hunting."""
+	threshold) one click to line-profile them, no manual hunting."""
 
 	def test_user_hot_frame_recommended(self):
 		tree = _root(
@@ -721,7 +721,7 @@ class TestRecommendedFlag:
 
 class TestMultiTreePicker:
 	"""v0.13: the picker walks the top-N hottest action trees, not just the
-	single hottest — so a flow with several slow actions surfaces them all
+	single hottest so a flow with several slow actions surfaces them all
 	(previously only the one dominant tree's frames appeared)."""
 
 	def test_surfaces_frames_from_multiple_trees(self):
@@ -766,7 +766,7 @@ class TestMultiTreePicker:
 		fns = {c["qualname"] for c in cands}
 		# The giant tree is budget-limited so the smaller action still surfaces.
 		assert "other_action" in fns
-		# Per-tree cap honored — the giant tree contributes <= _PER_TREE_CAP frames.
+		# Per-tree cap honored the giant tree contributes <= _PER_TREE_CAP frames.
 		giant_frames = [c for c in cands if c["file"].endswith("common.py")]
 		assert len(giant_frames) <= picker._PER_TREE_CAP
 
@@ -794,7 +794,7 @@ class TestMultiTreePicker:
 
 	def test_excludes_stdlib_frames(self, monkeypatch):
 		# A hot user frame that calls into Python stdlib (importlib.import_module
-		# at 53ms — captured as ``importlib/__init__.py``). The stdlib frame is
+		# at 53ms captured as ``importlib/__init__.py``). The stdlib frame is
 		# neither the customer's code nor a Frappe framework app, so it must NOT
 		# appear in the picker; the user-app frame that owns the cost does.
 		# ``_top_level_app`` only returns "[other]" for ``importlib`` when it can
@@ -824,7 +824,7 @@ class TestPickerDialogIndent:
 	(``build_tree_html`` in optimus_session.js).
 
 	The "indent is wrong" report: a top-level (depth-0) LEAF candidate
-	(e.g. ``bg_recheck_users`` — a hot frame with no surfaced children) was
+	(e.g. ``bg_recheck_users``: a hot frame with no surfaced children) was
 	rendered with a hard-coded ``padding:2px 0 2px 22px`` left pad. When it
 	followed a sibling root rendered as a collapsed ``<details>`` (e.g.
 	``_maybe_log_user``), the 22px pad made the leaf look NESTED under that
@@ -873,7 +873,7 @@ class TestPickerDialogIndent:
 
 
 class TestFilterOutIgnoredApps:
-	"""picker.filter_out_ignored_apps — the ONE shared filter used by both the
+	"""picker.filter_out_ignored_apps the ONE shared filter used by both the
 	manual picker (api.get_phase2_candidates) and auto-arm."""
 
 	def _cands(self):
@@ -922,7 +922,7 @@ class TestPickerEmptyHintIgnored:
 		assert "Ignored Apps" in msg
 		assert "5 candidate" in msg
 		# Must NOT push the operator to clear the whole list (that resurrects
-		# the framework-app defaults) — it must say to keep at least one entry.
+		# the framework-app defaults) it must say to keep at least one entry.
 		assert "keep at least one entry" in msg
 
 	def test_some_survivors_give_no_hint(self):

--- a/optimus/tests/test_masthead_document.py
+++ b/optimus/tests/test_masthead_document.py
@@ -2,7 +2,7 @@
 # For license information, please see license.txt
 
 """Masthead top-right shows the session title. (The touched-document doctype/name
-display was reverted — these tests guard that it doesn't creep back.)"""
+display was reverted these tests guard that it doesn't creep back.)"""
 
 import types
 
@@ -32,13 +32,13 @@ def _action():
 
 def test_masthead_shows_session_title_even_with_a_document():
 	"""Even when the session touched a document, the top-right shows the session
-	title — the doctype/name display was reverted."""
+	title the doctype/name display was reverted."""
 	rec = {"uuid": "u1", "form_dict": {"doctype": "Sales Order", "name": "SAL-ORD-2026-00042"}, "calls": []}
 	html = renderer.render(_doc([_action()]), recordings=[rec])
 	assert "Sales Order · 2026-08-27 21:55" in html  # composed session title
 	assert 'class="masthead-docname"' not in html
 	assert "<h1>Sales Order</h1>" not in html  # doctype is NOT the masthead heading
-	# (the document name may still appear in the per-action breadcrumb — only the
+	# (the document name may still appear in the per-action breadcrumb only the
 	#  masthead top-right display was reverted, not the per-action document line.)
 
 

--- a/optimus/tests/test_n_plus_one.py
+++ b/optimus/tests/test_n_plus_one.py
@@ -43,7 +43,7 @@ def test_n_plus_one_callsite_attributes_to_business_code(n_plus_one_recording, e
 	database.py:742 for the N+1 instead of the business-code frame.
 
 	v0.5.2: fixture renamed from erpnext/… to acme_sales/… because
-	erpnext is now classified as framework — this test is checking
+	erpnext is now classified as framework this test is checking
 	the 'blame user code, not framework helpers' behavior, which
 	requires the blame frame to be in a non-framework app.
 	"""
@@ -93,7 +93,7 @@ def test_one_query_per_request_across_many_requests_is_not_n_plus_one(empty_cont
 	"""Regression: the same query run ONCE per request across 50 separate
 	requests is NOT an N+1 (no loop) and must not be flagged. The old code
 	counted occurrences across all recordings, so 50 requests × 1 query =
-	"Same query ran 50× — usually a Python loop", a confident false positive.
+	"Same query ran 50× usually a Python loop", a confident false positive.
 	N+1 must require the loop to be WITHIN a single action."""
 	recordings = [
 		{
@@ -127,14 +127,14 @@ def test_misconfigured_min_occurrences_below_two_cannot_readmit_false_positive(e
 	``loop_count`` (peak repeats within one request) is always ≥ 1, and the
 	within-request gate is ``loop_count < min_occurrences``. If the setting
 	reached the gate as 1, a query that runs exactly ONCE per request would
-	satisfy ``1 < 1 == False`` and be flagged — the very cross-request false
+	satisfy ``1 < 1 == False`` and be flagged the very cross-request false
 	positive the analyzer exists to prevent (see
 	test_one_query_per_request_across_many_requests_is_not_n_plus_one). The
 	clamp floors the effective threshold at 2 so a single occurrence can never
 	qualify. This test fails the instant the clamp is dropped from line ~93."""
 	from optimus.settings import OptimusConfig
 
-	# Misconfigure the setting to 1 — the value that would defeat the gate.
+	# Misconfigure the setting to 1 the value that would defeat the gate.
 	monkeypatch.setattr(
 		"optimus.settings.get_config",
 		lambda: OptimusConfig(n_plus_one_min_occurrences=1),
@@ -165,7 +165,7 @@ def test_misconfigured_min_occurrences_below_two_cannot_readmit_false_positive(e
 	]
 	result = n_plus_one.analyze(recordings, empty_context)
 	assert result.findings == [], (
-		"min_occurrences=1 must still be clamped to 2 — a once-per-request "
+		"min_occurrences=1 must still be clamped to 2 a once-per-request "
 		"query across many requests is not a loop and must not be flagged"
 	)
 
@@ -196,7 +196,7 @@ def test_loop_within_single_request_still_detected(empty_context):
 
 def test_fallback_to_deepest_frame_when_only_frappe_frames(empty_context):
 	"""If the only /apps/ frame is in frappe itself, we still emit a
-	finding rather than silently dropping it — but as the
+	finding rather than silently dropping it but as the
 	'Framework N+1' type (Low severity, framework-aware description),
 	not the actionable 'N+1 Query' type.
 	"""
@@ -226,10 +226,10 @@ def test_fallback_to_deepest_frame_when_only_frappe_frames(empty_context):
 		f"Pure-frappe/* stack must emit 'Framework N+1'; got: {finding['finding_type']}"
 	)
 	assert finding["severity"] == "Low", (
-		"Framework N+1 is always Low severity — user can rarely fix it"
+		"Framework N+1 is always Low severity user can rarely fix it"
 	)
 	detail = json.loads(finding["technical_detail_json"])
-	# It fell back to the frappe frame — still include full path.
+	# It fell back to the frappe frame still include full path.
 	assert "frappe/model/document.py" in detail["callsite"]["filename"]
 	# And the detail must carry the is_framework flag.
 	assert detail.get("is_framework") is True
@@ -306,7 +306,7 @@ def test_loop_across_many_requests_reports_per_request_count_not_total(empty_con
 	assert "12 times in a row" in desc
 	assert "120 times in a row" not in desc
 	assert "10 separate requests" in desc
-	# Multi-request loops say "up to N" — loop_count is the busiest request's peak,
+	# Multi-request loops say "up to N" loop_count is the busiest request's peak,
 	# not a uniform per-request figure.
 	assert "up to 12 times in a row" in desc
 
@@ -318,18 +318,18 @@ def test_loop_across_many_requests_reports_per_request_count_not_total(empty_con
 	# affected_count and estimated_impact_ms are on the SAME occurrence set (the
 	# loop's own hits), so the generic per-hit consumers stay correct: this loop
 	# fired 120 hits at 2ms each. affected_count is the loop HIT count (120), NOT
-	# loop_count (12, the per-request peak that drives the title/hero) — mixing the
+	# loop_count (12, the per-request peak that drives the title/hero) mixing the
 	# two denominators inflated per-hit ×10 on multi-request loops.
 	assert f["affected_count"] == 120  # total loop hits (12× across 10 requests)
 	assert f["estimated_impact_ms"] == 120.0  # loop_time (120 hits × 1ms)
 	# per-hit = impact / count = the loop's real per-query cost (1ms). Before this
-	# fix affected_count was loop_count (12), so per-hit read 120/12 = 10ms — ×10.
+	# fix affected_count was loop_count (12), so per-hit read 120/12 = 10ms ×10.
 	assert f["estimated_impact_ms"] / f["affected_count"] == 1.0
 
 
 def test_loop_across_requests_stays_high_when_cumulative_time_is_large(empty_context):
 	"""Companion guard: the loop stays High when cumulative time warrants it
-	(60 × 5ms = 300ms > 200ms) — severity-by-time is honest, by-count was not."""
+	(60 × 5ms = 300ms > 200ms) severity-by-time is honest, by-count was not."""
 	recordings = [
 		{
 			"uuid": f"req-{r}",
@@ -402,7 +402,7 @@ def test_run_count_ignores_requests_where_query_did_not_loop(empty_context):
 						{"filename": "apps/myapp/module.py", "lineno": 100, "function": "loop"},
 					],
 				}
-			],  # the SAME query, but run once — no loop here
+			],  # the SAME query, but run once no loop here
 		}
 		for r in range(20)
 	]
@@ -423,7 +423,7 @@ def test_run_count_ignores_requests_where_query_did_not_loop(empty_context):
 def test_run_count_excludes_sub_threshold_repeats(empty_context):
 	"""A request counts as looping only if it hit the N+1 threshold. A finding that
 	qualifies on one 12× request must NOT fold in requests that repeated the query
-	just 2-9× (below the bar) — else run_count / loop_time / severity inflate and
+	just 2-9× (below the bar) else run_count / loop_time / severity inflate and
 	"looped in N requests" overstates the loop's real spread."""
 	def call(dur):
 		return {"query": "SELECT 1", "normalized_query": "SELECT ?", "duration": dur,
@@ -434,7 +434,7 @@ def test_run_count_excludes_sub_threshold_repeats(empty_context):
 			"event_type": "HTTP Request", "duration": 50, "calls": [call(dur)] * hits}
 
 	recs = [req("A", 12, 3.0)]  # qualifies: 12 >= min_occurrences (10)
-	recs += [req(f"b{i}", 3, 5.0) for i in range(5)]  # 3× each — below the threshold
+	recs += [req(f"b{i}", 3, 5.0) for i in range(5)]  # 3× each below the threshold
 	detail = json.loads(n_plus_one.analyze(recs, empty_context).findings[0]["technical_detail_json"])
 	assert detail["run_count"] == 1  # only the 12× request; the 3× ones are excluded
 	assert detail["loop_count"] == 12
@@ -448,7 +448,7 @@ def test_run_count_excludes_sub_threshold_repeats(empty_context):
 #   "Same query ran 22× at optimus/optimus/infra_capture.py:176"
 #
 # That's the SHOW GLOBAL STATUS snapshot our before_request hook runs on
-# every recording — real SQL, but profiler overhead, not application work
+# every recording real SQL, but profiler overhead, not application work
 # the user can optimize. Same goes for top_queries.
 
 
@@ -457,7 +457,7 @@ def test_framework_n_plus_one_query_builder_utils(empty_context):
 	issues the same normalized query 138 times while building
 	SELECTs for different inputs. Pre-v0.5.1 this emitted as
 	'N+1 Query' with an actionable fix hint, misleading the user
-	into thinking they should refactor their code — but the
+	into thinking they should refactor their code but the
 	blamed file is frappe/query_builder/utils.py which the user
 	doesn't own. v0.5.1 routes it to 'Framework N+1' instead."""
 	recording = {
@@ -491,7 +491,7 @@ def test_framework_n_plus_one_query_builder_utils(empty_context):
 		f"'Framework N+1'; got: {f['finding_type']}"
 	)
 	assert f["severity"] == "Low"
-	# Title signals it's framework — no scary "Same query ran Nx"
+	# Title signals it's framework no scary "Same query ran Nx"
 	# that implies the user should fix it.
 	assert "Framework query repeated" in f["title"]
 	assert "138" in f["title"]
@@ -503,7 +503,7 @@ def test_framework_n_plus_one_query_builder_utils(empty_context):
 
 
 def test_framework_finding_gates_on_cumulative_not_loop_time(empty_context):
-	"""#1: framework loop is 10ms (< 20ms floor) but cumulative 25ms — framework
+	"""#1: framework loop is 10ms (< 20ms floor) but cumulative 25ms framework
 	findings gate on total_time, so this survives (the loop_time gate dropped it)."""
 	fw_call = lambda dur: {  # noqa: E731
 		"query": "SELECT ? FROM information_schema.GLOBAL_VARIABLES",
@@ -533,7 +533,7 @@ def test_framework_finding_gates_on_cumulative_not_loop_time(empty_context):
 	assert detail["run_count"] == 1  # only one request actually looped
 	assert round(detail["total_time_ms"]) == 25
 	# Framework title uses the SESSION total (25), never the per-request loop count
-	# (10) — framework findings are cumulative-framed, unlike user N+1s.
+	# (10) framework findings are cumulative-framed, unlike user N+1s.
 	assert "25×" in f["title"]
 	assert "10×" not in f["title"]
 
@@ -610,7 +610,7 @@ def test_title_fits_in_140_chars_for_deeply_nested_module_paths(empty_context):
 					"function": "process_batch",
 				}],
 			}
-		] * 65,  # 65 occurrences — matches production error count
+		] * 65,  # 65 occurrences matches production error count
 	}
 	result = n_plus_one.analyze([recording], empty_context)
 	assert len(result.findings) == 1
@@ -646,7 +646,7 @@ def test_short_filename_helper_unit():
 	assert short_filename("erpnext.py") == "erpnext.py"
 	assert short_filename("model/document.py") == "model/document.py"
 
-	# Absolute path — drop leading slash, keep last 2 segments
+	# Absolute path drop leading slash, keep last 2 segments
 	assert (
 		short_filename(
 			"/Users/navin/office/frappe_bench/apps/frappe/frappe/handler.py"
@@ -733,7 +733,7 @@ def test_user_code_routed_through_profiler_wrap_still_attributed(empty_context):
 	filtered as profiler noise.
 
 	The rule is 'is the deepest non-frappe frame inside optimus/?'
-	— here the deepest is user code, so the finding fires."""
+	here the deepest is user code, so the finding fires."""
 	recording = {
 		"uuid": "user-through-wrap",
 		"path": "/",
@@ -760,7 +760,7 @@ def test_user_code_routed_through_profiler_wrap_still_attributed(empty_context):
 	result = n_plus_one.analyze([recording], empty_context)
 	assert len(result.findings) == 1, (
 		"User-code N+1 with a profiler wrap frame in the middle of the "
-		"stack must still produce a finding — the deepest non-frappe "
+		"stack must still produce a finding the deepest non-frappe "
 		"frame is the user's controller.py, so the callsite rule matches."
 	)
 	detail = json.loads(result.findings[0]["technical_detail_json"])
@@ -854,7 +854,7 @@ def test_walk_callsite_bench_path_profiler_stack_returns_none():
 	]
 	assert walk_callsite(stack) is None, (
 		"walk_callsite must return None for bench-relative profiler "
-		"stacks so n_plus_one drops the query — otherwise a "
+		"stacks so n_plus_one drops the query otherwise a "
 		"Framework N+1 finding gets emitted blaming the profiler's "
 		"own code."
 	)
@@ -862,8 +862,8 @@ def test_walk_callsite_bench_path_profiler_stack_returns_none():
 
 def test_n_plus_one_bench_relative_profiler_stack_produces_no_finding(empty_context):
 	"""Regression guard: the exact call shape from the user's
-	production report — ``apps/optimus/optimus/
-	infra_capture.py`` stacks — must produce zero findings (neither
+	production report ``apps/optimus/optimus/
+	infra_capture.py`` stacks must produce zero findings (neither
 	normal N+1 Query nor Framework N+1)."""
 	recording = {
 		"uuid": "bench-profiler-leak",
@@ -896,10 +896,10 @@ def test_n_plus_one_bench_relative_profiler_stack_produces_no_finding(empty_cont
 					},
 				],
 			}
-		] * 22,  # 22 occurrences — matches the reported count
+		] * 22,  # 22 occurrences matches the reported count
 	}
 	result = n_plus_one.analyze([recording], empty_context)
-	# No findings of EITHER type — the profiler's own queries are
+	# No findings of EITHER type the profiler's own queries are
 	# filtered entirely before the framework-vs-user routing.
 	assert result.findings == [], (
 		"Profiler's own bench-relative stack must produce zero findings; "
@@ -908,7 +908,7 @@ def test_n_plus_one_bench_relative_profiler_stack_produces_no_finding(empty_cont
 
 
 def test_is_profiler_own_query_unit():
-	"""Direct unit test of the helper — clearer than going through
+	"""Direct unit test of the helper clearer than going through
 	the full n_plus_one pipeline for each branch."""
 	from optimus.analyzers.base import is_profiler_own_query
 
@@ -993,7 +993,7 @@ def test_top_queries_filters_profiler_instrumentation(empty_context):
 		"event_type": "HTTP Request",
 		"duration": 500,
 		"calls": [
-			# Profiler instrumentation — should be dropped
+			# Profiler instrumentation should be dropped
 			{
 				"query": "SHOW GLOBAL STATUS WHERE Variable_name IN (...)",
 				"normalized_query": "SHOW GLOBAL STATUS WHERE Variable_name IN (...)",
@@ -1003,7 +1003,7 @@ def test_top_queries_filters_profiler_instrumentation(empty_context):
 					{"filename": "frappe/database/mariadb/database.py", "lineno": 742, "function": "sql"},
 				],
 			},
-			# Real application query — should appear in leaderboard
+			# Real application query should appear in leaderboard
 			{
 				"query": "SELECT * FROM tabSales Invoice WHERE customer = ?",
 				"normalized_query": "SELECT * FROM tabSales Invoice WHERE customer = ?",
@@ -1036,7 +1036,7 @@ def test_action_ref_points_to_the_looping_request_not_first_appearance(empty_con
 	"""#1: action_ref must name the dominant (looping) request, not the first the
 	query appeared in. Runs once in req 0, loops 15× in req 1 → ref == "1"."""
 	recordings = [
-		{  # request 0 — the query appears exactly once (NOT a loop)
+		{  # request 0 the query appears exactly once (NOT a loop)
 			"uuid": "req-0",
 			"path": "/",
 			"cmd": None,
@@ -1054,7 +1054,7 @@ def test_action_ref_points_to_the_looping_request_not_first_appearance(empty_con
 				}
 			],
 		},
-		{  # request 1 — the real 15× loop
+		{  # request 1 the real 15× loop
 			"uuid": "req-1",
 			"path": "/",
 			"cmd": None,
@@ -1076,7 +1076,7 @@ def test_action_ref_points_to_the_looping_request_not_first_appearance(empty_con
 	result = n_plus_one.analyze(recordings, empty_context)
 	assert len(result.findings) == 1
 	f = result.findings[0]
-	# Points at request 1 (index 1), where the loop ran — NOT request 0.
+	# Points at request 1 (index 1), where the loop ran NOT request 0.
 	assert f["action_ref"] == "1"
 	assert "15×" in f["title"]
 	detail = json.loads(f["technical_detail_json"])
@@ -1111,7 +1111,7 @@ def _mixed_loop_and_singles(loop_hits, loop_ms, single_count, single_ms):
 
 def test_small_loop_low_severity_and_loop_scoped_cost(empty_context):
 	"""#2/#1: severity AND the description cost use the loop's own time (30ms),
-	not the 280ms cumulative — so Low, and the description quotes 30ms not 280ms."""
+	not the 280ms cumulative so Low, and the description quotes 30ms not 280ms."""
 	recordings = _mixed_loop_and_singles(loop_hits=10, loop_ms=3.0, single_count=50, single_ms=5.0)
 	result = n_plus_one.analyze(recordings, empty_context)
 	assert len(result.findings) == 1
@@ -1130,7 +1130,7 @@ def test_small_loop_low_severity_and_loop_scoped_cost(empty_context):
 	# Projection never exceeds the current total.
 	assert detail["projected_total_ms"] <= detail["total_time_ms"]
 	# Headline economics are LOOP-scoped, so every downstream surface (hero, impact
-	# box, report sort, AI-fix prompt) tells the "10× / 30ms" story — NOT the 60 /
+	# box, report sort, AI-fix prompt) tells the "10× / 30ms" story NOT the 60 /
 	# 280 session totals, which stay in the detail above under a "session-wide" label.
 	assert f["affected_count"] == 10  # loop_count, not the 60 total
 	assert f["estimated_impact_ms"] == 30.0  # loop_time, not the 280ms total
@@ -1139,7 +1139,7 @@ def test_small_loop_low_severity_and_loop_scoped_cost(empty_context):
 	assert detail["p95_ms"] is not None
 	assert detail["projected_avg_time_ms"] == 6.0  # loop_avg (3ms) × 2
 	assert detail["projected_speedup_label"] == "~5× fewer queries"  # loop_count // 2
-	# The card's scope tag is analyzer-declared (data-driven) — no surface hardcodes
+	# The card's scope tag is analyzer-declared (data-driven) no surface hardcodes
 	# "N+1 == recoverable"; the impact/count really are the loop's own, not the total.
 	assert detail["impact_scope_label"] == "recoverable"
 
@@ -1169,7 +1169,7 @@ def test_sub_millisecond_loop_cost_reads_less_than_1ms_not_0ms(empty_context, mo
 	result = n_plus_one.analyze(recordings, empty_context)
 	assert len(result.findings) == 1
 	f = result.findings[0]
-	# User code, so _build_user_finding — which carries the <1ms branch — runs.
+	# User code, so _build_user_finding which carries the <1ms branch runs.
 	assert f["finding_type"] == "N+1 Query"
 	# A regressed ">= 0.5" guard (or a dropped branch) would render "0ms" here.
 	assert "<1ms" in f["customer_description"]

--- a/optimus/tests/test_n_plus_one_dedup.py
+++ b/optimus/tests/test_n_plus_one_dedup.py
@@ -6,14 +6,14 @@
 Before v0.5.2: n_plus_one grouped by (normalized_query, filename,
 lineno). A callsite that generated 10 different queries in the same
 loop emitted 10 separate N+1 findings. Report had "Same query ran
-74×" ten times — same fix, same line.
+74×" ten times same fix, same line.
 
 v0.5.2: regrouped by (filename, lineno). A multi-variant callsite
 emitted ONE collapsed finding titled "Callsite ran X queries (N
 variants) at file:line".
 
 v0.7.x: the multi-variant "Callsite ran …" finding type is dropped
-— the wording reads as jargon, the fix hint is generic, and the
+the wording reads as jargon, the fix hint is generic, and the
 dominant variant is already surfaced elsewhere. Only the
 single-variant classic "Same query ran N× at …" remains.
 """
@@ -52,7 +52,7 @@ def _make_recording(stack, queries_per_variant, variants, per_query_ms=2.0):
 def test_multi_variant_callsite_emits_no_finding():
 	"""v0.7.x: a callsite emitting 10 different SQL shapes ×30 each (300
 	total queries) used to collapse into one 'Callsite ran 300 queries
-	(10 variants)' finding. That wording wasn't actionable — drop the
+	(10 variants)' finding. That wording wasn't actionable drop the
 	multi-variant case entirely. The dominant variant is still visible
 	in the top-queries / table-breakdown sections; truly hot loops with
 	a single repeated SQL shape are still flagged by the classic
@@ -73,7 +73,7 @@ def test_multi_variant_callsite_emits_no_finding():
 
 def test_single_variant_keeps_classic_title():
 	"""Backwards compat: 1 variant × N occurrences still reads as
-	'Same query ran N× at file:line' — the classic N+1 shape."""
+	'Same query ran N× at file:line' the classic N+1 shape."""
 	stack = [
 		{"filename": "apps/myapp/foo.py", "lineno": 10, "function": "loop"},
 	]
@@ -89,7 +89,7 @@ def test_single_variant_keeps_classic_title():
 
 
 def test_max_variant_threshold_prevents_fanout_false_positives():
-	"""A fan-out callsite — 10 different queries, each called once —
+	"""A fan-out callsite 10 different queries, each called once
 	isn't an N+1. It's a function that dispatches to multiple queries.
 	We gate by the MOST-repeated variant, not the total, so these
 	don't trigger a finding."""
@@ -104,7 +104,7 @@ def test_max_variant_threshold_prevents_fanout_false_positives():
 	# Must NOT emit a finding.
 	assert result.findings == [], (
 		"Fan-out callsite (20 unique queries × 1 each) must not flag "
-		"as N+1 — the max-variant threshold should filter it. "
+		"as N+1 the max-variant threshold should filter it. "
 		f"Got: {[f['title'] for f in result.findings]}"
 	)
 

--- a/optimus/tests/test_onboarding_toast_state.py
+++ b/optimus/tests/test_onboarding_toast_state.py
@@ -60,7 +60,7 @@ def test_mark_onboarding_seen_persists(fake_env):
 
 def test_check_onboarding_seen_suppressed_when_user_has_existing_sessions(fake_env):
 	cache, fake_db = fake_env
-	# User has a Ready Optimus Session — they're an experienced user
+	# User has a Ready Optimus Session they're an experienced user
 	fake_db._count = 3
 	result = api.check_onboarding_seen()
 	assert result == {"seen": True}

--- a/optimus/tests/test_pdf_expand_collapsibles.py
+++ b/optimus/tests/test_pdf_expand_collapsibles.py
@@ -18,7 +18,7 @@ import types
 import pytest
 
 # pdf_export.py imports frappe at module top. Stub it for this
-# pure-string-transformation test — scoped to a per-test fixture so the
+# pure-string-transformation test scoped to a per-test fixture so the
 # stub doesn't leak to other test files (was a suite-wide pollution
 # source before the conftest fence; even with the fence, doing this
 # via fixture makes the contract explicit and auto-restoring).

--- a/optimus/tests/test_per_action.py
+++ b/optimus/tests/test_per_action.py
@@ -10,7 +10,7 @@ def test_save_sales_invoice_action_label(n_plus_one_recording, empty_context):
 	"""v0.5.1: the per-action table shows the TECHNICAL label (raw
 	cmd), not the humanized Steps-to-Reproduce form. A developer
 	reading the technical report wants to see 'frappe.client.save'
-	— the actual whitelisted method — not a prose summary.
+	the actual whitelisted method not a prose summary.
 	The Steps-to-Reproduce section uses `humanized_label` instead.
 	"""
 	result = per_action.analyze([n_plus_one_recording], empty_context)
@@ -98,12 +98,12 @@ def test_submit_cmd(empty_context):
 
 
 # ---------------------------------------------------------------------------
-# v0.5.1: per_action.humanized_label — Steps-to-Reproduce ONLY
+# v0.5.1: per_action.humanized_label Steps-to-Reproduce ONLY
 # ---------------------------------------------------------------------------
 # These tests target the `humanized_label` helper directly. It's used
 # by analyze._build_auto_notes_html to render the Steps-to-Reproduce
 # section. The per-action table and frontend XHR panel stay on the
-# technical `_label` — per user feedback: "only humanize call name
+# technical `_label`: per user feedback: "only humanize call name
 # in step to reproduce only not on other breakdowns."
 
 
@@ -156,7 +156,7 @@ def test_humanized_savedocs_cancel_action():
 
 def test_humanized_savedocs_without_doctype_falls_back():
 	"""Malformed payload (no parseable doctype) must fall back to
-	the technical label — never emit 'Save <empty>' with trailing
+	the technical label never emit 'Save <empty>' with trailing
 	whitespace."""
 	rec = {
 		"uuid": "sd",
@@ -222,7 +222,7 @@ def test_humanized_client_insert_is_create():
 # The Desk's savedocs endpoint takes different `action` values (Save,
 # Submit, Cancel, Update) that route to semantically different
 # behaviors under the same cmd. Pre-v0.5.2 the per-action table
-# showed the raw cmd for all of them — indistinguishable. v0.5.2
+# showed the raw cmd for all of them indistinguishable. v0.5.2
 # suffixes `:<Action>` so Save vs Submit rows aren't merged visually.
 
 
@@ -275,7 +275,7 @@ def test_savedocs_submit_action_appended_to_technical_label(empty_context):
 
 
 def test_savedocs_save_and_submit_are_distinguishable(empty_context):
-	"""End-to-end regression: user's exact scenario — one session
+	"""End-to-end regression: user's exact scenario one session
 	with one Save and one Submit on the same Sales Invoice. The
 	two Optimus Action rows must have DIFFERENT action_labels
 	so they render as distinct entries in the per-action table."""
@@ -624,7 +624,7 @@ def test_humanization_does_not_leak_into_per_action_table(empty_context):
 
 
 # ---------------------------------------------------------------------------
-# v0.5.1: cmd field is empty in real recordings — derive from path
+# v0.5.1: cmd field is empty in real recordings derive from path
 # ---------------------------------------------------------------------------
 # frappe.recorder.Recorder.__init__ captures cmd at hook time, BEFORE
 # frappe's REST routing sets form_dict.cmd inside handle_rpc_call. So
@@ -642,7 +642,7 @@ def test_label_derives_cmd_from_path_when_cmd_is_empty(empty_context):
 	import json as _json
 	recording = {
 		"uuid": "prod",
-		"cmd": "",  # EMPTY — matches production
+		"cmd": "",  # EMPTY matches production
 		"method": "POST",
 		"path": "/api/method/frappe.desk.form.save.savedocs",
 		"event_type": "HTTP Request",
@@ -655,18 +655,18 @@ def test_label_derives_cmd_from_path_when_cmd_is_empty(empty_context):
 	}
 	result = per_action.analyze([recording], empty_context)
 	# Per-action table gets the technical cmd, disambiguated by
-	# :Save (v0.5.2). Still technical — NOT the humanized form.
+	# :Save (v0.5.2). Still technical NOT the humanized form.
 	assert (
 		result.actions[0]["action_label"]
 		== "frappe.desk.form.save.savedocs:Save"
 	)
-	# humanized_label — used only in Steps-to-Reproduce — still
+	# humanized_label used only in Steps-to-Reproduce still
 	# produces the English form for this same recording.
 	assert per_action.humanized_label(recording) == "Create Sales Invoice"
 
 
 def test_label_derives_v2_api_method(empty_context):
-	"""/api/v2/method/<foo> parse works too — per-action table
+	"""/api/v2/method/<foo> parse works too per-action table
 	shows the raw cmd, humanized_label produces the English form."""
 	recording = {
 		"uuid": "v2",

--- a/optimus/tests/test_performance.py
+++ b/optimus/tests/test_performance.py
@@ -45,7 +45,7 @@ def test_wrap_fast_path_microbenchmark():
 		orig("User", "x")
 	baseline_ns = time.perf_counter_ns() - t0
 
-	# Wrapped (no active session — should hit fast path)
+	# Wrapped (no active session should hit fast path)
 	t0 = time.perf_counter_ns()
 	for _ in range(100_000):
 		wrapped("User", "x")

--- a/optimus/tests/test_phase2_integration.py
+++ b/optimus/tests/test_phase2_integration.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Phase-2 integration tests — exercise capture.start_line_profile_pass /
+"""Phase-2 integration tests exercise capture.start_line_profile_pass /
 stop_line_profile_pass / is_active end-to-end with a fake frappe.cache so
 we don't need a live Redis to confirm the Redis-backed lifecycle works.
 
@@ -157,7 +157,7 @@ class TestPhase2Lifecycle:
 			import pytest
 			pytest.skip("line_profiler not installed; integration covered under bench")
 
-		# `len` is a C-extension builtin — picker rejects it.
+		# `len` is a C-extension builtin picker rejects it.
 		picks = [{"dotted_path": "builtins.len", "source": "freeform"}]
 
 		import pytest

--- a/optimus/tests/test_profiler_settings_validation.py
+++ b/optimus/tests/test_profiler_settings_validation.py
@@ -5,7 +5,7 @@
 apps-in-tracked-apps validation.
 
 Production bug: user populated Tracked Apps with ``frappe`` and
-``erpnext`` — misreading the field as "apps to monitor". Inclusion-
+``erpnext``: misreading the field as "apps to monitor". Inclusion-
 mode semantics kicked in and flooded their actionable findings list
 with framework noise (a 1078-query query_builder N+1 that should
 have gone to Observations landed in Findings). The controller now
@@ -21,7 +21,7 @@ import pytest
 
 def _install_frappe_stub(monkeypatch):
 	"""Install a frappe stub with the minimum surface the controller
-	needs — msgprint, log_error, cache.delete_value, Document parent
+	needs msgprint, log_error, cache.delete_value, Document parent
 	class. Each test gets a fresh ``msgprint`` Mock that collects calls.
 	"""
 	stub = types.ModuleType("frappe")
@@ -62,7 +62,7 @@ def _install_frappe_stub(monkeypatch):
 def _fresh_controller(monkeypatch):
 	"""Return a fresh OptimusSettings instance with msgprint-capturing
 	frappe stub. All sys.modules mutations route via monkeypatch so the
-	real frappe is restored at test teardown — no pollution of
+	real frappe is restored at test teardown no pollution of
 	subsequent test files."""
 	stub = _install_frappe_stub(monkeypatch)
 	# Force re-import so the controller picks up the fresh stub's msgprint.
@@ -134,13 +134,13 @@ class TestFrameworkAppWarning:
 	def test_frappe_profiler_itself_does_not_trigger_warning(self, monkeypatch):
 		"""optimus is in FRAMEWORK_APPS (its own code paths
 		should be filtered out of findings) but it's not a
-		'framework app' in the UX sense — adding it to Tracked Apps
+		'framework app' in the UX sense adding it to Tracked Apps
 		is odd but not actively wrong."""
 		OptimusSettings, stub = _fresh_controller(monkeypatch)
 		doc = OptimusSettings()
 		doc.tracked_apps = [_row("optimus")]
 		doc._warn_on_framework_apps_in_tracked()
-		# No warning — optimus is meta/self and shouldn't
+		# No warning optimus is meta/self and shouldn't
 		# trip the "you probably misread the field" heuristic.
 		assert stub.msgprint_calls == []
 
@@ -170,7 +170,7 @@ class TestNormalization:
 			_row("myapp "),         # trailing space
 			_row(" myapp"),         # leading space
 			_row("second"),
-			_row(""),               # empty — drop
+			_row(""),               # empty drop
 		]
 		doc._normalize_tracked_apps()
 		names = [r.app_name for r in doc.tracked_apps]
@@ -180,7 +180,7 @@ class TestNormalization:
 class TestNumericFloorClamp:
 	"""``_clamp_numeric_floors`` floors each numeric setting at a safe
 	minimum so a typo (e.g. ``-1`` sampler interval, ``0`` session
-	retention) doesn't break the analyzer at runtime. Silently clamps —
+	retention) doesn't break the analyzer at runtime. Silently clamps
 	no msgprint."""
 
 	def test_clamps_negative_sampler_interval_to_floor(self, monkeypatch):
@@ -189,12 +189,12 @@ class TestNumericFloorClamp:
 		doc.pyinstrument_sampler_interval_ms = -1.0
 		doc._clamp_numeric_floors()
 		assert doc.pyinstrument_sampler_interval_ms == 0.1
-		# Silent clamp — no warning.
+		# Silent clamp no warning.
 		assert stub.msgprint_calls == []
 
 	def test_zero_session_retention_allowed(self, monkeypatch):
 		"""v0.13.x: ``session_retention_days = 0`` is the Strict-as-
-		unlimited sentinel — it tells the janitor to never sweep. The
+		unlimited sentinel it tells the janitor to never sweep. The
 		floor dropped from 1 → 0 to admit it; the janitor's
 		``_sweep_old_sessions`` early-returns on ``retention_days <=
 		0``. Pre-v0.13.x the test asserted clamp-to-1 because the
@@ -209,7 +209,7 @@ class TestNumericFloorClamp:
 
 	def test_zero_max_queries_per_recording_allowed(self, monkeypatch):
 		"""v0.13.x: ``max_queries_per_recording = 0`` is the Strict-as-
-		unlimited sentinel — analyze enriches every query (no
+		unlimited sentinel analyze enriches every query (no
 		truncation). Floor lowered 1 → 0 to admit it."""
 		OptimusSettings, _stub = _fresh_controller(monkeypatch)
 		doc = OptimusSettings()
@@ -229,7 +229,7 @@ class TestNumericFloorClamp:
 		assert doc.slow_query_threshold_ms == 200
 
 	def test_zero_min_action_duration_allowed(self, monkeypatch):
-		"""min_action_duration_ms uses 0 as the sentinel for 'no filter' —
+		"""min_action_duration_ms uses 0 as the sentinel for 'no filter'
 		must NOT be clamped above 0."""
 		OptimusSettings, _stub = _fresh_controller(monkeypatch)
 		doc = OptimusSettings()
@@ -238,10 +238,10 @@ class TestNumericFloorClamp:
 		assert doc.min_action_duration_ms == 0
 
 	def test_unset_fields_ignored(self, monkeypatch):
-		"""None / unset fields are skipped — no AttributeError, no clamp."""
+		"""None / unset fields are skipped no AttributeError, no clamp."""
 		OptimusSettings, _stub = _fresh_controller(monkeypatch)
 		doc = OptimusSettings()
-		# Don't set anything — all fields default to None on the stub.
+		# Don't set anything all fields default to None on the stub.
 		doc._clamp_numeric_floors()  # should not raise
 		# Confirm nothing got mutated to a floor value.
 		for fieldname in OptimusSettings._NUMERIC_FLOORS:
@@ -249,12 +249,12 @@ class TestNumericFloorClamp:
 
 	def test_non_numeric_input_left_alone(self, monkeypatch):
 		"""A non-numeric value (someone passing a string by mistake)
-		is silently skipped — let Frappe's field-type validator handle
+		is silently skipped let Frappe's field-type validator handle
 		it. The clamp helper must not raise."""
 		OptimusSettings, _stub = _fresh_controller(monkeypatch)
 		doc = OptimusSettings()
 		doc.session_retention_days = "not a number"
 		doc._clamp_numeric_floors()  # should not raise
-		# String passes through unchanged — Frappe's Int validator
+		# String passes through unchanged Frappe's Int validator
 		# rejects it on save.
 		assert doc.session_retention_days == "not a number"

--- a/optimus/tests/test_projected_post_fix_timing.py
+++ b/optimus/tests/test_projected_post_fix_timing.py
@@ -7,14 +7,14 @@ Each query-oriented finding now carries a projected per-query time
 estimating what the same query would cost AFTER the suggested fix.
 Lets the developer prioritize by ceiling-of-value: a 20× speedup is
 worth an afternoon, a 1.2× speedup probably isn't. Projections are
-heuristic ceilings, not guarantees — see ``base.project_post_fix_ms``
+heuristic ceilings, not guarantees see ``base.project_post_fix_ms``
 for the per-finding-type factors.
 
 Shape (added to ``technical_detail_json``):
 
   {
     "average_time_ms": 2.7,            # existing
-    "projected_avg_time_ms": 0.5,      # NEW — v0.5.3
+    "projected_avg_time_ms": 0.5,      # NEW v0.5.3
     "projected_total_ms": 24.0,        # NEW
     "projected_speedup_label": "~5× faster",  # NEW (optional)
   }
@@ -58,7 +58,7 @@ class TestHelperFunction:
 		assert project_post_fix_ms("Low Filter Ratio", 10.0) is None
 
 	def test_unknown_finding_type_returns_none(self):
-		"""Redundant Call / Slow Hot Path / etc. — no projection."""
+		"""Redundant Call / Slow Hot Path / etc. no projection."""
 		assert project_post_fix_ms("Redundant Call", 10.0) is None
 		assert project_post_fix_ms("Slow Hot Path", 10.0) is None
 
@@ -69,7 +69,7 @@ class TestHelperFunction:
 	def test_floor_enforced_at_minimum(self):
 		"""A perfect index lookup still costs ~0.3ms of round-trip +
 		plan time. Projection must never claim 0.0ms."""
-		# 20× speedup of 0.5ms would be 0.025ms — but floor is 0.3.
+		# 20× speedup of 0.5ms would be 0.025ms but floor is 0.3.
 		assert project_post_fix_ms(
 			"Full Table Scan", 0.5,
 		) == POST_FIX_FLOOR_MS
@@ -257,7 +257,7 @@ class TestRendering:
 		assert "projected-after-fix" not in html
 
 	def test_finding_without_projection_does_not_render_line(self):
-		"""Redundant Call findings don't project — the projected line
+		"""Redundant Call findings don't project the projected line
 		must NOT appear for them."""
 		import types
 

--- a/optimus/tests/test_query_table_layout.py
+++ b/optimus/tests/test_query_table_layout.py
@@ -91,7 +91,7 @@ class TestTemplateCSS:
 	def test_fixed_layout_rule_present(self):
 		tpl = _read_template()
 		assert "table.query-table { table-layout: fixed; }" in tpl, (
-			"table-layout: fixed must be set on .query-table — "
+			"table-layout: fixed must be set on .query-table "
 			"without it, browsers auto-size columns based on content "
 			"and the layout collapses when one row has a long callsite"
 		)
@@ -142,7 +142,7 @@ class TestTemplateCSS:
 
 	def test_queries_flat_table_col_idx_fits_two_digit_indexes(self):
 		"""Forward-compatible lower bound: col-idx must be ≥ 40px so that
-		even with tight 12px padding it has ≥ 28px content room — enough
+		even with tight 12px padding it has ≥ 28px content room enough
 		for ``10``, ``11``, ``999`` to fit on one line."""
 		tpl = _read_template()
 		m = re.search(
@@ -160,7 +160,7 @@ class TestTemplateCSS:
 		"""Historical: at 92px col-num couldn't fit ``Duration per hit`` inline
 		and the sub-label collapsed to a barely-visible ``P``. We later flipped
 		header scope-tags to ``display: block`` so the sub-label stacks below
-		the main word (no horizontal space needed) — but the 110px width is
+		the main word (no horizontal space needed) but the 110px width is
 		kept as defensive headroom: even if some future revert makes scope-
 		tags inline again, the column still has room for the inline label."""
 		tpl = _read_template()
@@ -195,11 +195,11 @@ class TestTemplateCSS:
 		"""``th .scope-tag`` must use ``display: block`` so sub-labels stack
 		BELOW the main header word instead of running inline. With nowrap
 		(see test_scope_tag_has_nowrap_guard) the inline form would overflow
-		into the next column header — block-display moves the label to a new
+		into the next column header block-display moves the label to a new
 		row of the th, taking zero horizontal space."""
 		tpl = _read_template()
 		# Match the BARE global rule whose selector starts with ``th .scope-tag``
-		# at the start of a line — distinguishes from compound selectors like
+		# at the start of a line distinguishes from compound selectors like
 		# ``#frontend table.vitals-table thead th .scope-tag``.
 		m = re.search(r"^\s*th\s+\.scope-tag\s*\{", tpl, re.MULTILINE)
 		assert m, (
@@ -215,7 +215,7 @@ class TestTemplateCSS:
 
 	def test_vitals_table_no_longer_overrides_scope_tag_display(self):
 		"""The vitals-table used to have its own override for header scope-
-		tag display:block — we promoted that pattern to the global default,
+		tag display:block we promoted that pattern to the global default,
 		so the per-table override is now redundant and must be removed (to
 		keep the CSS as single-source-of-truth)."""
 		tpl = _read_template()
@@ -226,7 +226,7 @@ class TestTemplateCSS:
 		)
 		assert m is None, (
 			"The `#frontend table.vitals-table thead th .scope-tag` override "
-			"should be removed — the global `th .scope-tag { display: block }` "
+			"should be removed the global `th .scope-tag { display: block }` "
 			"rule subsumes it."
 		)
 
@@ -285,7 +285,7 @@ class TestTemplateCSS:
 
 	def test_xhr_timing_table_has_no_inline_cell_styles(self):
 		"""Once the table uses the `.data` class, the per-cell inline
-		`style=\"padding: 6px 8px; ...\"` attributes must be stripped —
+		`style=\"padding: 6px 8px; ...\"` attributes must be stripped
 		they bypass the global header/body padding and prevent the
 		scope-tag from block-stacking."""
 		block = self._xhr_timing_block(_read_template())
@@ -351,7 +351,7 @@ class TestEndToEndRender:
 
 		# A deeply-nested callsite path that would previously dominate
 		# the column. 90+ chars is typical for a real app. (Must be a
-		# custom-app path, not frappe/* — the Top Queries leaderboard is
+		# custom-app path, not frappe/* the Top Queries leaderboard is
 		# user-app-only now, so a framework callsite would be filtered
 		# out and the table wouldn't render at all.)
 		long_callsite = (

--- a/optimus/tests/test_realtime_session_events.py
+++ b/optimus/tests/test_realtime_session_events.py
@@ -13,7 +13,7 @@ events. The contract is:
     - optimus_session_analyzing   (from analyze.run, at the top)
     - optimus_session_ready       (from analyze.run, at success)
     - optimus_session_failed      (from analyze.run, on exception)
-    - optimus_progress            (existing — multiple points in analyze.run)
+    - optimus_progress            (existing multiple points in analyze.run)
 
   Client subscribes to all five and also calls status() once at
   page-load + on visibility-change (no setInterval).
@@ -70,7 +70,7 @@ def test_analyze_run_publishes_failed_event():
 
 def test_analyze_run_publishes_ready_event():
 	"""Backward-compat guard: the existing optimus_session_ready
-	emission must remain — this is how the widget navigates the user
+	emission must remain this is how the widget navigates the user
 	to the report on success."""
 	from optimus import analyze
 
@@ -94,7 +94,7 @@ def test_publish_session_event_helper_exists_in_both_layers():
 def test_publish_session_event_catches_exceptions():
 	"""publish_realtime can fail (Socket.IO bridge down, dev env
 	without redis-socketio running). The helper must swallow those
-	exceptions — realtime is a UX convenience, not a hard dependency."""
+	exceptions realtime is a UX convenience, not a hard dependency."""
 	from optimus import analyze, api
 
 	for src in (
@@ -104,14 +104,14 @@ def test_publish_session_event_catches_exceptions():
 		# Must have a try/except around the publish_realtime call.
 		assert "try:" in src and "except" in src, (
 			"_publish_session_event must swallow publish_realtime "
-			"failures — realtime is best-effort"
+			"failures realtime is best-effort"
 		)
 
 
 # ---------------------------------------------------------------------------
 # Client-side contract: floating_widget.js
 # ---------------------------------------------------------------------------
-# No Python import here — the widget is JS. Use text-level checks on
+# No Python import here the widget is JS. Use text-level checks on
 # the file to assert the expected subscribe calls + absence of the
 # polling setInterval.
 
@@ -147,7 +147,7 @@ def test_widget_no_longer_polls_status_on_interval():
 	# The only callback should be an inline arrow function (the
 	# elapsed-timer body), NOT a reference to refreshStatus.
 	assert "refreshStatus" not in matches[0], (
-		"setInterval callback must not be refreshStatus — polling "
+		"setInterval callback must not be refreshStatus polling "
 		"of the status endpoint was removed in v0.5.1"
 	)
 
@@ -158,7 +158,7 @@ def test_widget_has_no_polling_helpers():
 	/api/method/optimus.api.status traffic returns."""
 	src = _read_widget_source()
 	assert "startPolling" not in src, (
-		"startPolling() helper must not exist — v0.5.1 removed "
+		"startPolling() helper must not exist v0.5.1 removed "
 		"HTTP polling in favor of realtime events"
 	)
 	assert "stopPolling" not in src, "stopPolling() helper must not exist"
@@ -167,7 +167,7 @@ def test_widget_has_no_polling_helpers():
 
 def test_widget_subscribes_to_all_realtime_events():
 	"""Client must have a frappe.realtime.on() subscription for
-	each of the server-side emit points — otherwise state changes
+	each of the server-side emit points otherwise state changes
 	fire into the void and the widget hangs."""
 	src = _read_widget_source()
 	expected_events = [
@@ -193,7 +193,7 @@ def test_widget_visibility_handler_only_refreshes_once():
 	assert "visibilitychange" in src
 	# And it calls refreshStatus (the one-shot)
 	assert "refreshStatus()" in src
-	# But NOT startPolling — that's gone.
+	# But NOT startPolling that's gone.
 	assert "startPolling" not in src
 
 
@@ -201,7 +201,7 @@ def test_widget_init_calls_status_only_once():
 	"""init() must call refreshStatus exactly once for the one-shot
 	rehydrate. Any additional call is a regression."""
 	src = _read_widget_source()
-	# Extract the init() function body by balanced-brace walking — a
+	# Extract the init() function body by balanced-brace walking a
 	# naive regex like ``function init\(\)\s*\{([^}]+)\}`` would stop at
 	# the first nested ``}`` (inside the early-return if-block, etc.),
 	# missing the actual refreshStatus call below.

--- a/optimus/tests/test_recorder_redaction_patch.py
+++ b/optimus/tests/test_recorder_redaction_patch.py
@@ -5,10 +5,10 @@
 
 These tests verify the patch installed at ``optimus/__init__.py:_patch_recorder``:
 
-  * ``Recorder.__init__`` — after the original runs, ``self.form_dict`` and
+  * ``Recorder.__init__``: after the original runs, ``self.form_dict`` and
     ``self.headers`` are walked through ``redaction.redact_sensitive`` so
     raw passwords / cookies never reach ``dump()`` → ``RECORDER_REQUEST_HASH``.
-  * ``Recorder.register`` — ``data["query"]`` is run through
+  * ``Recorder.register``: ``data["query"]`` is run through
     ``redaction.redact_sql_literals`` before the original appends it to
     ``self.calls``. The renderer-time scrubber stays as defense-in-depth.
 
@@ -21,7 +21,7 @@ from __future__ import annotations
 
 import pytest
 
-import optimus  # noqa: F401 — triggers _patch_recorder at import-time
+import optimus  # noqa: F401 triggers _patch_recorder at import-time
 
 
 def _Recorder():
@@ -66,7 +66,7 @@ class TestPatchInstalled:
 
 
 class _FakeRecorderInstance:
-	"""Minimal stand-in for a Recorder instance — we only need a ``calls``
+	"""Minimal stand-in for a Recorder instance we only need a ``calls``
 	list for the original ``register`` to append to."""
 
 	def __init__(self):

--- a/optimus/tests/test_redis_audit.py
+++ b/optimus/tests/test_redis_audit.py
@@ -10,16 +10,16 @@ key argument. Inline f-string keys (``f"profiler:..."`` /
 ``f"optimus:..."``) inside a ``frappe.cache.X(...)`` call are orphans
 and fail this test. The audit also asserts the doc inventory
 (``docs/REDIS-SCHEMA.md``) matches the canonical
-:data:`optimus.redis_keys.KEY_PATTERNS` tuple — drift in either
+:data:`optimus.redis_keys.KEY_PATTERNS` tuple drift in either
 direction fails CI.
 
 Excluded:
-  * ``optimus/tests/`` and ``optimus/tests_integration/`` — test
+  * ``optimus/tests/`` and ``optimus/tests_integration/``: test
     fixtures legitimately stub Redis keys.
-  * ``optimus/patches/`` — one-shot DocType migration scripts; their
+  * ``optimus/patches/``: one-shot DocType migration scripts; their
     literal-key uses are by design (cleaning up specific legacy keys
     by name).
-  * ``optimus/redis_keys.py`` itself — the f-string definitions inside
+  * ``optimus/redis_keys.py`` itself the f-string definitions inside
     the builder bodies ARE the canonical strings.
 
 The session.py and line_profile/capture.py modules carry their own
@@ -36,14 +36,14 @@ from pathlib import Path
 
 from optimus import redis_keys
 
-# Excluded directories — every .py file under these paths is skipped.
+# Excluded directories every .py file under these paths is skipped.
 EXCLUDED_DIRS = (
 	"optimus/tests/",
 	"optimus/tests_integration/",
 	"optimus/patches/",
 )
 
-# Excluded files — the audit's own canonical-string definitions live
+# Excluded files the audit's own canonical-string definitions live
 # here, so the f-strings inside :mod:`optimus.redis_keys` are legitimate.
 EXCLUDED_FILES = (
 	"optimus/redis_keys.py",
@@ -101,10 +101,10 @@ def _find_orphan_inline_keys() -> list[str]:
 			# starts with an Optimus namespace prefix, it's an orphan.
 			# Multi-line cache calls (where the key is on the next line
 			# via a continuation) require the f-string + the prefix to
-			# co-occur with the cache call — i.e. the WRITER wrote
+			# co-occur with the cache call i.e. the WRITER wrote
 			# `frappe.cache.X(f"profiler:..."` inline. If the key was
 			# extracted to a previous line via a helper call, this
-			# pattern won't match — and that's the desired behaviour.
+			# pattern won't match and that's the desired behaviour.
 			if _INLINE_KEY_RE.search(line):
 				orphans.append(f"{posix}:{i + 1}  {line.strip()}")
 	return orphans
@@ -130,7 +130,7 @@ def _parse_documented_patterns(doc_text: str) -> list[str]:
 class TestEveryRedisCallUsesKeyBuilder:
 	"""Drift canary: no inline f-string keys inside ``frappe.cache.X(...)``
 	calls outside the exclusion list. If this fails, you wrote a
-	``frappe.cache.set_value(f"profiler:...", ...)`` call — refactor it
+	``frappe.cache.set_value(f"profiler:...", ...)`` call refactor it
 	to call ``optimus.redis_keys.<feature>(...)`` instead (add a builder
 	if one doesn't exist)."""
 
@@ -170,7 +170,7 @@ class TestSchemaSentinel:
 
 	def test_write_sentinel_idempotent(self, monkeypatch):
 		# Install a tiny frappe.cache stub that stores set_value /
-		# get_value in a dict — exercises the real code path without
+		# get_value in a dict exercises the real code path without
 		# needing a bench.
 		import sys
 		from types import SimpleNamespace
@@ -209,7 +209,7 @@ class TestWrapUnwrap:
 		assert version == redis_schema.SCHEMA_VERSION
 
 	def test_unwrap_legacy_returns_none_version(self):
-		"""A bare dict (pre-v0.12.0 shape) flows through as-is — no
+		"""A bare dict (pre-v0.12.0 shape) flows through as-is no
 		envelope, no drift."""
 		from optimus import redis_schema
 

--- a/optimus/tests/test_redundant_calls.py
+++ b/optimus/tests/test_redundant_calls.py
@@ -25,7 +25,7 @@ _USER_CALLER_STACK = [
 	{"filename": "apps/myapp/controllers/bulk.py", "lineno": 42, "function": "do_import"},
 ]
 
-# Framework-only stack — walk_callsite returns None for this, so
+# Framework-only stack walk_callsite returns None for this, so
 # findings built from it get filtered out.
 _FRAMEWORK_CALLER_STACK = [
 	{"filename": "frappe/app.py", "lineno": 120, "function": "application"},
@@ -109,7 +109,7 @@ def test_high_severity_at_5x_threshold():
 
 
 def test_cache_get_threshold_separate_from_doc_threshold():
-	# 8 cache_get calls — well under cache threshold of 50
+	# 8 cache_get calls well under cache threshold of 50
 	recording = {
 		"uuid": "rec-1",
 		"calls": [],
@@ -127,7 +127,7 @@ def test_cache_get_threshold_separate_from_doc_threshold():
 def test_cache_threshold_suppresses_low_count_noise():
 	"""v0.5.2 round 4: cache threshold bumped from 10 → 50. A loop
 	running a cache lookup 30× from the same callsite was previously
-	a Medium finding at 0ms impact — indistinguishable from framework
+	a Medium finding at 0ms impact indistinguishable from framework
 	background noise. Now suppressed entirely.
 
 	Production report trigger: 6 'Redundant cache lookup: <hash> (19/21/25/26/31×)'
@@ -232,7 +232,7 @@ def test_framework_callsite_filters_finding():
 	ctx = AnalyzeContext(session_uuid="t", docname="t")
 	result = redundant_calls.analyze([recording], ctx)
 
-	# No finding — the callsite was framework-only.
+	# No finding the callsite was framework-only.
 	rc = [f for f in result.findings if f["finding_type"] == "Redundant Call"]
 	assert rc == [], (
 		f"Framework-only callsite must not produce a Redundant Call "
@@ -276,7 +276,7 @@ def test_user_callsite_finding_is_kept():
 def test_erpnext_callsite_filters_finding():
 	"""v0.5.2: official Frappe-maintained apps (erpnext, hrms,
 	payments, lms, helpdesk, insights, crm, builder, wiki, drive) are
-	framework for the purposes of the Redundant Call filter — the
+	framework for the purposes of the Redundant Call filter the
 	application developer can't practically patch upstream. A raw
 	production session on Sales Invoice Save+Submit surfaced 10
 	'Redundant cache lookup' findings all landing in
@@ -313,7 +313,7 @@ def test_erpnext_callsite_filters_finding():
 	rc = [f for f in result.findings if f["finding_type"] == "Redundant Call"]
 	assert rc == [], (
 		"ERPNext-internal cache loop must be suppressed from the "
-		"actionable Redundant Call list — users can't patch ERPNext. "
+		"actionable Redundant Call list users can't patch ERPNext. "
 		f"Got: {[f['title'] for f in rc]}"
 	)
 	# Suppression warning surfaces the reason.
@@ -327,7 +327,7 @@ def test_third_party_lib_callsite_filters_finding():
 	"""v0.5.2 round 2: werkzeug / site-packages / gunicorn / rq are
 	infrastructure users can't modify. Production report had 3
 	Redundant Cache Lookup findings in
-	env/lib/python3.14/site-packages/werkzeug/serving.py — the user
+	env/lib/python3.14/site-packages/werkzeug/serving.py the user
 	can't patch werkzeug. Must filter."""
 	werkzeug_stack = [
 		{"filename": "frappe/app.py", "lineno": 120, "function": "application"},
@@ -362,14 +362,14 @@ def test_third_party_lib_callsite_filters_finding():
 
 def test_cross_request_spread_does_not_count_as_redundant():
 	"""v0.5.2 round 2: a cache lookup called ONCE per request
-	across 25 requests isn't a loop — it's framework code that
+	across 25 requests isn't a loop it's framework code that
 	naturally fires once per request. Production report had
 	findings like 'Redundant cache lookup (25 times)' where each
 	of the 25 was a separate request, 1 call each. Filter these
 	with a per-action threshold check."""
 	# 60 recordings, each with exactly ONE cache_get for the same key.
 	# Total = 60 (above threshold of 50, bumped in v0.5.2 round 4),
-	# but per-action max = 1 — not a loop.
+	# but per-action max = 1 not a loop.
 	recordings = []
 	for i in range(60):
 		recordings.append({

--- a/optimus/tests/test_regenerate_reports_api.py
+++ b/optimus/tests/test_regenerate_reports_api.py
@@ -47,7 +47,7 @@ def _regenerate_reports_body() -> str:
 
 class TestSurface:
 	def test_regenerate_reports_is_whitelisted(self):
-		"""The endpoint must carry @frappe.whitelist() — otherwise
+		"""The endpoint must carry @frappe.whitelist() otherwise
 		the front-end can't call it."""
 		src = _read_api_source()
 		# Allow optional intermediate decorators (e.g. @rate_limit) between
@@ -70,10 +70,10 @@ class TestSurface:
 	def test_does_not_re_enqueue_analyze(self):
 		"""Guardrail: regenerate_reports must NOT call
 		_enqueue_analyze. If it does, it's just a slower
-		retry_analyze — the whole point is to skip the analyzer."""
+		retry_analyze the whole point is to skip the analyzer."""
 		body = _regenerate_reports_body()
 		assert "_enqueue_analyze" not in body, (
-			"regenerate_reports must NOT enqueue analyze — that would "
+			"regenerate_reports must NOT enqueue analyze that would "
 			"defeat the purpose of having a separate endpoint"
 		)
 		# Positive check: it does call _render_and_attach_reports.
@@ -84,11 +84,11 @@ class TestSurface:
 
 	def test_clears_cached_pdf(self):
 		"""After regenerating the safe HTML, the cached PDF is
-		stale — must be invalidated so the next download_pdf call
+		stale must be invalidated so the next download_pdf call
 		regenerates from fresh HTML."""
 		body = _regenerate_reports_body()
 		assert "clear_cached_pdf" in body, (
-			"regenerate_reports must clear the cached PDF — otherwise "
+			"regenerate_reports must clear the cached PDF otherwise "
 			"the download_pdf endpoint would serve a stale PDF rendered "
 			"from the old HTML"
 		)
@@ -103,13 +103,13 @@ class TestSurface:
 
 	def test_best_effort_recording_fetch(self):
 		"""When recordings have expired from Redis, the endpoint
-		must still succeed with empty recordings — the important
+		must still succeed with empty recordings the important
 		stuff is stored in the DocType."""
 		body = _regenerate_reports_body()
-		# try/except around the fetch — falls back to [].
+		# try/except around the fetch falls back to [].
 		assert "try:" in body and "recordings = []" in body, (
 			"regenerate_reports must degrade to empty recordings on "
-			"fetch failure — the safe renderer still produces a useful "
+			"fetch failure the safe renderer still produces a useful "
 			"report without them"
 		)
 
@@ -117,7 +117,7 @@ class TestSurface:
 		"""v0.12.9: regenerate_reports must refuse Recording / Stopping
 		/ Analyzing sessions. Pre-v0.12.9 the code had no status check
 		despite the docstring claiming "Allowed on Ready OR Failed
-		sessions" — a re-render on an in-flight session would attach
+		sessions" a re-render on an in-flight session would attach
 		an incomplete report to a still-running analyze that the
 		pipeline would then overwrite. The gate enforces the
 		docstring's contract."""
@@ -129,7 +129,7 @@ class TestSurface:
 			body,
 		), (
 			"regenerate_reports must gate on row['status'] not in "
-			"('Ready', 'Failed') — pre-v0.12.9 the endpoint accepted "
+			"('Ready', 'Failed') pre-v0.12.9 the endpoint accepted "
 			"any status and re-rendered mid-analyze sessions"
 		)
 		# The error message must mention 'retry_analyze' as the

--- a/optimus/tests/test_rename_phase_two_doctype_patch.py
+++ b/optimus/tests/test_rename_phase_two_doctype_patch.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""v0.6.x: tests for ``patches/v0_6_0/rename_phase_two_doctype.py`` — the
+"""v0.6.x: tests for ``patches/v0_6_0/rename_phase_two_doctype.py``: the
 one-time DocType rename from ``Profiler Phase 2 Run`` →
 ``Profiler Phase Two Run`` (audit item 2.6). The patch ran BEFORE the
 v0.7.0 app rename, so the DocType names here stay Profiler-prefixed;
@@ -115,7 +115,7 @@ class TestRenamePhaseTwoDoctypePatch:
 
 	def test_rename_failure_logs_and_does_not_commit(self, monkeypatch):
 		"""If rename_doc raises (e.g. table-lock during migrate), the
-		patch must NOT commit and must NOT raise — let the operator
+		patch must NOT commit and must NOT raise let the operator
 		retry migrate."""
 		stub = _install_frappe_stub(monkeypatch, old_exists=True, rename_raises=True)
 		patch = _import_patch()
@@ -126,7 +126,7 @@ class TestRenamePhaseTwoDoctypePatch:
 
 class TestPatchRegistered:
 	def test_patches_txt_lists_in_pre_model_sync(self):
-		"""The rename MUST run before model sync — otherwise model sync
+		"""The rename MUST run before model sync otherwise model sync
 		creates a fresh new-name DocType row alongside the old one."""
 		import os
 		patches_txt = os.path.join(

--- a/optimus/tests/test_render_drilldown.py
+++ b/optimus/tests/test_render_drilldown.py
@@ -139,14 +139,14 @@ class TestDrilldownRender:
 		)
 		# v0.7.x Phase D: drill-down chain renders as pill steps; the
 		# per-step `% of parent` value isn't shown in the new layout
-		# (the mock dropped it for visual cleanliness — data still
+		# (the mock dropped it for visual cleanliness data still
 		# available via the underlying drilldown_chain dict for API
 		# consumers).
 
 	def test_finding_without_matching_tree_node_renders_placeholder(self):
 		"""v0.7.x: a finding whose callsite doesn't match any node in
 		the tree (origin lookup fails) is now treated the same as
-		'chain attempted but empty' — the Drill-down placeholder
+		'chain attempted but empty' the Drill-down placeholder
 		renders ('no deeper user-code frame'). The attachment runs
 		because the finding has a callsite + action_ref + tree; the
 		walker returns [] because it couldn't locate the origin, and
@@ -154,7 +154,7 @@ class TestDrilldownRender:
 
 		Pre-v0.7 this case rendered nothing at all. The placeholder is
 		slightly less accurate here ('we couldn't find the origin'
-		isn't quite 'no deeper code'), but it's still defensible — the
+		isn't quite 'no deeper code'), but it's still defensible the
 		user sees that drill-down was tried and produced no chain."""
 		from optimus import renderer
 
@@ -176,7 +176,7 @@ class TestDrilldownRender:
 		assert "Drill-down" in html
 		# Placeholder text rendered.
 		assert "no deeper user-code frame" in html
-		# No actual chain entries rendered — the bg of `_run_validations`
+		# No actual chain entries rendered the bg of `_run_validations`
 		# / framework descent shouldn't appear (we never matched an
 		# origin to walk from).
 		assert "% of parent" not in html

--- a/optimus/tests/test_render_phase2_panel.py
+++ b/optimus/tests/test_render_phase2_panel.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for renderer._render_phase2_panel — exercises the phase-2 HTML
+"""Tests for renderer._render_phase2_panel exercises the phase-2 HTML
 without spinning up Frappe / Jinja. We feed a minimal session-doc-shaped
 object directly to the helper.
 """
@@ -67,7 +67,7 @@ class TestRenderPhase2PanelSingleRun:
 		html = renderer._render_phase2_panel(session)
 
 		assert "my_app.x.compute" in html
-		# v0.7.x Phase I.2: heading dropped the "Phase 2" prefix —
+		# v0.7.x Phase I.2: heading dropped the "Phase 2" prefix
 		# now reads just "Line-Level Drilldown" (the section's own
 		# content makes the line-level drilldown nature self-evident
 		# without the internal-phase jargon).
@@ -268,7 +268,7 @@ class TestRenderPhase2PanelPosition:
 		assert phase2_idx > 0, "id=\"phase2\" wrapper missing from rendered HTML"
 		assert findings_h2 > 0, "Findings <h2> missing from rendered HTML"
 		assert phase2_idx < findings_h2, (
-			"Phase 2 panel must render before the Findings <h2> — it is the "
+			"Phase 2 panel must render before the Findings <h2> it is the "
 			"showcase section, hoisted above the actionable list"
 		)
 

--- a/optimus/tests/test_renderer_structure_snapshot.py
+++ b/optimus/tests/test_renderer_structure_snapshot.py
@@ -2,11 +2,11 @@
 # For license information, please see license.txt
 
 """Structural DOM snapshot of ``renderer.render_raw`` against a synthetic
-fixture session — the canary that protects the template contract during
+fixture session the canary that protects the template contract during
 the v0.10.0+ renderer split.
 
-The existing renderer-touching tests (46 files) all assert *content* —
-"the string '50× hits' appears in the HTML" — but none of them lock the
+The existing renderer-touching tests (46 files) all assert *content*
+"the string '50× hits' appears in the HTML" but none of them lock the
 *structure* (tag nesting, CSS class names, section IDs, data attributes).
 A refactor that quietly renamed ``<div class="finding-card">`` to
 ``<section class="finding">`` would pass every existing test and break
@@ -14,21 +14,21 @@ the (frozen) template's CSS. This file closes that gap.
 
 The fingerprint is structural, not byte-for-byte:
 
-  * ``section_ids`` — sorted list of every ``id="..."`` attribute value
+  * ``section_ids``: sorted list of every ``id="..."`` attribute value
     that appears in the document. Catches a section being silently
     dropped or renamed.
 
-  * ``class_names`` — sorted multiset of every distinct ``class="..."``
+  * ``class_names``: sorted multiset of every distinct ``class="..."``
     token (split on whitespace). Catches a CSS class being renamed,
     added, or removed.
 
-  * ``tag_counts`` — total count per tag name across the whole
+  * ``tag_counts``: total count per tag name across the whole
     document. Coarse DOM-shape sanity; catches gross structural drift
     (e.g. ``<div>`` → ``<section>`` mass rename).
 
 Byte-for-byte would be too brittle (Pygments token ordering across
 versions, dict iteration in JSON, etc.). The structural shape drifts
-slowly and intentionally — when a legitimate template change lands,
+slowly and intentionally when a legitimate template change lands,
 the test fails with a focused diff and the contributor regenerates the
 snapshot via ``REGENERATE_RENDERER_SNAPSHOT=1 pytest``.
 
@@ -58,7 +58,7 @@ _REGENERATE_ENV = "REGENERATE_RENDERER_SNAPSHOT"
 
 
 # --------------------------------------------------------------------------
-# Fixture — covers as many of the 14 conditional sections as practical
+# Fixture covers as many of the 14 conditional sections as practical
 # --------------------------------------------------------------------------
 
 
@@ -173,7 +173,7 @@ def _v5_aggregate() -> dict:
 
 def _snapshot_doc() -> SimpleNamespace:
 	"""Synthetic Optimus Session that exercises the major conditional
-	sections — findings (actionable + observational), actions (HTTP +
+	sections findings (actionable + observational), actions (HTTP +
 	RQ Job → waterfall + background-jobs), top_queries, table_breakdown,
 	and the v5 server-resource + frontend panels."""
 	findings = [
@@ -287,7 +287,7 @@ def _fingerprint(html_text: str) -> dict:
 
 def _diff_message(expected: dict, actual: dict) -> str:
 	"""Return a focused human-readable diff so a snapshot mismatch points
-	straight at what drifted. Cheap to compute — only used on failure."""
+	straight at what drifted. Cheap to compute only used on failure."""
 	msgs = []
 	e_ids = set(expected.get("section_ids", []))
 	a_ids = set(actual.get("section_ids", []))
@@ -310,11 +310,11 @@ def _diff_message(expected: dict, actual: dict) -> str:
 			tag_diffs.append(f"<{t}>: {ev} → {av}")
 	if tag_diffs:
 		msgs.append("tag_counts changed: " + ", ".join(tag_diffs[:15]))
-	return "\n  ".join(msgs) or "fingerprint mismatch (no obvious diff — re-read both)"
+	return "\n  ".join(msgs) or "fingerprint mismatch (no obvious diff re-read both)"
 
 
 # --------------------------------------------------------------------------
-# The canary test — fingerprint matches golden (or regenerates it)
+# The canary test fingerprint matches golden (or regenerates it)
 # --------------------------------------------------------------------------
 
 
@@ -345,7 +345,7 @@ class TestStructureSnapshot:
 
 	def test_self_containment_invariant(self):
 		"""Duplicates the canary assertion from test_report_a11y so the
-		snapshot fixture is itself locked to never grow a remote-fetch URL —
+		snapshot fixture is itself locked to never grow a remote-fetch URL
 		even if the per-section extractions add a section that accidentally
 		imports something with a network side-effect."""
 		doc = _snapshot_doc()
@@ -364,7 +364,7 @@ class TestStructureSnapshot:
 		)
 
 	def test_minimum_sections_present(self):
-		"""Independent of the byte-match — at least the sections triggered
+		"""Independent of the byte-match at least the sections triggered
 		by this fixture must appear. Guards against a future extraction
 		that silently drops a section from the template-context dict (the
 		``{% if report_data.X %}`` gate stays open but the data is missing)."""
@@ -390,7 +390,7 @@ class TestStructureSnapshot:
 
 
 # --------------------------------------------------------------------------
-# Import-surface tests — the contract that survives the split
+# Import-surface tests the contract that survives the split
 # --------------------------------------------------------------------------
 
 
@@ -406,11 +406,11 @@ class TestPublicAPIPreserved:
 		assert callable(getattr(renderer, "render", None))
 
 	def test_finding_to_dict_resolves(self):
-		# Semi-public — used by analyze.py for the AI auto-suggest payload.
+		# Semi-public used by analyze.py for the AI auto-suggest payload.
 		assert callable(getattr(renderer, "_finding_to_dict", None))
 
 	def test_build_donut_svg_resolves(self):
-		# Public — passed into the template context.
+		# Public passed into the template context.
 		assert callable(getattr(renderer, "build_donut_svg", None))
 
 	def test_build_hot_frames_table_resolves(self):
@@ -424,7 +424,7 @@ class TestPublicAPIPreserved:
 		assert getattr(renderer, "_BoundedFileCache", None) is not None
 
 	def test_read_source_snippet_resolves(self):
-		# Heavy semi-public — many analyze + test callers.
+		# Heavy semi-public many analyze + test callers.
 		assert callable(getattr(renderer, "_read_source_snippet", None))
 
 	def test_markdown_to_safe_html_resolves(self):

--- a/optimus/tests/test_report_a11y.py
+++ b/optimus/tests/test_report_a11y.py
@@ -6,7 +6,7 @@
 Renders end-to-end via ``renderer.render_raw`` and asserts the a11y pass holds:
 darkened mute token, severity text labels on the waterfall (not colour-only),
 the AI-fix "unverified" badge, back-to-top anchors, and the self-contained /
-offline-safe invariant (no scripts, no external resource loads — aerele.in
+offline-safe invariant (no scripts, no external resource loads aerele.in
 *anchor* links are allowed).
 """
 
@@ -61,7 +61,7 @@ def _render(**kw):
 
 
 # --------------------------------------------------------------------------
-# FIX 1 — contrast token
+# FIX 1 contrast token
 # --------------------------------------------------------------------------
 
 def test_ink_mute_darkened_to_aa():
@@ -73,7 +73,7 @@ def test_ink_mute_darkened_to_aa():
 
 
 # --------------------------------------------------------------------------
-# FIX 4 — waterfall severity labels (not colour-only)
+# FIX 4 waterfall severity labels (not colour-only)
 # --------------------------------------------------------------------------
 
 def test_waterfall_has_text_severity_labels():
@@ -88,7 +88,7 @@ def test_waterfall_has_text_severity_labels():
 
 
 # --------------------------------------------------------------------------
-# Finding impact — show per-hit alongside the consolidated total
+# Finding impact show per-hit alongside the consolidated total
 # --------------------------------------------------------------------------
 
 def test_finding_impact_shows_per_hit_with_consolidated():
@@ -110,7 +110,7 @@ def test_finding_impact_suppresses_per_hit_when_it_would_round_to_zero():
 
 
 # --------------------------------------------------------------------------
-# FIX 5 — AI-fix unverified badge
+# FIX 5 AI-fix unverified badge
 # --------------------------------------------------------------------------
 
 def test_ai_fix_unverified_badge_present():
@@ -137,7 +137,7 @@ def test_back_to_top_links_removed_find_in_page_note_kept():
 
 
 # --------------------------------------------------------------------------
-# Invariant — self-contained / offline-safe
+# Invariant self-contained / offline-safe
 # --------------------------------------------------------------------------
 
 def test_report_is_self_contained_offline():
@@ -152,6 +152,6 @@ def test_report_is_self_contained_offline():
 	assert not re.search(r'<link\b[^>]*href\s*=\s*["\']https?:', html)  # no remote stylesheet
 	assert "@import" not in html
 	assert "url(http" not in html.replace(" ", "").replace("'", "").replace('"', "")
-	# Anchor links (e.g. aerele.in) ARE allowed — sanity-check one exists so the
+	# Anchor links (e.g. aerele.in) ARE allowed sanity-check one exists so the
 	# checks above aren't trivially passing on an empty page.
 	assert re.search(r'<a [^>]*href="https?://', html)

--- a/optimus/tests/test_report_context.py
+++ b/optimus/tests/test_report_context.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for ``optimus.report_context.build_report_context`` — the Phase J.1
+"""Tests for ``optimus.report_context.build_report_context``: the Phase J.1
 adapter that turns our flat 45-key render-context into the 19-key contract
 shape per ``template_variable_contract.md`` (reference design package).
 
@@ -137,7 +137,7 @@ class TestIsUserCode:
 
 class TestTopLevelKeys:
 	def test_all_19_contract_keys_present(self):
-		# Subset rather than equality — pragmatic non-contract extensions
+		# Subset rather than equality pragmatic non-contract extensions
 		# like ``actions_framework`` / ``background_jobs_framework`` from
 		# J.2.3 are permitted; the contract just specifies a minimum.
 		out = build_report_context(_doc(), _ctx())
@@ -410,7 +410,7 @@ class TestActionPlanShape:
 	def test_step_title_and_desc_are_html_escaped(self):
 		"""SECURITY: title/desc can carry attacker-controlled captured data
 		(e.g. a client-supplied page_url in a Slow Frontend Render title) and
-		the template renders title_html/description_html with ``| safe`` — so
+		the template renders title_html/description_html with ``| safe``: so
 		they MUST be HTML-escaped here or it's stored XSS in the report viewer."""
 		ap_in = [{
 			"n": 1,
@@ -498,7 +498,7 @@ class TestBackgroundJobsShape:
 		``findings_count: None`` from analyze. The bg-jobs section
 		template sums ``findings_count`` via Jinja's ``map | sum``, and
 		Jinja's ``map('default', 0)`` filter only handles Undefined (NOT
-		None) — so an uncoerced None used to crash the whole render with
+		None) so an uncoerced None used to crash the whole render with
 		``unsupported operand type(s) for +: 'int' and 'NoneType'``.
 		``_build_background_jobs`` now coerces the original
 		``findings_count`` key to ``int(... or 0)`` alongside the contract
@@ -590,7 +590,7 @@ class TestFrontendShape:
 		out = build_report_context(_doc(), _ctx(frontend_vitals_by_page=vitals))
 		row = out["frontend"]["web_vitals"][0]
 		assert row["fcp_class"] == "vital-none"
-		assert row["fcp_display"] == "—"
+		assert row["fcp_display"] == ""
 		assert row["cls_class"] == "vital-meh"
 
 

--- a/optimus/tests/test_report_file_save.py
+++ b/optimus/tests/test_report_file_save.py
@@ -20,7 +20,7 @@ Frappe's validator has a designed bypass:
 
 analyze runs as a background RQ job in the normal case (no request
 context, bypass fires). But when the site has the scheduler disabled,
-analyze runs INLINE inside api.stop's HTTP handler — frappe.request
+analyze runs INLINE inside api.stop's HTTP handler frappe.request
 is set, bypass doesn't fire, HTML report insert fails with
 FileTypeNotAllowed.
 

--- a/optimus/tests/test_retry_phase2_batch.py
+++ b/optimus/tests/test_retry_phase2_batch.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""v0.6.x: surface tests for ``api.retry_phase2_analyzes_batch`` — the
+"""v0.6.x: surface tests for ``api.retry_phase2_analyzes_batch``: the
 batched retry endpoint that replaces the per-run ``frappe.call(...)`` loop
 in ``optimus_session.js``. Pattern: source-inspect (mirrors
 ``test_suggest_fix_api.py``)."""
@@ -61,7 +61,7 @@ class TestRetryPhase2BatchEndpoint:
 		assert "non-empty list" in body
 
 	def test_isolates_per_row_failures(self):
-		"""One bad run_uuid must NOT abort the rest of the batch — that's
+		"""One bad run_uuid must NOT abort the rest of the batch that's
 		the whole point of moving the loop server-side."""
 		body = _fn_body("retry_phase2_analyzes_batch")
 		# Each iteration is wrapped in try/except.
@@ -78,7 +78,7 @@ class TestRetryPhase2BatchEndpoint:
 
 	def test_delegates_to_retry_phase2_analyze(self):
 		"""The batched endpoint should reuse the single-run logic, not
-		duplicate it — otherwise drift between the two paths is inevitable."""
+		duplicate it otherwise drift between the two paths is inevitable."""
 		body = _fn_body("retry_phase2_analyzes_batch")
 		assert "retry_phase2_analyze(run_uuid)" in body
 
@@ -94,7 +94,7 @@ class TestRetryPhase2BatchJsCall:
 
 	def test_js_threshold_is_two_or_more_stuck_runs(self):
 		"""The batch button must only appear when batching actually
-		saves round-trips — i.e. 2+ stuck runs. One stuck run still
+		saves round-trips i.e. 2+ stuck runs. One stuck run still
 		uses the per-run button."""
 		js = _read(_JS_PATH)
 		assert "stuck_runs.length >= 2" in js

--- a/optimus/tests/test_root_cause_grouping.py
+++ b/optimus/tests/test_root_cause_grouping.py
@@ -3,7 +3,7 @@
 
 """Tests for the renderer's root-cause grouping pass.
 
-A single get-doc-in-a-loop bug often produces 4-5 findings — a Slow
+A single get-doc-in-a-loop bug often produces 4-5 findings a Slow
 Hot Path on the wrapper, a Hot Line on the exact line, a Redundant
 Call for the fetched doc, a Redundant Permission Check downstream
 of it. The dev only has ONE fix to make; rendering 5 separate cards
@@ -55,7 +55,7 @@ def _hot_line(*, function="_check_user_exists", filename="apps/myapp/common.py",
 	return {
 		"finding_type": "Hot Line",
 		"severity": severity,
-		"title": f"{function}:{lineno} consumed {impact_ms}ms (100 hits) — single hottest line",
+		"title": f"{function}:{lineno} consumed {impact_ms}ms (100 hits) single hottest line",
 		"customer_description": "leaf hot line",
 		"estimated_impact_ms": impact_ms,
 		"affected_count": 100,
@@ -106,7 +106,7 @@ def _infra(*, severity="Low", impact_ms=0.0):
 class TestRootCauseKey:
 	def test_drilldown_leaf_wins_over_callsite(self):
 		"""When drilldown_chain is non-empty, the leaf's (file, function)
-		is used — not the (retargeted or not) callsite. This is what
+		is used not the (retargeted or not) callsite. This is what
 		lets a Slow Hot Path on ``looped_validate`` (its retargeted
 		callsite says ``_run_validations`` but its chain ends at
 		``_check_user_exists``) group with a Hot Line that targets
@@ -142,7 +142,7 @@ class TestRootCauseKey:
 class TestGrouping:
 	def test_four_findings_one_leaf_collapse_to_primary(self):
 		"""The user's pattern: Slow Hot Path (looped_validate chain),
-		Hot Line, Redundant Call, Redundant Permission Check — all
+		Hot Line, Redundant Call, Redundant Permission Check all
 		resolve to _check_user_exists. They collapse into one primary
 		with three sub_findings."""
 		shp = _shp(
@@ -155,7 +155,7 @@ class TestGrouping:
 		hot = _hot_line(impact_ms=300.0, severity="High")
 		rc = _redundant_call(severity="High", impact_ms=80.0,
 		                     function="_check_user_exists")
-		# Two redundant calls — same root cause, different subjects.
+		# Two redundant calls same root cause, different subjects.
 		rc2 = {
 			**_redundant_call(severity="Medium", impact_ms=40.0),
 			"finding_type": "Redundant Permission Check",
@@ -209,7 +209,7 @@ class TestGrouping:
 		assert result[-1]["finding_type"] == "System CPU Hot"
 
 	def test_primary_pick_uses_severity_first(self):
-		"""Within a group, severity beats impact_ms — a HIGH 100ms
+		"""Within a group, severity beats impact_ms a HIGH 100ms
 		finding beats a MEDIUM 1000ms finding for primary."""
 		low_impact_high_sev = _hot_line(severity="High", impact_ms=100.0)
 		high_impact_med_sev = _redundant_call(severity="Medium", impact_ms=1000.0,
@@ -230,7 +230,7 @@ class TestGrouping:
 		assert _group_findings_by_root_cause([]) == []
 
 	def test_subs_carry_compact_payload_only(self):
-		"""sub_findings entries are a compact dict — they don't carry
+		"""sub_findings entries are a compact dict they don't carry
 		the full technical_detail or llm_fix, just enough to render the
 		collapsed row (type, severity, title, description, impact, count)."""
 		shp = _shp(

--- a/optimus/tests/test_safe_commit.py
+++ b/optimus/tests/test_safe_commit.py
@@ -1,13 +1,13 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""v0.6.x: tests for ``optimus.safe_commit`` — the rollback-on-error
+"""v0.6.x: tests for ``optimus.safe_commit``: the rollback-on-error
 wrapper that every explicit commit in this codebase now routes through.
 
 Addresses Lens audit finding *"frappe.db.commit() without try/except"*.
 
 Uses pytest's ``monkeypatch.setitem(sys.modules, ...)`` so the stubbed
-``frappe`` is auto-restored at test teardown — without that, every test
+``frappe`` is auto-restored at test teardown without that, every test
 running AFTER one of these in the same pytest session would inherit our
 minimal stub and crash on missing recorder / realtime / local symbols.
 """
@@ -44,8 +44,8 @@ def _build_frappe_stub(*, commit_raises=False, rollback_raises=False):
 def _import_safe_commit(monkeypatch):
 	"""Return ``optimus.safe_commit`` re-resolved against the
 	current ``sys.modules["frappe"]`` stub. The function captures
-	``frappe`` per-call via a lazy import — no module-level binding to
-	worry about — but we still defensively delete any cached
+	``frappe`` per-call via a lazy import no module-level binding to
+	worry about but we still defensively delete any cached
 	``optimus`` package reference so a fresh import isn't a
 	subtle no-op."""
 	# safe_commit lives at package top-level (optimus/__init__.py).
@@ -77,7 +77,7 @@ class TestSafeCommit:
 		"""Rare double-fault: commit() raises, then rollback() ALSO raises.
 		We swallow the rollback error (the connection's likely dead anyway
 		so the rollback exception is just noise) and bubble the ORIGINAL
-		commit exception — that's the one with the actionable error
+		commit exception that's the one with the actionable error
 		message."""
 		stub = _build_frappe_stub(commit_raises=True, rollback_raises=True)
 		monkeypatch.setitem(sys.modules, "frappe", stub)

--- a/optimus/tests/test_scheduler_inline_fallback.py
+++ b/optimus/tests/test_scheduler_inline_fallback.py
@@ -34,7 +34,7 @@ def test_enqueue_analyze_honors_inline_analyze_limit():
     # janitor) gets the same protection uniformly.
     src = inspect.getsource(api._enqueue_analyze)
     assert "optimus_inline_analyze_limit" in src
-    # And must NOT have the cap check still in _stop_session — that
+    # And must NOT have the cap check still in _stop_session that
     # would be a duplicate that could diverge.
     stop_src = inspect.getsource(api._stop_session)
     assert "optimus_inline_analyze_limit" not in stop_src
@@ -125,8 +125,8 @@ def test_enqueue_analyze_swallows_inline_failure(monkeypatch):
 	re-raise and return True.
 
 	If we let the exception propagate up to stop(), the stop API
-	returns a 500 and the widget shows "Failed to stop profiler —
-	try again" — which is wrong, because the stop DID work; only
+	returns a 500 and the widget shows "Failed to stop profiler
+	try again" which is wrong, because the stop DID work; only
 	analyze failed. The session is already marked Failed in the DB.
 	"""
 	import sys
@@ -162,7 +162,7 @@ def test_enqueue_analyze_swallows_inline_failure(monkeypatch):
 		raising=False,
 	)
 
-	# Must NOT raise — the failure has been absorbed so stop() can
+	# Must NOT raise the failure has been absorbed so stop() can
 	# return 200 and report the Failed status to the widget.
 	ran_inline = api_mod._enqueue_analyze("test-uuid-fail")
 	assert ran_inline is True
@@ -192,7 +192,7 @@ def test_enqueue_analyze_blocks_huge_inline_session(monkeypatch):
     _enqueue_analyze must:
       1. Mark the Optimus Session as Failed
       2. Write an actionable message to analyzer_warnings
-         (NOT 'analyze_error' — that field doesn't exist on the doctype,
+         (NOT 'analyze_error' that field doesn't exist on the doctype,
          writing to it would crash with MariaDB 'Unknown column')
       3. NOT invoke frappe.enqueue
       4. Return True so the caller treats it like any other inline
@@ -264,7 +264,7 @@ def test_enqueue_analyze_blocks_huge_inline_session(monkeypatch):
 
     # Return contract: cap-exceeded counts as "session is finalized".
     assert ran_inline is True
-    # And frappe.enqueue must NOT have been called — the cap check
+    # And frappe.enqueue must NOT have been called the cap check
     # fires BEFORE the enqueue.
     assert enqueue_calls == []
 
@@ -281,7 +281,7 @@ def test_enqueue_analyze_blocks_huge_inline_session(monkeypatch):
     # `analyze_error`. The doctype has no `analyze_error` field, so
     # writing to it would crash with MariaDB 'Unknown column' in
     # production. FakeDB accepts any field name so the test would
-    # silently pass if the code regressed to the wrong field name —
+    # silently pass if the code regressed to the wrong field name
     # assert explicitly.
     payload = status_calls[0][2]
     assert "analyzer_warnings" in payload, (
@@ -301,7 +301,7 @@ def test_enqueue_analyze_cap_is_called_by_stop_session():
     """Source-inspection regression guard: _stop_session must pass
     docname to _enqueue_analyze so the cap check has the doc to
     update. Earlier versions had the cap check inline in
-    _stop_session — the refactor moved it to _enqueue_analyze, and
+    _stop_session the refactor moved it to _enqueue_analyze, and
     if _stop_session forgets to pass docname, the cap silently
     skips.
     """
@@ -320,7 +320,7 @@ def test_enqueue_analyze_cap_is_called_by_stop_session():
 
 def test_enqueue_analyze_cap_is_called_by_retry_analyze():
     """Same guard for retry_analyze. v0.5.1 fix ensures retry
-    applies the same inline cap as stop() — a 200-recording Failed
+    applies the same inline cap as stop() a 200-recording Failed
     session on a scheduler-disabled site must not run inline
     without the cap check.
     """

--- a/optimus/tests/test_server_script_render.py
+++ b/optimus/tests/test_server_script_render.py
@@ -8,7 +8,7 @@ Frappe's ``safe_exec`` (apps/frappe/frappe/utils/safe_exec.py:49,118) compiles
 Server Scripts with a synthetic filename ``<serverscript>: <scrubbed-name>``.
 The capture + analyze halves of Optimus already treat these as user code
 (call_tree.py:475-495 explicitly carves Server Scripts out of the plumbing
-filter). The renderer is what was lacking — labels collapsed to a generic
+filter). The renderer is what was lacking labels collapsed to a generic
 ``<server-script body>``, app bucketing went to ``[other]``, no source
 snippet, no editor link.
 
@@ -54,7 +54,7 @@ class TestExtractScriptName:
 
 	def test_bare_server_script_returns_none(self):
 		# Frappe writes a bare ``<serverscript>`` when no script_filename
-		# is passed — nothing to look up, so callers skip.
+		# is passed nothing to look up, so callers skip.
 		assert sss.extract_script_name("<serverscript>") is None
 		assert sss.extract_script_name("<serverscript> ") is None
 
@@ -107,7 +107,7 @@ class TestGetServerScriptRecord:
 			raise RuntimeError("db is on fire")
 
 		monkeypatch.setattr(frappe, "get_all", boom, raising=False)
-		# Must NOT raise — best-effort guarantee.
+		# Must NOT raise best-effort guarantee.
 		assert sss.get_server_script_record("my_script") is None
 
 	def test_cache_memoizes_lookup(self, fake_frappe_db):
@@ -167,7 +167,7 @@ class TestCallTreeDisplay:
 		assert label != "<server-script body>"
 
 	def test_display_label_for_bare_server_script_keeps_fallback(self):
-		"""Bare ``<serverscript>`` (no name) has nothing better to show — keep
+		"""Bare ``<serverscript>`` (no name) has nothing better to show keep
 		a generic label (no crash, no name confusion)."""
 		node = {"filename": "<serverscript>", "function": "", "lineno": None}
 		label = call_tree._display_name_for_node(node)
@@ -183,12 +183,12 @@ class TestAppBucketing:
 		assert call_tree._top_level_app("", "<serverscript>: my_script") == "Server Scripts"
 
 	def test_bare_server_script_buckets_to_server_scripts(self):
-		# Even without a name, it's still a Server Script — better than the
+		# Even without a name, it's still a Server Script better than the
 		# anonymous [other] bucket.
 		assert call_tree._top_level_app("", "<serverscript>") == "Server Scripts"
 
 	def test_other_angle_bracket_filenames_still_route_to_other(self):
-		"""Regression guard: don't widen the carve-out beyond Server Scripts —
+		"""Regression guard: don't widen the carve-out beyond Server Scripts
 		``<string>`` / ``<frozen …>`` etc. must still go to ``[other]``."""
 		assert call_tree._top_level_app("", "<string>") == "[other]"
 		assert call_tree._top_level_app("", "<frozen importlib._bootstrap>") == "[other]"
@@ -207,7 +207,7 @@ class TestRendererSnippetAndLink:
 
 		fake_frappe_db["rows"] = [{"name": "Foo", "script": "a\nb"}]
 		resolved = renderer._resolve_source_path("<serverscript>: foo")
-		# Tuple sentinel — distinguishes from str (real path) and None.
+		# Tuple sentinel distinguishes from str (real path) and None.
 		assert resolved is not None
 		assert resolved != "<serverscript>: foo"  # not just the raw filename
 		# Sentinel shape: ("server_script", scrubbed_name)
@@ -236,7 +236,7 @@ class TestEndToEndServerScriptFinding:
 	def test_finding_card_shows_snippet_and_desk_link(self, fake_frappe_db):
 		"""Render a session with one finding whose callsite is a Server Script.
 		The card must (a) link to the Desk Server Script form, (b) inline the
-		Server Script's source body — not a vscode:// link, not a bare
+		Server Script's source body not a vscode:// link, not a bare
 		``<server-script body>`` blob."""
 		from optimus import renderer
 
@@ -304,7 +304,7 @@ class TestEndToEndServerScriptFinding:
 
 # ---------------------------------------------------------------------------
 # Server Script driven through the def-expansion path
-# (``_decorator_through_def_rows`` → ``_source_lines``) — the combination the
+# (``_decorator_through_def_rows`` → ``_source_lines``) the combination the
 # ±2-window / render tests above never exercise end-to-end.
 # ---------------------------------------------------------------------------
 
@@ -318,8 +318,8 @@ class TestServerScriptThroughDefExpansion:
 			{
 				"name": "My Script",
 				"script": (
-					"@frappe.whitelist()\n"  # 1 — pyinstrument's recorded line
-					"def handler():\n"  # 2 — the def
+					"@frappe.whitelist()\n"  # 1 pyinstrument's recorded line
+					"def handler():\n"  # 2 the def
 					"    for u in frappe.db.get_all('User'):\n"  # 3
 					"        frappe.get_doc('User', u.name)\n"  # 4
 				),

--- a/optimus/tests/test_session_jobs.py
+++ b/optimus/tests/test_session_jobs.py
@@ -4,7 +4,7 @@
 """Per-job terminal-status tracking (v0.7.x).
 
 A flow's enqueued RQ jobs are recorded in a never-pruned hash so analyze can
-report each one's terminal status (completed / failed / timeout / running) —
+report each one's terminal status (completed / failed / timeout / running)
 including jobs that failed or timed out and produced no recording. Uses a fake
 cache backend so we don't depend on Redis.
 """
@@ -95,18 +95,18 @@ def test_empty_session_uuid_is_safe(fake_cache):
 
 
 # ---------------------------------------------------------------------------
-# _atomic_merge_job_meta — closes the multi-worker read-modify-write race.
+# _atomic_merge_job_meta closes the multi-worker read-modify-write race.
 # ---------------------------------------------------------------------------
 # In multi-long-worker production, the previous read-modify-write (HGET +
 # Python merge + HSET via two Redis calls) can drop fields when two workers
-# update the SAME job_id's meta concurrently — e.g. Worker A's after_job
+# update the SAME job_id's meta concurrently e.g. Worker A's after_job
 # writes recording_uuid while Worker B's analyze.run hits the wait cap and
 # writes status="Running". Whoever writes second clobbers the other's
 # modifications.
 #
 # The fix moves the merge server-side via a Redis Lua script (atomic). The
 # wrapper falls back to the existing read-modify-write for cache backends
-# that reject ``.eval()`` — exercised by these tests through FakeCache,
+# that reject ``.eval()``: exercised by these tests through FakeCache,
 # which doesn't implement eval. The concurrent-write proof against real
 # Redis (TestAtomicMergeJobMetaConcurrent below) is the regression test
 # that the Lua path actually fires and is lossless.
@@ -166,7 +166,7 @@ class TestAtomicMergeJobMeta:
 	def test_fallback_when_eval_raises(self, fake_cache, monkeypatch):
 		"""If frappe.cache.eval exists but raises (e.g. NoScriptError on a
 		Redis variant), the helper must still complete via the non-atomic
-		path — best-effort, never break the caller."""
+		path best-effort, never break the caller."""
 		import frappe
 
 		def boom(*a, **kw):
@@ -206,7 +206,7 @@ class TestAtomicMergeJobMetaConcurrent:
 	"""Stand-in for the production multi-worker race using threads. In real
 	RQ deployments each worker is a SEPARATE PROCESS with its own
 	``frappe.local`` (Werkzeug Local is per-thread/process), so the full
-	``_atomic_merge_job_meta`` wrapper — including ``make_key`` — works
+	``_atomic_merge_job_meta`` wrapper including ``make_key``: works
 	end-to-end in each worker. Threads can't replay that exactly because
 	``frappe.local.conf`` isn't set in non-main threads; the test pre-computes
 	the prefixed key in the main thread and calls the Lua script directly
@@ -223,7 +223,7 @@ class TestAtomicMergeJobMetaConcurrent:
 		try:
 			frappe.cache.ping()
 		except Exception:
-			pytest.skip("No bench Redis available — start with `bench start`")
+			pytest.skip("No bench Redis available start with `bench start`")
 		try:
 			frappe.cache.eval("return 1", 0)
 		except Exception:
@@ -255,10 +255,10 @@ class TestAtomicMergeJobMetaConcurrent:
 			for t in threads:
 				t.join()
 
-			# Read via the SUT (which uses raw redis-py — bypasses the
+			# Read via the SUT (which uses raw redis-py bypasses the
 			# RedisWrapper's pickle wrapper, matches the Lua write encoding).
 			meta = session._read_job(sid, jid)
-			assert meta is not None, "meta missing entirely — Lua write failed"
+			assert meta is not None, "meta missing entirely Lua write failed"
 			missing = [f"field_{i}" for i in range(N) if meta.get(f"field_{i}") != f"value_{i}"]
 			assert not missing, (
 				f"{len(missing)}/{N} fields dropped under concurrent writes; "

--- a/optimus/tests/test_session_meta.py
+++ b/optimus/tests/test_session_meta.py
@@ -91,10 +91,10 @@ def test_register_recording_does_not_resurrect_cleared_active_pointer(fake_cache
 	"""v0.7.x regression guard: a Stop call clears the active-session
 	Redis pointer. If an in-flight request's ``after_request`` then calls
 	``register_recording``, the TTL refresh must NOT re-create the
-	pointer — otherwise subsequent HTTP requests get captured into the
+	pointer otherwise subsequent HTTP requests get captured into the
 	already-stopped session and the widget flips back to Recording on
 	the user's next interaction. The fix replaced ``set_value`` (which
-	creates) with ``expire_key`` (Redis EXPIRE — no-op on missing keys).
+	creates) with ``expire_key`` (Redis EXPIRE no-op on missing keys).
 	"""
 	user = "alice@example.com"
 	session_uuid = "uuid-1"

--- a/optimus/tests/test_set_hide_framework_tables_default_patch.py
+++ b/optimus/tests/test_set_hide_framework_tables_default_patch.py
@@ -5,7 +5,7 @@
 
 The JSON now ships ``"default": "1"`` for the ``hide_framework_tables``
 Check field, but existing Single rows persisted a 0 before the default
-was added — so a one-time patch flips 0/None → 1. Truthy values are
+was added so a one-time patch flips 0/None → 1. Truthy values are
 left alone (idempotent + respects any deliberate ``"1"`` already set).
 """
 
@@ -57,14 +57,14 @@ def _import_patch(monkeypatch):
 	re-execute a module that's still cached in ``sys.modules`` or
 	referenced via the parent package's ``__dict__``. If we delete it
 	first, the next ``from`` lookup either fetches a stale parent-attr
-	or re-imports cleanly — but mixing with ``monkeypatch.delitem`` got
+	or re-imports cleanly but mixing with ``monkeypatch.delitem`` got
 	tangled with pytest's teardown ordering and surfaced an
 	``ImportError: module not in sys.modules`` mid-suite. The reliable
 	path is: ensure the module is in ``sys.modules`` (via plain import,
 	which is cached fast), then ``importlib.reload`` to re-run the
 	top-level code under the current stub. ``monkeypatch`` (unused
-	below — kept in the signature for symmetry / future use) doesn't
-	need to touch the patch module — only the frappe stub.
+	below kept in the signature for symmetry / future use) doesn't
+	need to touch the patch module only the frappe stub.
 	"""
 	import importlib
 
@@ -86,14 +86,14 @@ class TestSetHideFrameworkTablesDefault:
 
 	def test_flips_none_to_one(self, monkeypatch):
 		"""A Single row that existed before the field was added has no
-		stored value for the field — ``get_single_value`` returns None."""
+		stored value for the field ``get_single_value`` returns None."""
 		stub = _install_frappe_stub(monkeypatch)
 		patch = _import_patch(monkeypatch)
 		patch.execute()
 		assert stub._single_values.get("hide_framework_tables") == 1
 
 	def test_flips_empty_string_to_one(self, monkeypatch):
-		"""Some legacy Frappe rows store Checks as ""/"" (empty) — falsy."""
+		"""Some legacy Frappe rows store Checks as ""/"" (empty) falsy."""
 		stub = _install_frappe_stub(monkeypatch)
 		stub._single_values["hide_framework_tables"] = ""
 		patch = _import_patch(monkeypatch)
@@ -141,13 +141,13 @@ class TestPatchRegistered:
 			in entries
 		), (
 			"patches.txt must register the set_hide_framework_tables_default "
-			"patch — otherwise bench migrate won't run it"
+			"patch otherwise bench migrate won't run it"
 		)
 
 
 class TestJSONDefault:
 	def test_json_has_explicit_default_one(self):
-		"""The JSON field MUST carry ``"default": "1"`` — fresh installs
+		"""The JSON field MUST carry ``"default": "1"``: fresh installs
 		need the new default to land in the Single row on first create."""
 		import json
 		import os

--- a/optimus/tests/test_settings.py
+++ b/optimus/tests/test_settings.py
@@ -4,7 +4,7 @@
 """Unit tests for the optimus.settings cached reader.
 
 The reader is the single place analyzers and hooks call to resolve
-configuration — threshold values, the enabled toggle, the tracked-
+configuration threshold values, the enabled toggle, the tracked-
 apps allowlist. Tests here pin the precedence (DocType > site_config
 > default), the soft-fail behavior (never crash a request), and the
 dataclass immutability that makes caching safe.
@@ -20,7 +20,7 @@ import pytest
 # NOTE at the top of optimus/settings.py), so a frappe stub
 # isn't needed at module-load time. But a handful of tests below DO
 # need ``frappe.cache.get_value`` to exist (so they can patch it). We
-# install a per-test stub via an autouse fixture below — that way the
+# install a per-test stub via an autouse fixture below that way the
 # stub doesn't leak to other test files (was the leading source of the
 # "80 failed" pollution: a module-level ``sys.modules["frappe"] = stub``
 # replaced the real frappe for the entire pytest session).
@@ -75,7 +75,7 @@ class TestDefaults:
 		assert cfg.redundant_perm_threshold == 10
 		assert cfg.n_plus_one_min_occurrences == 10
 		# v0.5.3: per-recording EXPLAIN / enrichment cap. Fallback
-		# default is 2000 — comfortable for most flows, with a clear
+		# default is 2000 comfortable for most flows, with a clear
 		# banner when truncation kicks in for heavier flows.
 		assert cfg.max_queries_per_recording == 2000
 
@@ -142,7 +142,7 @@ class TestSoftFail:
 
 	def test_is_enabled_defaults_true_on_error(self, monkeypatch):
 		"""If the settings read crashes, is_enabled must return True.
-		Returning False would silently disable the profiler — a very
+		Returning False would silently disable the profiler a very
 		confusing support issue ('why isn't it recording anything?')."""
 		def boom():
 			raise RuntimeError("cache down")
@@ -159,7 +159,7 @@ class TestSoftFail:
 class TestTrackedApps:
 	def test_tracked_apps_normalized_to_tuple(self, monkeypatch):
 		"""tracked_apps must be a tuple in the dataclass so it's
-		hashable / immutable. Input from the DocType is a list — the
+		hashable / immutable. Input from the DocType is a list the
 		reader must convert."""
 		monkeypatch.setattr(
 			settings, "_read_doctype_row",
@@ -172,7 +172,7 @@ class TestTrackedApps:
 
 
 class TestIgnoredApps:
-	"""v0.6.x: 'Ignored Apps' — exclusion list whose findings are dropped from
+	"""v0.6.x: 'Ignored Apps' exclusion list whose findings are dropped from
 	the report. Mirrors the tracked_apps wiring."""
 
 	def test_default_seeds_framework_apps(self):

--- a/optimus/tests/test_settings_ai.py
+++ b/optimus/tests/test_settings_ai.py
@@ -4,7 +4,7 @@
 """Tests for the v0.6.0 AI-fix config fields on Optimus Settings.
 
 Pure-test path. Verifies the new fields default sensibly, resolve from a
-DocType row, and — importantly — that the secret API key is NOT part of
+DocType row, and importantly that the secret API key is NOT part of
 the cached ``OptimusConfig`` (it's read on demand by ai_fix.py via
 Frappe's encrypted-password store).
 """
@@ -33,7 +33,7 @@ class TestAiConfigDefaults:
 		assert cfg.ai_suggest_indexes is True
 
 	def test_api_key_is_not_part_of_the_config(self):
-		# The key is sensitive — never cached on the config snapshot.
+		# The key is sensitive never cached on the config snapshot.
 		assert not hasattr(settings.OptimusConfig(), "ai_api_key")
 		assert "ai_api_key" not in settings._DEFAULTS
 
@@ -122,7 +122,7 @@ class TestAiConfigResolution:
 		assert cfg.ai_auto_suggest_max == 12
 
 	def test_auto_suggest_max_zero_means_all(self):
-		# 0 is a legitimate value ("every eligible finding") — must not
+		# 0 is a legitimate value ("every eligible finding") must not
 		# fall through to the default of 5.
 		row = self._row(ai_auto_suggest=True, ai_auto_suggest_max=0)
 		with patch.object(settings, "_read_doctype_row", return_value=row), \

--- a/optimus/tests/test_settings_envelope_rollout.py
+++ b/optimus/tests/test_settings_envelope_rollout.py
@@ -6,16 +6,16 @@ to the v0.12.0 ``wrap_value`` / ``unwrap_value`` envelope.
 
 The rollout has three contract pieces under test:
 
-  1. **Write path** — a fresh ``get_config`` call that misses the cache
+  1. **Write path**: a fresh ``get_config`` call that misses the cache
      re-resolves via ``_resolve`` and stores the OptimusConfig field dict
      INSIDE the envelope (``{"_v": 1, "data": {...}}``), not as a bare
      dict.
-  2. **New-shape read path** — a ``get_config`` call against a cache that
+  2. **New-shape read path**: a ``get_config`` call against a cache that
      already holds an enveloped value unwraps cleanly and returns a
      valid OptimusConfig.
-  3. **Legacy-compat read path** — a ``get_config`` call against a cache
+  3. **Legacy-compat read path**: a ``get_config`` call against a cache
      that holds a PRE-v0.12.11 bare-dict value (no ``_v`` key) ALSO
-     unwraps cleanly. This is the migration-safety guarantee — readers
+     unwraps cleanly. This is the migration-safety guarantee readers
      that get rolled out before writers (e.g. a worker on the new code
      hits a Redis value left over from a worker on the old code) must
      NOT crash.
@@ -110,11 +110,11 @@ class TestSettingsEnvelopeWrite:
 		)
 		# Version pins to the current SCHEMA_VERSION (= 1 in v0.12.0
 		# baseline). If the test starts failing on a future bump, that's
-		# the migration moment — bump together with redis_schema.
+		# the migration moment bump together with redis_schema.
 		from optimus.redis_schema import SCHEMA_VERSION
 
 		assert stored["_v"] == SCHEMA_VERSION
-		# Payload is the OptimusConfig.__dict__ shape — same keys the
+		# Payload is the OptimusConfig.__dict__ shape same keys the
 		# OptimusConfig dataclass exposes.
 		assert isinstance(stored["data"], dict)
 		assert "ai_enabled" in stored["data"]
@@ -154,7 +154,7 @@ class TestSettingsEnvelopeLegacyCompat:
 	def test_hit_on_legacy_bare_dict_returns_config(self):
 		fresh = _fresh_settings_module()
 		cache = _FakeCache()
-		# Pre-seed with a BARE OptimusConfig field dict — no envelope, no
+		# Pre-seed with a BARE OptimusConfig field dict no envelope, no
 		# ``_v`` key. This is exactly what pre-v0.12.11 writers stored.
 		seed_payload = fresh.OptimusConfig().__dict__
 		cache.store[fresh._CACHE_KEY] = seed_payload
@@ -164,7 +164,7 @@ class TestSettingsEnvelopeLegacyCompat:
 			cfg = fresh.get_config()
 
 		assert cfg is not None
-		# CRITICAL: the legacy value was NOT discarded — it was used
+		# CRITICAL: the legacy value was NOT discarded it was used
 		# as-is. (Migrating legacy values on read is explicitly OUT of
 		# scope for the rollout; the next on_update cache invalidation
 		# + re-resolve will produce a new-shape envelope.)
@@ -183,7 +183,7 @@ class TestSettingsEnvelopeDriftHandling:
 	def test_drift_falls_through_to_resolve(self):
 		fresh = _fresh_settings_module()
 		cache = _FakeCache()
-		# Seed with an envelope tagged as schema version 999 — a future
+		# Seed with an envelope tagged as schema version 999 a future
 		# version this build doesn't recognise.
 		cache.store[fresh._CACHE_KEY] = {"_v": 999, "data": {"ai_enabled": True}}
 		frappe_stub = _stub_frappe(cache)

--- a/optimus/tests/test_settings_profile.py
+++ b/optimus/tests/test_settings_profile.py
@@ -25,7 +25,7 @@ import pytest
 
 from optimus import settings
 
-# The DocType field descriptions advertise "Reference values — Strict: X ·
+# The DocType field descriptions advertise "Reference values: Strict: X ·
 # Recommended: Y · Relaxed: Z" to admins. Those numbers MUST equal _PROFILES or
 # the UI lies about what a preset does. This path locates the DocType JSON
 # relative to this test file (no bench needed).
@@ -42,13 +42,13 @@ _REFVAL_RE = re.compile(
 	r"Relaxed:\s*(\d+(?:\.\d+)?)"
 )
 
-# Every knob whose DocType description advertises a "Reference values —
+# Every knob whose DocType description advertises a "Reference values
 # Strict / Recommended / Relaxed" triplet is governed by the preset.
 # Kept here (not imported) so the test pins the contract independently
 # of the implementation's own tuple. v0.13.x expanded the set from 9
-# detection-sensitivity knobs to 19 — including capture caps,
+# detection-sensitivity knobs to 19 including capture caps,
 # retention, display filters, Phase-2 UI knobs, and the AI auto-suggest
-# cap — so the UI's "Reference values" promise is honored everywhere
+# cap so the UI's "Reference values" promise is honored everywhere
 # it's advertised.
 SENSITIVITY_KEYS = (
 	# General → Session retention
@@ -81,7 +81,7 @@ SENSITIVITY_KEYS = (
 
 @pytest.fixture(autouse=True)
 def _frappe_stub(monkeypatch):
-	"""Minimal frappe stub, mirroring test_settings.py — settings.py
+	"""Minimal frappe stub, mirroring test_settings.py settings.py
 	imports frappe lazily, but get_config's cache path touches
 	frappe.cache, so give it harmless no-ops."""
 	stub = types.ModuleType("frappe")
@@ -110,7 +110,7 @@ class TestProfileTable:
 
 	def test_custom_is_not_a_named_profile(self):
 		# Custom means "use stored field values", so it must NOT be in
-		# the preset table — _resolve keys off `_PROFILES.get(profile)`.
+		# the preset table _resolve keys off `_PROFILES.get(profile)`.
 		assert "Custom" not in settings._PROFILES
 
 	def test_recommended_equals_defaults(self):
@@ -122,12 +122,12 @@ class TestProfileTable:
 
 	# ---- Strict-vs-Relaxed semantic ordering ---------------------------
 	#
-	# For DETECTION thresholds the rule is "lower = catch more" — Strict's
+	# For DETECTION thresholds the rule is "lower = catch more" Strict's
 	# number is at-or-below Relaxed's, so a redundant-call loop or a slow
 	# query fires under Strict at a hair lower a cost.
 	#
-	# For RESOURCE / RETENTION knobs the rule inverts — "higher = stricter
-	# data preservation" — Strict's number is at-or-above Relaxed's. A
+	# For RESOURCE / RETENTION knobs the rule inverts "higher = stricter
+	# data preservation" Strict's number is at-or-above Relaxed's. A
 	# Strict deployment keeps sessions for 90 days vs Relaxed's 7,
 	# captures 5000 queries per recording vs 1000, allows 25 Phase-2 runs
 	# per session vs 5, etc. Stricter monitoring → more data.
@@ -136,7 +136,7 @@ class TestProfileTable:
 	# per group. Any new sensitivity key must join one of the two tuples
 	# below or this test will tell the engineer which side it falls on.
 
-	# Strict <= Relaxed (lower number = stricter — for detection
+	# Strict <= Relaxed (lower number = stricter for detection
 	# thresholds, lower = catch more; for ``auto_expand_min_ms``, lower
 	# = follow into smaller hot spots; Strict's 0 is the strictest
 	# possible value).
@@ -166,7 +166,7 @@ class TestProfileTable:
 	# v0.13.x: fields whose read site honors ``0 = unlimited``. Strict
 	# uses 0 (the strictest possible posture: don't cap, don't drop,
 	# don't truncate, don't expire). Relaxed uses a literal positive
-	# number, so ``Strict >= Relaxed`` doesn't hold here — the contract
+	# number, so ``Strict >= Relaxed`` doesn't hold here the contract
 	# is "Strict is 0 AND Relaxed is positive AND Relaxed is positive".
 	_STRICT_UNBOUNDED_KEYS = (
 		"max_queries_per_recording",
@@ -190,7 +190,7 @@ class TestProfileTable:
 	def test_strict_uses_unlimited_sentinel_on_capped_knobs(self):
 		"""v0.13.x: every cap that honors 0-as-unlimited at its read site
 		uses 0 under Strict (the strictest posture). Relaxed always uses
-		a positive literal — the read site code that branches on ``cap
+		a positive literal the read site code that branches on ``cap
 		> 0`` would otherwise act unbounded under Relaxed too, defeating
 		the point of the preset."""
 		for key in self._STRICT_UNBOUNDED_KEYS:
@@ -213,7 +213,7 @@ class TestProfileTable:
 		)
 
 	def test_profiles_match_doctype_reference_values(self):
-		"""_PROFILES must equal the 'Reference values — Strict/Recommended/
+		"""_PROFILES must equal the 'Reference values: Strict/Recommended/
 		Relaxed' numbers advertised in each sensitivity field's DocType
 		description, so the form's help text never contradicts behavior."""
 		with open(_SETTINGS_JSON) as fh:
@@ -268,7 +268,7 @@ class TestProfileResolution:
 		assert settings._resolve().redundant_doc_threshold == 99
 
 	def test_named_profile_bypasses_site_config(self, monkeypatch):
-		"""A named profile wins over site_config — the preset is authoritative."""
+		"""A named profile wins over site_config the preset is authoritative."""
 		monkeypatch.setattr(
 			settings, "_read_doctype_row",
 			lambda: {"config_profile": "Strict"},

--- a/optimus/tests/test_settings_round6.py
+++ b/optimus/tests/test_settings_round6.py
@@ -3,7 +3,7 @@
 
 """Tests for the v0.6.0 Round 6 Optimus Settings additions.
 
-Pure-test path — no live Frappe site needed. Verifies the new fields
+Pure-test path no live Frappe site needed. Verifies the new fields
 default correctly, the multi-line skip-list parser strips blanks +
 comments, and each analyzer's resolver respects the configured value.
 """
@@ -124,12 +124,12 @@ class TestHotLineThresholdResolver:
 			hot_line_high_min_ms=200.0,
 		)
 		with patch("optimus.settings.get_config", return_value=fake_cfg):
-			# 60% of 1000ms = 600ms — under 80% threshold, so Medium
+			# 60% of 1000ms = 600ms under 80% threshold, so Medium
 			# (since med_pct = 80% * 0.5 = 40%).
 			result = lp_analyzer._classify_hot_line(600, 1000)
 			assert result == "Medium"
 
-			# 90% of 1000ms = 900ms — above both threshold and min_ms.
+			# 90% of 1000ms = 900ms above both threshold and min_ms.
 			result = lp_analyzer._classify_hot_line(900, 1000)
 			assert result == "High"
 
@@ -140,7 +140,7 @@ class TestHotLineThresholdResolver:
 	def test_settings_unreachable_falls_back(self):
 		# Resolver still produces classifiable thresholds.
 		with patch("optimus.settings.get_config", side_effect=RuntimeError):
-			# 60% of 1000ms = 600ms — over the legacy 50%/100ms High bar.
+			# 60% of 1000ms = 600ms over the legacy 50%/100ms High bar.
 			assert lp_analyzer._classify_hot_line(600, 1000) == "High"
 
 
@@ -217,7 +217,7 @@ class TestRendererMinActionFilter:
 			html = renderer.render_raw(doc, recordings=[])
 
 		assert "real_action" in html
-		# noise_poll was below the 10ms cutoff — not in the per-action
+		# noise_poll was below the 10ms cutoff not in the per-action
 		# table.
 		assert "noise_poll" not in html
 
@@ -230,10 +230,10 @@ class TestExpandHotChainHonorsSettings:
 
 	# Filename must look like an "apps/<app>/<app>/..." path so the
 	# pure-helper filter classifies frames as user code rather than
-	# framework plumbing — otherwise descent stops at frame_0.
+	# framework plumbing otherwise descent stops at frame_0.
 	_APP_FILE = "apps/myapp/myapp/x.py"
 	# _derive_module_path strips apps/<app>/, dedups the duplicate, and
-	# produces "myapp.x" — so the picked frame's dotted_path is
+	# produces "myapp.x" so the picked frame's dotted_path is
 	# "myapp.x.frame_0".
 	_PICKED_PATH = "myapp.x.frame_0"
 

--- a/optimus/tests/test_severity_pill_mapping.py
+++ b/optimus/tests/test_severity_pill_mapping.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""D.M-S8 — severity-pill class mirrors finding severity.
+"""D.M-S8 severity-pill class mirrors finding severity.
 
 The finding card renders a colour-coded pill via:
     <span class="severity-pill {{ f.severity | lower }}">{{ f.severity }}</span>
@@ -105,11 +105,11 @@ def test_severity_pill_class_matches_data_severity():
 		html,
 	)
 	assert pills, "expected severity-pill spans in rendered HTML"
-	# At least one of each severity must render — confirms the test
+	# At least one of each severity must render confirms the test
 	# fixture flowed through the finding pipeline.
 	classes_seen = {cls for cls, _label in pills}
 	assert classes_seen >= {"high", "medium", "low"}, (
-		f"missing severity tiers — got {classes_seen!r}"
+		f"missing severity tiers got {classes_seen!r}"
 	)
 	# Every pair must agree.
 	for cls, label in pills:

--- a/optimus/tests/test_skip_instrumentation.py
+++ b/optimus/tests/test_skip_instrumentation.py
@@ -52,7 +52,7 @@ def test_should_skip_frappe_profiler_status_poll():
 	favor of realtime events, but the endpoint is still called once
 	on page load (to rehydrate widget state after navigation/reload)
 	and once on tab-visibility return. Those calls MUST NOT be
-	captured into the profiler session they belong to — they're
+	captured into the profiler session they belong to they're
 	instrumentation, not user work."""
 	from optimus.hooks_callbacks import _should_skip_request
 
@@ -63,7 +63,7 @@ def test_should_skip_frappe_profiler_status_poll():
 def test_should_skip_all_frappe_profiler_api_methods():
 	"""Any `optimus.api.*` whitelisted method is instrumentation
 	noise. Covers start, stop, status, submit_frontend_metrics,
-	retry_analyze, analyze_fetch, regenerate_reports, download_pdf — all of
+	retry_analyze, analyze_fetch, regenerate_reports, download_pdf all of
 	them match the prefix."""
 	from optimus.hooks_callbacks import _should_skip_request
 
@@ -79,7 +79,7 @@ def test_should_skip_all_frappe_profiler_api_methods():
 	):
 		_set_fake_local(cmd=cmd)
 		assert _should_skip_request() is True, (
-			f"{cmd} must be skipped — it's profiler instrumentation, "
+			f"{cmd} must be skipped it's profiler instrumentation, "
 			"not application work"
 		)
 
@@ -100,7 +100,7 @@ def test_should_skip_frappe_builtin_recorder_methods():
 	):
 		_set_fake_local(cmd=cmd)
 		assert _should_skip_request() is True, (
-			f"{cmd} must be skipped — it's the Frappe recorder's own "
+			f"{cmd} must be skipped it's the Frappe recorder's own "
 			"plumbing"
 		)
 
@@ -119,14 +119,14 @@ def test_should_not_skip_regular_application_calls():
 	):
 		_set_fake_local(cmd=cmd)
 		assert _should_skip_request() is False, (
-			f"{cmd} must NOT be skipped — it's real application work"
+			f"{cmd} must NOT be skipped it's real application work"
 		)
 
 
 def test_should_not_skip_page_loads_without_cmd():
 	"""Page loads (`/app/recorder`, `/api/resource/Sales Invoice/…`) have
 	no cmd in form_dict. They must fall through as 'not noise' even
-	when the URL happens to contain the word 'recorder' — the skip
+	when the URL happens to contain the word 'recorder' the skip
 	list matches cmd prefixes, not URL substrings."""
 	from optimus.hooks_callbacks import _should_skip_request
 
@@ -171,7 +171,7 @@ def test_should_skip_is_prefix_match_not_exact():
 def test_should_not_match_similar_but_different_prefixes():
 	"""Guard against over-matching. A hypothetical
 	`frappe_profiler_extensions.api.foo` starts with `optimus`
-	but is NOT our API — the prefix ends with a dot for a reason.
+	but is NOT our API the prefix ends with a dot for a reason.
 	Same for `frappe.core.doctype.recorder_archive.*`."""
 	from optimus.hooks_callbacks import _should_skip_request
 
@@ -197,7 +197,7 @@ def test_should_not_match_similar_but_different_prefixes():
 
 def test_path_based_skip_for_v1_method_url():
 	"""/api/method/<foo> is the most common URL shape. At before_request
-	time, frappe.form_dict.cmd is NOT set for these — Frappe's routing
+	time, frappe.form_dict.cmd is NOT set for these Frappe's routing
 	sets it later, inside handle_rpc_call. The path is the only source."""
 	from optimus.hooks_callbacks import _should_skip_request
 
@@ -240,7 +240,7 @@ def test_path_based_does_not_skip_regular_method_urls():
 
 
 def test_path_based_ignores_rest_resource_urls():
-	"""/api/resource/Sales Invoice/INV-00042 has no /method/ segment —
+	"""/api/resource/Sales Invoice/INV-00042 has no /method/ segment
 	it's a REST resource call, not a whitelisted method. Must fall
 	through as 'not noise'."""
 	from optimus.hooks_callbacks import _should_skip_request
@@ -250,7 +250,7 @@ def test_path_based_ignores_rest_resource_urls():
 
 
 def test_path_based_ignores_desk_app_urls():
-	"""/app/recorder is the Frappe Recorder UI — a page load, not a
+	"""/app/recorder is the Frappe Recorder UI a page load, not a
 	whitelisted method call. Even though the URL contains 'recorder',
 	the path parser must not match because there's no /method/ marker."""
 	from optimus.hooks_callbacks import _should_skip_request
@@ -264,7 +264,7 @@ def test_path_based_handles_trailing_slash():
 	parser must strip it before the prefix check, otherwise
 	'optimus.api.status/' won't match
 	'optimus.api.' via startswith (which would still match,
-	actually — but a follow-on exact comparison wouldn't). Defense-
+	actually but a follow-on exact comparison wouldn't). Defense-
 	in-depth check for cleanup."""
 	from optimus.hooks_callbacks import _should_skip_request
 
@@ -273,7 +273,7 @@ def test_path_based_handles_trailing_slash():
 
 
 def test_path_based_handles_missing_request():
-	"""frappe.local has no `request` attribute at all — edge case during
+	"""frappe.local has no `request` attribute at all edge case during
 	startup or health checks. Must fall through as False."""
 	from optimus.hooks_callbacks import _should_skip_request
 
@@ -295,7 +295,7 @@ def test_form_dict_cmd_still_wins_over_path():
 		cmd="optimus.api.status",
 		path="/api/method/frappe.client.save",
 	)
-	# form_dict.cmd wins — returns the legacy value.
+	# form_dict.cmd wins returns the legacy value.
 	assert _extract_cmd_from_request() == "optimus.api.status"
 
 
@@ -330,7 +330,7 @@ def test_before_request_early_exits_on_skipped_cmd():
 	# The skip call must appear in before_request.
 	assert "_should_skip_request()" in src
 
-	# The skip check must occur BEFORE the optimus_session_id assignment —
+	# The skip check must occur BEFORE the optimus_session_id assignment
 	# setting the flag first would cause after_request to register the
 	# recording anyway, defeating the filter.
 	skip_idx = src.find("_should_skip_request()")

--- a/optimus/tests/test_source_path_resolution.py
+++ b/optimus/tests/test_source_path_resolution.py
@@ -6,7 +6,7 @@
 Call-tree / pyinstrument callsites are stored as `<app>/<module-path>` (e.g.
 `ugly_code/python/common.py` for `<bench>/apps/ugly_code/ugly_code/python/
 common.py`). A bare `open()` fails because the Frappe worker cwd is
-`<bench>/sites` — so the AI-fix prompt and the report's "smoking gun" snippet
+`<bench>/sites`: so the AI-fix prompt and the report's "smoking gun" snippet
 never got the source. `renderer._resolve_source_path` fixes that; the source
 readers and the analyze-time enrichment route through it.
 """
@@ -41,7 +41,7 @@ class TestResolveSourcePath:
 	def test_resolves_a_frappe_core_relative_path(self):
 		# frappe/__init__.py → <bench>/apps/frappe/frappe/__init__.py via
 		# frappe.get_app_path. (In the full suite another test may have left a
-		# stub `frappe` in sys.modules — then this branch can't resolve and
+		# stub `frappe` in sys.modules then this branch can't resolve and
 		# returns None; that's tolerated. It must never return a bogus path.)
 		resolved = renderer._resolve_source_path("frappe/__init__.py")
 		assert resolved is None or os.path.exists(resolved)
@@ -80,7 +80,7 @@ class TestAnalyzeEnrichmentResolves:
 	def test_enriches_call_tree_finding_with_app_relative_callsite(self):
 		# call_tree findings store the location at the TOP level (no `callsite`
 		# wrapper). _enrich_findings_with_source_snippets must synthesize the
-		# callsite AND attach a snippet — resolving the relative path.
+		# callsite AND attach a snippet resolving the relative path.
 		findings = [{
 			"title": "In X, 60% of the time was spent in render",
 			"technical_detail_json": json.dumps({
@@ -103,7 +103,7 @@ class TestAnalyzeEnrichmentResolves:
 		analyze._enrich_findings_with_source_snippets(findings)
 		detail = json.loads(findings[0]["technical_detail_json"])
 		# No crash, no bogus snippet (the callsite may get synthesized for
-		# _finding_to_dict's benefit — that's fine).
+		# _finding_to_dict's benefit that's fine).
 		cs = detail.get("callsite") or {}
 		assert not cs.get("source_snippet")
 
@@ -122,7 +122,7 @@ class TestAiPayloadForFinding:
 			llm_fix_json=None,
 		)
 		# v0.10.0: the phase-2 index keys on the file's basename. The
-		# function "render" now lives in renderer/_internal.py — the index
+		# function "render" now lives in renderer/_internal.py the index
 		# key becomes ("_internal.py", "render").
 		phase2_index = {("_internal.py", "render"): {
 			"lineno": 1, "content": "first line", "total_ms": 387, "hits": 2,
@@ -150,7 +150,7 @@ class TestAiPayloadForFinding:
 class TestAiPayloadRecordedQueries:
 	"""v0.6.x: pass actual recorded SQL queries to the AI as evidence so
 	the model has the verbatim query text to ground against, instead of
-	inferring SQL shape from the Python source — which was the leading
+	inferring SQL shape from the Python source which was the leading
 	cause of bogus refactorings (e.g. inventing filters that copy a
 	variable from elsewhere in the function)."""
 
@@ -227,7 +227,7 @@ class TestAiPayloadRecordedQueries:
 		]
 
 	def test_sub_threshold_queries_dropped(self):
-		"""Trivial sub-half-ms queries (cache hits etc.) are noise — don't
+		"""Trivial sub-half-ms queries (cache hits etc.) are noise don't
 		surface them as 'examples' the AI tries to optimise."""
 		recordings_by_uuid = {"r0": {
 			"uuid": "r0",

--- a/optimus/tests/test_steps_to_reproduce.py
+++ b/optimus/tests/test_steps_to_reproduce.py
@@ -45,7 +45,7 @@ def test_notes_field_is_text_editor():
 
 
 def test_notes_label_reflects_steps_purpose():
-	"""The label must make the field's purpose clear to users — the
+	"""The label must make the field's purpose clear to users the
 	description alone isn't enough because the field header in the
 	form view only shows the label."""
 	meta = _load_doctype_json()
@@ -63,7 +63,7 @@ def test_api_start_accepts_notes():
 
 	sig = inspect.signature(api.start)
 	assert "notes" in sig.parameters
-	# Default should be empty string — keeping start() backward compatible
+	# Default should be empty string keeping start() backward compatible
 	# with callers that don't pass notes.
 	assert sig.parameters["notes"].default == ""
 
@@ -99,13 +99,13 @@ def test_report_template_renders_notes():
 	# "Steps to Reproduce" heading must appear so users know the purpose.
 	assert "Steps to Reproduce" in template
 
-	# Repro section renders ABOVE the "Findings — what to fix" section.
+	# Repro section renders ABOVE the "Findings what to fix" section.
 	repro_idx = template.find("report_data.repro")
 	findings_heading_idx = template.find("Findings - what to fix")
 	assert repro_idx > 0
 	assert findings_heading_idx > 0
 	assert findings_heading_idx > repro_idx, (
-		"repro section must appear above 'Findings — what to fix'"
+		"repro section must appear above 'Findings what to fix'"
 	)
 
 
@@ -136,9 +136,9 @@ def test_notes_are_bleach_sanitized_before_render():
 def test_json_shaped_xss_payload_is_sanitized():
 	"""Architect-review finding: sanitize_html has a fast-path that
 	skips bleach for input detected as valid JSON. An attacker could
-	set notes = '{"x": "<script>alert(1)</script>"}' — which IS valid
+	set notes = '{"x": "<script>alert(1)</script>"}' which IS valid
 	JSON (a JSON dict literal with a string value containing the
-	script) — and sanitize_html without always_sanitize=True returns
+	script) and sanitize_html without always_sanitize=True returns
 	it unchanged. The template's |safe then renders the script as
 	a live <script> tag. always_sanitize=True closes this bypass.
 	"""
@@ -174,7 +174,7 @@ def test_renderer_passes_always_sanitize_true():
 	assert "always_sanitize=True" in src, (
 		"renderer.render must call sanitize_html(..., always_sanitize=True). "
 		"Without it, valid JSON or no-tag input bypasses sanitization "
-		"entirely — stored XSS regression."
+		"entirely stored XSS regression."
 	)
 
 
@@ -234,7 +234,7 @@ def test_auto_notes_produces_ordered_list_with_humanized_labels():
 
 	# Preamble explains auto-generation and invites editing.
 	assert "Auto-generated" in html_out
-	# Ordered list, not unordered — order matters for reproducers.
+	# Ordered list, not unordered order matters for reproducers.
 	assert "<ol>" in html_out and "</ol>" in html_out
 	# First recording resolves to "Save Sales Invoice" via per_action._label.
 	assert "Save Sales Invoice" in html_out
@@ -265,7 +265,7 @@ def test_auto_notes_html_escapes_user_controlled_strings():
 
 def test_auto_notes_caps_long_sessions_with_overflow_marker():
 	"""A 200-action session shouldn't fill the notes field with 200
-	<li> entries — cap at 50 and surface a '… and N more' marker so
+	<li> entries cap at 50 and surface a '… and N more' marker so
 	users know the list is truncated."""
 	from optimus.analyze import _AUTO_NOTES_MAX_ENTRIES, _build_auto_notes_html
 
@@ -275,7 +275,7 @@ def test_auto_notes_caps_long_sessions_with_overflow_marker():
 		for i in range(_AUTO_NOTES_MAX_ENTRIES + 10)
 	]
 	html_out = _build_auto_notes_html(recordings)
-	# Count the <li> entries — should be cap + 1 (for the overflow marker).
+	# Count the <li> entries should be cap + 1 (for the overflow marker).
 	li_count = html_out.count("<li>")
 	assert li_count == _AUTO_NOTES_MAX_ENTRIES + 1
 	assert "10 more" in html_out
@@ -284,21 +284,21 @@ def test_auto_notes_caps_long_sessions_with_overflow_marker():
 def test_auto_notes_unnamed_action_falls_back_gracefully():
 	"""If somehow a recording has no cmd / path / method, the label
 	resolver returns an empty string. The helper must substitute a
-	placeholder rather than emit '<li> — 0 ms</li>'."""
+	placeholder rather than emit '<li>: 0 ms</li>'."""
 	from optimus.analyze import _build_auto_notes_html
 
 	recordings = [{"method": "", "path": "", "cmd": "",
 	               "duration": 0, "calls": []}]
 	html_out = _build_auto_notes_html(recordings)
-	# Must not have a blank label — the per_action._label fallback ends up
+	# Must not have a blank label the per_action._label fallback ends up
 	# as " " (method + " " + path with both empty), so we check the
 	# placeholder OR a non-empty label.
 	assert "<li>" in html_out
-	# The <li> content between <li> and the em-dash separator must be
-	# non-whitespace — otherwise the reproducer is "— 0 ms" which is
+	# The <li> content between <li> and the colon separator must be
+	# non-whitespace otherwise the reproducer is " 0 ms" which is
 	# useless to a reader.
 	import re
-	m = re.search(r"<li>([^<]*?) — ", html_out)
+	m = re.search(r"<li>([^<]*?): ", html_out)
 	assert m is not None
 	label = m.group(1).strip()
 	assert label, f"Auto-notes emitted blank label: {html_out!r}"
@@ -325,9 +325,9 @@ def test_persist_auto_fills_notes_when_field_is_empty():
 def test_auto_notes_filters_realtime_polling_noise():
 	"""v0.5.1: real production reproducer read:
 
-	    GET /api/method/frappe.realtime.has_permission — 25ms
-	    POST /api/method/frappe.desk.form.save.savedocs — 775ms
-	    GET /api/method/frappe.realtime.has_permission — 6ms
+	    GET /api/method/frappe.realtime.has_permission 25ms
+	    POST /api/method/frappe.desk.form.save.savedocs 775ms
+	    GET /api/method/frappe.realtime.has_permission 6ms
 
 	Of those three, only the savedocs is a user action. The two
 	has_permission entries are the Desk polling for realtime
@@ -369,7 +369,7 @@ def test_auto_notes_filters_realtime_polling_noise():
 	]
 
 	html_out = _build_auto_notes_html(recordings)
-	# Only the savedocs survives — humanized as "Create Sales Invoice".
+	# Only the savedocs survives humanized as "Create Sales Invoice".
 	assert "Create Sales Invoice" in html_out
 	assert "774.8 ms" in html_out
 	# Polling endpoints filtered out
@@ -417,7 +417,7 @@ def test_auto_notes_filters_static_assets_and_form_load_boilerplate():
 
 
 def test_auto_notes_all_noise_returns_empty_string():
-	"""A session of only polling/noise returns empty — the caller
+	"""A session of only polling/noise returns empty the caller
 	then leaves the notes field blank rather than filling it with
 	the preamble and an empty list."""
 	from optimus.analyze import _build_auto_notes_html
@@ -461,7 +461,7 @@ def test_auto_notes_real_user_sequence_reads_naturally():
 			"calls": [],
 			"form_dict": {"doctype": "Customer", "name": "CUST-001"},
 		},
-		# (permission polling — filtered)
+		# (permission polling filtered)
 		{
 			"method": "GET",
 			"path": "/api/method/frappe.realtime.has_permission",
@@ -532,14 +532,14 @@ def test_start_dialog_no_longer_asks_for_notes():
 	# fieldname: "notes" any more.
 	assert 'fieldname: "notes"' not in widget_src, (
 		"The start dialog still defines a 'notes' field. The v0.5.1 "
-		"design removed it — notes is now auto-filled from captured "
+		"design removed it notes is now auto-filled from captured "
 		"actions during analyze. Delete the dialog entry."
 	)
 	# And the frappe.call args must not pass notes either.
 	assert "notes: values.notes" not in widget_src, (
 		"The start call still passes a `notes` argument. Since the "
 		"dialog no longer collects it, values.notes is always undefined "
-		"— drop the arg from the frappe.call."
+		" drop the arg from the frappe.call."
 	)
 
 
@@ -573,7 +573,7 @@ def test_actions_for_humanizer_compacts_recordings():
 
 
 def test_assemble_humanized_notes_is_just_the_friendly_steps():
-	"""Only the preamble + the rendered Markdown steps — no raw
+	"""Only the preamble + the rendered Markdown steps no raw
 	"Captured actions" appendix (the per-action breakdown in the report
 	already lists every action with its technical label)."""
 	from optimus.analyze import _assemble_humanized_notes
@@ -601,7 +601,7 @@ def test_build_humanized_notes_html_returns_empty_when_ai_disabled():
 
 
 def test_build_humanized_notes_html_returns_empty_on_llm_failure():
-	"""If the LLM call raises, the helper swallows it and returns "" — the
+	"""If the LLM call raises, the helper swallows it and returns "" the
 	caller then uses _build_auto_notes_html. analyze must never fail just
 	because the humanizer did."""
 	from types import SimpleNamespace

--- a/optimus/tests/test_submit_frontend_metrics.py
+++ b/optimus/tests/test_submit_frontend_metrics.py
@@ -170,7 +170,7 @@ def test_submit_accepts_and_stores(mock_frappe):
 
 def test_submit_appends_to_existing_list(mock_frappe):
     """Two sequential submits must accumulate into the Redis list
-    atomically — RPUSH semantics preserve both.
+    atomically RPUSH semantics preserve both.
     """
     from optimus import api
 
@@ -249,7 +249,7 @@ def test_frontend_js_wraps_beacon_body_for_frappe_routing():
     Without the wrap, Frappe's request handler parses the raw body
     as JSON and flattens the top-level keys into form_dict, so
     submit_frontend_metrics is called with session_uuid=..., xhr=...,
-    vitals=... — which does NOT match the (payload: str) signature
+    vitals=... which does NOT match the (payload: str) signature
     and fails with TypeError. The beacon path silently drops every
     payload in that case.
 
@@ -268,7 +268,7 @@ def test_frontend_js_wraps_beacon_body_for_frappe_routing():
     # Must construct a beaconBody distinct from the raw frappe.call body.
     assert "beaconBody" in src, (
         "optimus_frontend.js must construct a beaconBody wrapped as "
-        "{payload: body} for sendBeacon — see comment explaining the "
+        "{payload: body} for sendBeacon see comment explaining the "
         "server contract"
     )
     # Must wrap as {payload: body}.
@@ -278,11 +278,11 @@ def test_frontend_js_wraps_beacon_body_for_frappe_routing():
     )
     # The Blob constructor used with sendBeacon must reference
     # beaconBody, not the unwrapped body. Find `new Blob([beaconBody]`
-    # specifically — this string only appears in actual code, not in
+    # specifically this string only appears in actual code, not in
     # the explanatory comment block.
     assert "new Blob([beaconBody]" in src, (
         "sendBeacon must send new Blob([beaconBody], ...), not the "
-        "raw body — otherwise Frappe's JSON body flattening mismatches "
+        "raw body otherwise Frappe's JSON body flattening mismatches "
         "the endpoint signature"
     )
 
@@ -350,7 +350,7 @@ def test_submit_enforces_soft_cap_tail_prefer(mock_frappe):
         "docname": "PS-0004",
     }
 
-    # Push 1500 XHRs — 500 over the cap of 1000.
+    # Push 1500 XHRs 500 over the cap of 1000.
     xhrs = [
         {"recording_id": f"r{i}", "url": f"/api/{i}",
          "method": "GET", "duration_ms": 10, "status": 200,
@@ -365,7 +365,7 @@ def test_submit_enforces_soft_cap_tail_prefer(mock_frappe):
 
     xhr_list = mock_frappe["list_store"]["profiler:frontend:S4:xhr"]
     assert len(xhr_list) == 1000
-    # Tail preferred — the last entry's timestamp should be 1499.
+    # Tail preferred the last entry's timestamp should be 1499.
     # (Client-side slicing first drops the first 500, then LTRIM is a
     # no-op because the list is already at cap.)
     last = json.loads(xhr_list[-1])

--- a/optimus/tests/test_suggest_fix_api.py
+++ b/optimus/tests/test_suggest_fix_api.py
@@ -4,7 +4,7 @@
 """Surface tests for the v0.6.0 AI-fix API endpoints.
 
 ``suggest_fix`` / ``test_ai_connection`` need a live bench for true
-integration tests, which the test harness doesn't provide — so, matching
+integration tests, which the test harness doesn't provide so, matching
 the pattern of ``test_regenerate_reports_api.py``, we source-inspect the
 endpoint bodies to pin the contract: whitelisted, gated, AI-enabled
 guard, eligible-type guard, cache short-circuit, and persistence shape.

--- a/optimus/tests/test_summary_html.py
+++ b/optimus/tests/test_summary_html.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for `analyze._build_summary_html` — the plain-language "Summary"
+"""Tests for `analyze._build_summary_html`: the plain-language "Summary"
 prose at the top of the report.
 
 It must read for a non-developer: "operations" not "actions", humanized
@@ -60,7 +60,7 @@ class TestSummaryProse:
 		assert "Submit Sales Invoice" in text
 		assert "frappe.desk.form.save.savedocs" not in html
 		# The finding's title had the raw cmd swapped for the human label too.
-		assert "looped_validate" in text  # the function name stays — it's the actionable bit
+		assert "looped_validate" in text  # the function name stays it's the actionable bit
 		# "priority", not "severity".
 		assert "priority" in text and "severity" not in text.lower()
 		# The query count is still there.
@@ -108,7 +108,7 @@ class TestSummaryProse:
 		assert "potential issue" not in text
 
 	def test_works_without_recordings(self):
-		# Recordings can TTL out before a re-render — fall back to the raw label.
+		# Recordings can TTL out before a re-render fall back to the raw label.
 		ctx = _ctx(
 			actions=[{"action_label": "frappe.client.save:SO-0001", "recording_uuid": "gone", "duration_ms": 200}],
 			findings=[{"severity": "High", "title": "Same query ran 30x", "estimated_impact_ms": 100, "action_ref": "0"}],
@@ -141,7 +141,7 @@ class TestSummaryBulletShape:
 		assert "<li>" in html
 		assert "</ul>" in html
 		# And there are no leftover <p> wrappers from the pre-v0.7.x
-		# shape — those would render as paragraphs interleaved with the
+		# shape those would render as paragraphs interleaved with the
 		# bullet list, looking broken.
 		assert "<p>" not in html
 

--- a/optimus/tests/test_table_breakdown.py
+++ b/optimus/tests/test_table_breakdown.py
@@ -127,7 +127,7 @@ class TestReadWriteSplit:
 
 	def test_write_target_tables_kept_even_below_the_time_cutoff(self, empty_context):
 		# Lots of slow reads on read-only tables push everything past the
-		# top-N-by-time cutoff — but the one table that was *written* (a
+		# top-N-by-time cutoff but the one table that was *written* (a
 		# single cheap UPDATE) must still show up, so a doc-save's writes
 		# aren't invisible.
 		calls = [
@@ -156,7 +156,7 @@ class TestIndexCandidates:
 		assert "customer" in cands and cands["customer"]["sources"] == ["JOIN"]
 		assert "posting_date" in cands and cands["posting_date"]["sources"] == ["ORDER BY"]
 		# `name` is the JOIN column on the OTHER side (attributed to tabCust) AND
-		# a Frappe metadata column — either way it's not a tabSI candidate.
+		# a Frappe metadata column either way it's not a tabSI candidate.
 		assert "name" not in cands
 
 	def test_candidates_ranked_by_frequency(self, empty_context):
@@ -172,7 +172,7 @@ class TestIndexCandidates:
 		assert hot["hits"] == 3
 
 	def test_candidates_only_from_reads_not_writes(self, empty_context):
-		# The UPDATE's WHERE column must NOT become an index candidate here —
+		# The UPDATE's WHERE column must NOT become an index candidate here
 		# the breakdown's candidates are explicitly "to speed up reads".
 		rec = _rec(("UPDATE `tabFoo` SET `x` = ? WHERE `only_in_update` = ?", 5))
 		row = _row_for(table_breakdown.analyze([rec], empty_context).aggregate["table_breakdown"], "tabFoo")
@@ -249,7 +249,7 @@ def test_is_frappe_meta_table_truth_table():
 	# Case-insensitive + tolerates backticks.
 	assert is_frappe_meta_table("tabdoctype") is True
 	assert is_frappe_meta_table("`tabCustom Field`") is True
-	# Real data tables — NOT meta.
+	# Real data tables NOT meta.
 	for t in ("tabSales Invoice", "tabUser", "tabFile", "tabVersion",
 	          "tabEmail Queue", "tabCommunication", "tabError Log", "tabItem"):
 		assert is_frappe_meta_table(t) is False
@@ -259,7 +259,7 @@ def test_is_frappe_meta_table_truth_table():
 
 class TestFrappeMetaTablesExcluded:
 	def test_meta_table_gets_flag_and_no_candidates(self, empty_context):
-		# tabSingles reads filter on `doctype`/`field` — but it's a meta
+		# tabSingles reads filter on `doctype`/`field`: but it's a meta
 		# table, so no candidates and no framework_cols list either.
 		q = "SELECT `value` FROM `tabSingles` WHERE `doctype` = ? AND `field` = ?"
 		row = _row_for(
@@ -287,7 +287,7 @@ class TestFrappeMetaTablesExcluded:
 		# (bench migrate owns their schema), so they're filtered out of
 		# the index-recommendations cards. They still appear in the timing
 		# breakdown table above (when the "Hide framework tables" toggle
-		# is off) — the row is informational, just not actionable.
+		# is off) the row is informational, just not actionable.
 		from unittest.mock import patch
 
 		from optimus import renderer
@@ -402,7 +402,7 @@ class TestRenderedSection:
 		html = renderer.render_raw(self._doc(breakdown), recordings=[])
 		assert "Time spent per database table" in html
 		# Reads / Writes columns rendered (each carries a "consolidated"
-		# scope tag — match a prefix so the test is robust to tag tweaks).
+		# scope tag match a prefix so the test is robust to tag tweaks).
 		assert "<th class=\"num\">Reads " in html
 		assert "<th class=\"num\">Writes " in html
 		# Candidate columns + their source tooltip + the write-impact note.
@@ -470,14 +470,14 @@ def test_is_framework_db_table_truth_table():
 	          "tabWorkspace", "tabRole"):
 		assert is_framework_db_table(t) is True
 
-	# Framework-internal (new — user/session bookkeeping; deliberately
+	# Framework-internal (new user/session bookkeeping; deliberately
 	# excludes tabUser, which is a real user-data table some apps query
 	# meaningfully).
 	for t in ("tabHas Role", "tabDefaultValue", "tabUser Social Login",
 	          "tabUser Role Profile", "tabBlock Module", "tabUser Email"):
 		assert is_framework_db_table(t) is True
 
-	# MySQL system tables — any information_schema.* name.
+	# MySQL system tables any information_schema.* name.
 	for t in ("information_schema.columns", "information_schema.tables",
 	          "information_schema.statistics", "INFORMATION_SCHEMA.COLUMNS"):
 		assert is_framework_db_table(t) is True
@@ -537,7 +537,7 @@ class TestHideFrameworkTablesToggle:
 
 	def test_default_on_filters_framework_tables(self):
 		from optimus import renderer
-		# Default toggle is True (no patching needed — OptimusConfig() default).
+		# Default toggle is True (no patching needed OptimusConfig() default).
 		html = renderer.render_raw(self._doc(self._four_tables()), recordings=[])
 		# Only the user-app table survives in the table-breakdown section.
 		assert "tabSales Invoice" in html
@@ -598,7 +598,7 @@ class TestHideFrameworkTablesToggle:
 		# Per-action breakdown keeps the action_label (containing "tabUser") intact.
 		assert "frappe.client.get_value:tabUser" in html
 		# But the db-tables section still hides tabUser (the breakdown didn't list it
-		# here — so the note shouldn't render either, since nothing was hidden).
+		# here so the note shouldn't render either, since nothing was hidden).
 		assert "framework/internal tables hidden" not in html
 		assert "framework/internal table hidden" not in html
 
@@ -607,7 +607,7 @@ class TestRenderConfigFooter:
 	"""v0.6.x: the report footer stamps the render-affecting settings that
 	were in effect at render time. Without this stamp, users who toggle a
 	Optimus Settings flag and re-open an existing (un-regenerated) HTML
-	file see no change and assume a bug — when in fact the saved file is
+	file see no change and assume a bug when in fact the saved file is
 	frozen at its rendered-time settings."""
 
 	def _doc(self):
@@ -636,7 +636,7 @@ class TestRenderConfigFooter:
 		assert "hide_framework_tables=on" in html
 		assert "tracked_apps=(none)" in html
 		# v0.13.x: ignored_apps seeded with all Frappe-org apps. The
-		# footer joins names with ", " — assert the full alphabetical list.
+		# footer joins names with ", " assert the full alphabetical list.
 		assert (
 			"ignored_apps=builder, crm, drive, erpnext, frappe, "
 			"helpdesk, hrms, insights, lms, payments, wiki"
@@ -646,7 +646,7 @@ class TestRenderConfigFooter:
 		assert "min_action_duration_ms=0" in html
 		assert "large_duration_threshold_ms=1000" in html
 		# The nudge phrase explains why the user might be looking at stale
-		# data — the whole point of the stamp.
+		# data the whole point of the stamp.
 		assert "Regenerate Reports" in html
 
 	def test_footer_reflects_patched_settings(self):

--- a/optimus/tests/test_tldr_compose.py
+++ b/optimus/tests/test_tldr_compose.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for `renderer._compose_tldr` — the v0.7.x redesign Phase B
+"""Tests for `renderer._compose_tldr`: the v0.7.x redesign Phase B
 TL;DR hero composer.
 
 The hero picks the single highest-impact finding (severity desc, then
@@ -69,7 +69,7 @@ class TestHeadlineByCategory:
 
 	def test_user_n_plus_one_multi_request_hedges_with_up_to(self):
 		# loop_count is the PEAK single-request size when the loop spans requests,
-		# so the hero hedges ("up to") and names the spread — matching the title.
+		# so the hero hedges ("up to") and names the spread matching the title.
 		f = _finding(
 			finding_type="N+1 Query",
 			affected_count=120,
@@ -86,7 +86,7 @@ class TestHeadlineByCategory:
 
 	def test_framework_n_plus_one_hero_is_informational_not_actionable(self):
 		# A Framework N+1 can win the hero slot (highest impact), but it must NOT
-		# claim "the single biggest win" — the loop lives in Frappe, not user code.
+		# claim "the single biggest win" the loop lives in Frappe, not user code.
 		# It carries NO impact_scope_label (only user N+1 sets "recoverable"), which
 		# is exactly what routes it to the informational headline.
 		f = _finding(
@@ -105,7 +105,7 @@ class TestHeadlineByCategory:
 	def test_legacy_user_n_plus_one_without_impact_scope_label_stays_user(self):
 		# Regression: a user N+1 stored by a pre-``impact_scope_label`` build (the
 		# field is absent from technical_detail) must still render as the user's
-		# own actionable win on re-render — NOT the framework "can't change" copy.
+		# own actionable win on re-render NOT the framework "can't change" copy.
 		# Routing is gated on the stable finding_type, so the missing label is fine.
 		f = _finding(
 			finding_type="N+1 Query",
@@ -167,7 +167,7 @@ class TestHeadlineByCategory:
 class TestSorting:
 	def test_picks_highest_severity_first(self):
 		# Use the fallback finding_type so the headline includes the
-		# title verbatim — sorting test doesn't care about the
+		# title verbatim sorting test doesn't care about the
 		# category-specific prose, just which finding wins.
 		low = _finding(finding_type="?", severity="Low", estimated_impact_ms=5000, title="LOW_FINDING")
 		high = _finding(finding_type="?", severity="High", estimated_impact_ms=100, title="HIGH_FINDING")
@@ -198,7 +198,7 @@ class TestEmptyState:
 		tldr = renderer._compose_tldr([], _doc())
 		sub = str(tldr["sub_markup"])
 		assert "severity finding" not in sub
-		# But session totals stay — sub-line reworded in v0.7.x to make
+		# But session totals stay sub-line reworded in v0.7.x to make
 		# the consolidated-session aggregation explicit.
 		assert "Total active time:" in sub
 		assert "consolidated &middot; session" in sub
@@ -234,7 +234,7 @@ class TestMarkupSafety:
 	def test_user_supplied_title_is_html_escaped(self):
 		"""Finding titles come from analyzer output but can carry
 		user-controlled content (e.g. DocType names, action labels).
-		Markup.format() escapes plain-string args — confirm a stray
+		Markup.format() escapes plain-string args confirm a stray
 		<script> in the title is escaped, not interpolated raw."""
 		f = _finding(
 			finding_type="Hook Bottleneck",

--- a/optimus/tests/test_top_queries.py
+++ b/optimus/tests/test_top_queries.py
@@ -28,7 +28,7 @@ def test_top_callsite_from_business_code(full_scan_recording, empty_context):
 	"""Top queries should report the business-logic callsite, not frappe internals."""
 	result = top_queries.analyze([full_scan_recording], empty_context)
 	top = result.aggregate["top_queries"]
-	# All fixture frames are in acme_reports (custom app) — should see
+	# All fixture frames are in acme_reports (custom app) should see
 	# those paths, not frappe. v0.5.2: renamed from erpnext because
 	# erpnext is now classified as framework.
 	for q in top:
@@ -52,7 +52,7 @@ def test_framework_callsite_queries_excluded_from_leaderboard(empty_context):
 	"""v0.6.0: the slowest-queries leaderboard is scoped to the user's
 	own app. A slow query whose blame frame is inside frappe/ or
 	erpnext/ must not appear in ``top_queries`` even though it's slower
-	than the user-app queries — it's noise the developer can't act on.
+	than the user-app queries it's noise the developer can't act on.
 	The per-action breakdown still carries it."""
 	recording = {
 		"uuid": "r1",
@@ -108,7 +108,7 @@ def test_query_without_callsite_excluded_from_leaderboard(empty_context):
 def test_trivially_fast_queries_excluded_from_leaderboard(empty_context):
 	"""When every user-app query is sub-floor (a few ms each), the
 	leaderboard stays empty rather than padding itself with queries that
-	aren't worth singling out — there's no "reasonable" slowest query."""
+	aren't worth singling out there's no "reasonable" slowest query."""
 	recording = {
 		"uuid": "r1",
 		"calls": [

--- a/optimus/tests/test_truncation_banner.py
+++ b/optimus/tests/test_truncation_banner.py
@@ -11,7 +11,7 @@ Two related changes:
      5000 or 10000 to get full-coverage analysis.
 
   2. When truncation happens, a prominent red banner renders at the
-     TOP of the report — above the exec-summary card. Previously
+     TOP of the report above the exec-summary card. Previously
      the warning was buried in the collapsed Analyzer Notes at the
      bottom, and developers read incomplete reports without
      noticing.
@@ -86,7 +86,7 @@ class TestTruncationBannerRenders:
 		scrolling at the headline won't see the warning.
 		v0.7.x redesign: the exec-summary card was replaced by the
 		TL;DR hero (mock spec). The banner-must-come-before-the-most-
-		prominent-content rule still applies — the prominent block
+		prominent-content rule still applies the prominent block
 		just changed identity."""
 		from optimus import renderer
 
@@ -128,7 +128,7 @@ class TestTruncationBannerRenders:
 
 	def test_banner_absent_when_warnings_are_not_truncation(self):
 		"""Other analyzer warnings (framework-filter, alias-suppression,
-		etc.) must NOT trigger the truncation banner — it's specifically
+		etc.) must NOT trigger the truncation banner it's specifically
 		for the TRUNCATED marker. (The 'Analyzer notes' section that used
 		to list these was removed, so the warning isn't rendered at all.)"""
 		from optimus import renderer

--- a/optimus/tests/test_version_cache_buster.py
+++ b/optimus/tests/test_version_cache_buster.py
@@ -20,7 +20,7 @@ def _js_entries():
 def test_app_include_js_contains_version():
 	"""Every JS entry must have a ?v=<version>.<anything> cache-buster
 	starting with the current __version__. The suffix after the version
-	is the mtime-based auto-invalidator — we don't care about its exact
+	is the mtime-based auto-invalidator we don't care about its exact
 	value, just that the version is present."""
 	pattern = re.compile(
 		rf"\?v={re.escape(__version__)}(\.\d+)?$"
@@ -57,14 +57,14 @@ def test_app_include_paths_are_correct():
 
 def test_mtime_component_auto_invalidates_on_file_edit(tmp_path, monkeypatch):
 	"""v0.5.2: the ?v= suffix includes the file's mtime so ANY edit to
-	the JS/CSS auto-busts the browser cache — even when __version__
+	the JS/CSS auto-busts the browser cache even when __version__
 	hasn't been bumped. Pre-v0.5.2 was a real user incident: v0.5.2's
 	realtime code shipped while the browser kept serving v0.5.1's
 	polling code because the query string was unchanged.
 	"""
 	from optimus.hooks import _asset_version
 
-	# Call twice — result should change if the file is touched.
+	# Call twice result should change if the file is touched.
 	v1 = _asset_version("js/floating_widget.js")
 	# The version string format is "<version>.<mtime>" or just
 	# "<version>" if the file couldn't be stat'd.

--- a/optimus/tests/test_waterfall.py
+++ b/optimus/tests/test_waterfall.py
@@ -1,7 +1,7 @@
 # Copyright (c) 2026, Optimus contributors
 # For license information, please see license.txt
 
-"""Tests for `renderer._build_waterfall` — the v0.7.x redesign Phase
+"""Tests for `renderer._build_waterfall`: the v0.7.x redesign Phase
 C horizontal-bar action timeline.
 
 Top-N actions by duration, scaled to the displayed slice's max so
@@ -76,8 +76,8 @@ class TestPctScaling:
 
 	def test_pct_scales_to_displayed_slice_max(self):
 		"""When max_rows=2 selects the top-2 from a larger list,
-		scaling uses those two's max — not the (unshown) overall
-		max — so the second row is comparable visually."""
+		scaling uses those two's max not the (unshown) overall
+		max so the second row is comparable visually."""
 		actions = [
 			_a(0, duration_ms=200),
 			_a(1, duration_ms=100),
@@ -135,14 +135,14 @@ class TestBgFlag:
 class TestLayout:
 	"""Template-side waterfall layout invariants. The waterfall uses a CSS grid
 	with three columns: label / bar-track / duration. The label column has a
-	fixed pixel width — too narrow and typical 40-50 char action labels
+	fixed pixel width too narrow and typical 40-50 char action labels
 	(``POST /api/method/erpnext.accounts.utils.recompute`` ≈ 49 chars) ellipsize
 	even though the bar track has unused empty space."""
 
 	def test_waterfall_label_column_fits_typical_action_label(self):
 		"""The first track of ``.waterfall-row``'s ``grid-template-columns``
 		must be ≥ 320px so typical 47-49 char action labels render fully.
-		At 11.5px monospace each char is ~6.5px, so 320px ≈ 49 chars —
+		At 11.5px monospace each char is ~6.5px, so 320px ≈ 49 chars
 		just covers the longest observed labels."""
 		import os
 		import re
@@ -159,7 +159,7 @@ class TestLayout:
 		)
 		assert m, (
 			".waterfall-row must define grid-template-columns as "
-			"`<label_px> 1fr <duration_px>` — could not locate the rule"
+			"`<label_px> 1fr <duration_px>`: could not locate the rule"
 		)
 		label_px = int(m.group(1))
 		assert label_px >= 320, (

--- a/optimus/tests_integration/README.md
+++ b/optimus/tests_integration/README.md
@@ -1,9 +1,9 @@
-# `optimus.tests_integration` — real-bench integration tests
+# `optimus.tests_integration`: real-bench integration tests
 
 A sibling to `optimus/tests/`. The unit suite (`optimus/tests/`) runs in
 ~6 seconds against a Frappe stub and ships with the pure-pytest CI
 workflow. This directory holds tests that need a **live Frappe bench**
-— real MariaDB, real Redis, real RQ workers — and runs in CI via
+real MariaDB, real Redis, real RQ workers and runs in CI via
 `.github/workflows/integration.yml` against a bench provisioned by
 `.github/helper/install.sh`.
 
@@ -53,16 +53,16 @@ picked up here.)
 
 ## Fixtures (`conftest.py`)
 
-* **`test_site`** — yields `frappe.local.site` (the site the runner
+* **`test_site`**: yields `frappe.local.site` (the site the runner
   connected to). Tests rarely need it explicitly but it's useful for
   shelling out to `bench --site {test_site} …`.
-* **`cleanup_session`** — autouse. After every test, hard-deletes any
+* **`cleanup_session`**: autouse. After every test, hard-deletes any
   `Optimus Session` rows for the current user + clears the user's
   Redis active-session pointer. `FrappeTestCase` already rolls back
   per-test, but the analyze pipeline writes through a background-worker
-  connection that escapes the rollback in production flows — same for
+  connection that escapes the rollback in production flows same for
   Redis state. The cleanup is defence-in-depth.
-* **`seeded_session`** — convenience wrapper. Calls `api.start`, yields
+* **`seeded_session`**: convenience wrapper. Calls `api.start`, yields
   the `session_uuid`, then on teardown calls `api.stop` + waits up to
   60 s for the session to land on a terminal state (`Ready` /
   `Failed`).
@@ -99,7 +99,7 @@ class TestMyFeature(FrappeTestCase):
         frappe.set_user("Administrator")  # or another fixture user
 
     def test_my_invariant(self):
-        # Direct frappe.db / frappe.cache / api calls — no mocks.
+        # Direct frappe.db / frappe.cache / api calls no mocks.
         ...
 ```
 
@@ -117,8 +117,8 @@ using the harness above:
 |---|---|---|
 | ✓ `test_atomic_lua_merge_concurrent.py` (done in v0.12.1) | real-Redis + real-Lua concurrent test exercising the v0.7.x trilogy's invariants (recording+status race, distinct job_ids, setdefault first-writer-wins, fallback path) | Field loss under worker contention |
 | ✓ `test_regenerate_reports_idempotent.py` (done in v0.12.4) | calls `api.regenerate_reports` twice and byte-diffs the two HTML outputs (patches `renderer._now_iso` for determinism), confirms attachment lands on `raw_report_file`, confirms session-field changes produce different HTML, confirms Failed-status sessions still re-render | Re-render path is byte-stable across consecutive calls; silent caching / non-determinism would break upgrade roll-forward |
-| ✓ `test_phase2_tool_orphan_recovery.py` (done in v0.12.5) | leaks `sys.monitoring` tool 2 as `line_profiler`, calls `optimus._startup_probe_tool2()`, asserts the leak is reclaimed (tool freed + events cleared); also asserts the probe respects non-line_profiler ownership boundaries and is a no-op when tool 2 is free | The v0.7.x `fbf3179` fix holds across real worker bounces — without it, a worker line-traces every subsequent request → CPU peg + frozen UI |
-| ✓ `test_safe_report_self_contained_on_real_bench.py` (done in v0.12.6) | renders a session via `api.regenerate_reports`, reads the on-disk attached HTML, asserts no remote-fetch URLs (`src=https?:` / `<link href=https?:` / `@import` / `url(http`), no `<script>` tags (inline or external), no bench-local asset references (`/assets/`, `/files/`, `/api/method/`) | Self-containment canary holds when assets come through real Frappe file_manager paths — load-bearing dev-shop interchange guarantee |
+| ✓ `test_phase2_tool_orphan_recovery.py` (done in v0.12.5) | leaks `sys.monitoring` tool 2 as `line_profiler`, calls `optimus._startup_probe_tool2()`, asserts the leak is reclaimed (tool freed + events cleared); also asserts the probe respects non-line_profiler ownership boundaries and is a no-op when tool 2 is free | The v0.7.x `fbf3179` fix holds across real worker bounces without it, a worker line-traces every subsequent request → CPU peg + frozen UI |
+| ✓ `test_safe_report_self_contained_on_real_bench.py` (done in v0.12.6) | renders a session via `api.regenerate_reports`, reads the on-disk attached HTML, asserts no remote-fetch URLs (`src=https?:` / `<link href=https?:` / `@import` / `url(http`), no `<script>` tags (inline or external), no bench-local asset references (`/assets/`, `/files/`, `/api/method/`) | Self-containment canary holds when assets come through real Frappe file_manager paths load-bearing dev-shop interchange guarantee |
 | ✓ `test_janitor_sweeps_actually_delete.py` (done in v0.12.7) | seeds Optimus Sessions with controlled `started_at` + status, runs `janitor.sweep_old_sessions`, asserts: 100-day Ready session deleted, 30-day Ready session kept, 100-day Analyzing session kept (terminal-state-only contract), attached File rows cascade-deleted alongside parent session | Daily retention cron actually deletes (not just marks); attached file rows don't orphan; active sessions untouched regardless of age |
 
 Each is ~100-200 LOC. Pick the highest-impact one when you're picking

--- a/optimus/tests_integration/conftest.py
+++ b/optimus/tests_integration/conftest.py
@@ -3,29 +3,29 @@
 
 """Pytest fixtures for the real-bench integration suite.
 
-This module is **only imported under ``bench --site … run-tests``** — the
+This module is **only imported under ``bench --site … run-tests``**: the
 pure-pytest workflow at ``.github/workflows/tests.yml`` invokes
 ``pytest optimus/tests/`` and never traverses this directory, so the
 Frappe stub in ``optimus/tests/conftest.py`` doesn't apply here.
 
 The fixtures assume a live Frappe site is initialised (``frappe.init`` +
-``frappe.connect`` have already run — Frappe's test runner does this
+``frappe.connect`` have already run Frappe's test runner does this
 before importing the test modules). Direct Frappe access (``frappe.db``,
-``frappe.cache``, ``frappe.get_doc`` etc.) is the whole point — the unit
+``frappe.cache``, ``frappe.get_doc`` etc.) is the whole point the unit
 suite stubs them, the integration suite uses them.
 
 Fixtures:
 
-* :func:`test_site` — yields the site name. Tests rarely need it
+* :func:`test_site`: yields the site name. Tests rarely need it
   explicitly (frappe.local already knows), but it's useful for assertions
   and for shelling out to ``bench --site {test_site} …``.
-* :func:`cleanup_session` (autouse) — defence-in-depth teardown that
+* :func:`cleanup_session` (autouse) defence-in-depth teardown that
   hard-deletes any ``Optimus Session`` rows left behind plus their
   ``profiler:*`` Redis keys. ``FrappeTestCase`` already rolls back the
   per-test transaction, but the analyze pipeline writes through a
   background-worker connection that escapes the transaction in production
-  flows — and the Redis state isn't transactional either way.
-* :func:`seeded_session` — convenience wrapper that calls ``api.start``,
+  flows and the Redis state isn't transactional either way.
+* :func:`seeded_session`: convenience wrapper that calls ``api.start``,
   yields the session_uuid, and on teardown calls ``api.stop`` and waits
   for analyze to finalise. Used by the lifecycle test.
 """
@@ -41,7 +41,7 @@ import pytest
 @pytest.fixture(scope="session")
 def test_site() -> str:
 	"""The name of the Frappe site the test runner is connected to. Returns
-	``frappe.local.site`` so tests stay site-agnostic — the helper script
+	``frappe.local.site`` so tests stay site-agnostic the helper script
 	creates ``test_site`` but a local developer running this suite against
 	their own bench site sees that site name."""
 	return frappe.local.site
@@ -53,7 +53,7 @@ def cleanup_session():
 
 	FrappeTestCase wraps each test in a DB transaction that's rolled back
 	at teardown, but the analyze pipeline runs in a background worker via
-	RQ — its writes are in a separate connection that escapes that
+	RQ its writes are in a separate connection that escapes that
 	transaction in real flows. Same for Redis: the active-session pointer
 	and the per-session metadata hash aren't transactional either way.
 
@@ -64,12 +64,12 @@ def cleanup_session():
 	already rolled back.
 	"""
 	yield
-	# Lazy imports — analyze.py / session.py do their own frappe imports
+	# Lazy imports analyze.py / session.py do their own frappe imports
 	# at module top, but the conftest shouldn't reach them at module load
 	# (it would slow down test-collection in the bench runner).
 	try:
 		_purge_test_sessions()
-	except Exception as exc:  # pragma: no cover — best-effort path
+	except Exception as exc:  # pragma: no cover best-effort path
 		frappe.log_error(
 			title="optimus integration: cleanup_session",
 			message=f"{type(exc).__name__}: {exc}",
@@ -79,7 +79,7 @@ def cleanup_session():
 def _purge_test_sessions() -> None:
 	"""Delete every ``Optimus Session`` row whose user is the current
 	session user, plus their associated Redis state. Safe to call on a
-	bench that holds OTHER sessions (different users) — the user-scoped
+	bench that holds OTHER sessions (different users) the user-scoped
 	filter prevents collateral damage."""
 	user = getattr(frappe.session, "user", None) or "Administrator"
 	rows = frappe.get_all(

--- a/optimus/tests_integration/test_atomic_lua_merge_concurrent.py
+++ b/optimus/tests_integration/test_atomic_lua_merge_concurrent.py
@@ -8,7 +8,7 @@ The v0.7.x bg-tracking trilogy (``a356f64`` → ``0e4a270`` → ``f30f44e``)
 closed a multi-worker field-loss race. Pre-trilogy, two workers writing
 to the same job_id's per-field dict could lose fields under a
 read-modify-write race: Worker A reads meta, modifies, writes; Worker B
-in the interleave reads the pre-A meta, modifies, writes — and Worker A's
+in the interleave reads the pre-A meta, modifies, writes and Worker A's
 change is gone.
 
 The fix moves the merge SERVER-SIDE via :data:`_MERGE_JOB_META_LUA` (and
@@ -17,7 +17,7 @@ invariant under genuine concurrent thread contention against real Redis +
 real Lua.
 
 A unit-suite test exists for this in ``optimus/tests/test_session_jobs.py``
-but it ``pytest.skip``s when Redis or Lua isn't reachable — under the
+but it ``pytest.skip``s when Redis or Lua isn't reachable under the
 pure-pytest workflow, that's every run. The integration version is the
 first-class CI gate: real Redis + real Lua, always runs, richer
 scenarios.
@@ -29,8 +29,8 @@ the bench. Threads in this test can't replicate that because
 non-main Python threads. The mitigation (mirroring the unit test): pre-
 compute the prefixed Redis key in the main thread, then have worker
 threads call ``frappe.cache.eval(_MERGE_JOB_META_LUA, …)`` directly.
-That preserves the load-bearing invariant — Redis Lua serialisation
-of HGET + JSON-merge + HSET — which is exactly what the trilogy
+That preserves the load-bearing invariant Redis Lua serialisation
+of HGET + JSON-merge + HSET which is exactly what the trilogy
 protects.
 
 For the fallback path (Python read-modify-write when Lua isn't
@@ -58,7 +58,7 @@ def _require_redis_and_lua():
 	try:
 		frappe.cache.ping()
 	except Exception:
-		return "No bench Redis available — start with `bench start`"
+		return "No bench Redis available start with `bench start`"
 	try:
 		frappe.cache.eval("return 1", 0)
 	except Exception:
@@ -104,7 +104,7 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 		super().tearDown()
 
 	# ----------------------------------------------------------------
-	# 1. The exact v0.7.x race — pair threads writing recording_uuid +
+	# 1. The exact v0.7.x race pair threads writing recording_uuid +
 	#    status to the same job_id, looped across 50 distinct job_ids.
 	#    This is the canonical regression test.
 	# ----------------------------------------------------------------
@@ -136,7 +136,7 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 				json.dumps({"status": status}),
 			)
 
-		# Use a Barrier so all threads release at the exact same moment —
+		# Use a Barrier so all threads release at the exact same moment
 		# maximises the race-window overlap. Without it, t.start() loops
 		# can sequence threads on a fast runner.
 		barrier = threading.Barrier(2 * N_JOBS)
@@ -181,7 +181,7 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 		)
 
 	# ----------------------------------------------------------------
-	# 2. Distinct job_ids — N threads, N distinct hash fields. The
+	# 2. Distinct job_ids N threads, N distinct hash fields. The
 	#    per-field cjson encode within ONE Lua script should isolate
 	#    each thread's write.
 	# ----------------------------------------------------------------
@@ -218,12 +218,12 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 			if not meta or meta.get("recording_uuid") != f"rec-{i}":
 				missing.append(f"job-{i}: meta={meta!r}")
 		assert not missing, (
-			f"{len(missing)}/{N} distinct-job-id writes lost — "
+			f"{len(missing)}/{N} distinct-job-id writes lost "
 			f"per-field cjson isolation broken. Missing: {missing!r}"
 		)
 
 	# ----------------------------------------------------------------
-	# 3. setdefault — two threads race to set ``method``; the second
+	# 3. setdefault two threads race to set ``method``; the second
 	#    writer's value MUST NOT clobber the first's. The trilogy's
 	#    _SETDEFAULT_JOB_META_LUA is what protects this on the enqueue
 	#    path (multiple callers can race ``record_job`` if the same
@@ -249,7 +249,7 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 			json.dumps({"method": "first.writer"}),
 		)
 
-		# Now race many threads — each tries setdefault with a different
+		# Now race many threads each tries setdefault with a different
 		# method. None should win; the original "first.writer" stays.
 		N = 20
 		barrier = threading.Barrier(N)
@@ -277,10 +277,10 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 		)
 
 	# ----------------------------------------------------------------
-	# 4. Fallback path — when Lua eval raises, _atomic_merge_job_meta
+	# 4. Fallback path when Lua eval raises, _atomic_merge_job_meta
 	#    must still write via the Python read-modify-write fallback.
 	#    Single-threaded so we can exercise the FULL wrapper (which
-	#    needs frappe.local set up — only the main thread has it).
+	#    needs frappe.local set up only the main thread has it).
 	# ----------------------------------------------------------------
 
 	def test_fallback_path_writes_when_lua_unavailable(self):
@@ -294,7 +294,7 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 		sid = self._session_uuid
 		jid = "job-fallback"
 
-		# Patch frappe.cache.eval to raise — the wrapper must catch and
+		# Patch frappe.cache.eval to raise the wrapper must catch and
 		# fall through to _read_job → merge → _write_job.
 		def _eval_raises(*args, **kwargs):
 			raise RuntimeError("Lua eval disabled for fallback test")
@@ -312,7 +312,7 @@ class TestAtomicLuaMergeConcurrent(FrappeTestCase):
 
 	# ----------------------------------------------------------------
 	# 5. Sanity: with Lua disabled, _atomic_merge_job_meta doesn't
-	#    raise — the wrapper catches the eval failure and falls
+	#    raise the wrapper catches the eval failure and falls
 	#    through silently. Defensive lock-in for the contract that
 	#    "atomic-merge must NEVER break the host code".
 	# ----------------------------------------------------------------

--- a/optimus/tests_integration/test_install_smoke.py
+++ b/optimus/tests_integration/test_install_smoke.py
@@ -9,7 +9,7 @@ land in MariaDB:
   * The ``Optimus User`` role is created.
   * Every Optimus DocType is registered in ``tabDocType``.
   * The ``Optimus Settings`` Single doc is creatable + readable.
-  * ``bench migrate`` is idempotent — re-running it leaves the schema
+  * ``bench migrate`` is idempotent re-running it leaves the schema
     untouched and never raises.
 
 Pure-pytest's Frappe stub can mock individual install-time calls in
@@ -24,7 +24,7 @@ import frappe
 from frappe.tests.utils import FrappeTestCase
 
 # Every DocType optimus declares. Sourced from
-# ``optimus/optimus/doctype/`` directory listing — the install assertion
+# ``optimus/optimus/doctype/`` directory listing the install assertion
 # is that EVERY one of these landed in tabDocType after install-app.
 _OPTIMUS_DOCTYPES = (
 	"Optimus Session",
@@ -43,13 +43,13 @@ class TestInstallSmoke(FrappeTestCase):
 		auto-assigns it to every System Manager. The role is the desk-
 		level permission gate for the floating widget."""
 		assert frappe.db.exists("Role", "Optimus User"), (
-			"Optimus User role not present — install.after_install didn't land"
+			"Optimus User role not present install.after_install didn't land"
 		)
 
 	def test_all_optimus_doctypes_exist(self):
 		"""Every Optimus DocType is registered. Missing entries here
 		would mean ``bench install-app`` skipped reloading a doctype
-		— most likely a missing entry in ``patches.txt`` or a typo in
+		most likely a missing entry in ``patches.txt`` or a typo in
 		the doctype's JSON ``module`` field."""
 		missing = [
 			dt for dt in _OPTIMUS_DOCTYPES
@@ -65,21 +65,21 @@ class TestInstallSmoke(FrappeTestCase):
 		doc = frappe.get_cached_doc("Optimus Settings")
 		assert doc.doctype == "Optimus Settings"
 		# v0.7.x: enabled defaults to 1 on a fresh install. Tolerate
-		# either value here — what we're locking is "readable", not
+		# either value here what we're locking is "readable", not
 		# "set to a specific default" (that's covered by unit tests).
 		assert hasattr(doc, "enabled")
 
 	# v0.12.34: ``test_bench_migrate_idempotent`` removed. Frappe v16
 	# replaced the standalone ``migrate()`` function with the
 	# ``SiteMigration`` class, whose ``run(site)`` method calls
-	# ``frappe.destroy()`` after running — designed for ``bench
+	# ``frappe.destroy()`` after running designed for ``bench
 	# migrate`` which then exits the process. Inside a running test,
 	# the ``destroy`` unbinds ``frappe.local`` (db, conf, etc.), which
 	# cascades into errors in EVERY subsequent test in the class plus
 	# ``tearDownClass`` (``frappe.db.value_cache`` becomes unbound).
 	#
-	# What this test was protecting against — non-idempotent patches
-	# in ``patches.txt`` — is already covered:
+	# What this test was protecting against non-idempotent patches
+	# in ``patches.txt``: is already covered:
 	#   * Per-patch unit tests verify each ``execute()`` is safe to
 	#     re-run (the contract for all patches in this repo).
 	#   * The bench bootstrap itself runs ``bench migrate`` (see

--- a/optimus/tests_integration/test_janitor_sweeps_actually_delete.py
+++ b/optimus/tests_integration/test_janitor_sweeps_actually_delete.py
@@ -16,12 +16,12 @@ The unit suite covers individual sweep functions in isolation
   * That the cron does, in fact, delete the underlying DocType row
     (not just mark or move it).
   * That attached File rows (``raw_report_file``) get deleted along
-    with the session — orphan File rows would inflate disk usage
+    with the session orphan File rows would inflate disk usage
     forever, even though the parent session is gone.
   * That the cutoff math is correct: a session 100 days old → deleted;
     a session 30 days old → kept (with the default 90-day retention).
   * That **active** sessions (Recording, Analyzing, Stopping, etc.)
-    are untouched regardless of age — the daily sweep only prunes
+    are untouched regardless of age the daily sweep only prunes
     terminal-state sessions; the 5-minute sweep handles the others.
 
 That gap is what this final integration test fills. Each test creates
@@ -139,7 +139,7 @@ class TestJanitorSweepsActuallyDelete(FrappeTestCase):
 					"is_private": 1,
 				}
 			)
-			# Avoid validate_file_extension by clearing request — same
+			# Avoid validate_file_extension by clearing request same
 			# trick analyze._save_report_file uses.
 			saved_request = getattr(frappe.local, "request", None)
 			try:
@@ -180,18 +180,18 @@ class TestJanitorSweepsActuallyDelete(FrappeTestCase):
 
 		assert not self._session_exists(fixture["uuid"]), (
 			f"sweep_old_sessions did NOT delete the 100-day-old Ready session "
-			f"{fixture['uuid']!r} — retention policy is broken; the Optimus "
+			f"{fixture['uuid']!r} retention policy is broken; the Optimus "
 			f"Session table will grow forever"
 		)
 
 	def test_sweep_keeps_session_within_retention(self):
 		"""Negative control. A Ready session comfortably INSIDE the
-		configured retention window MUST be left alone by the sweep —
+		configured retention window MUST be left alone by the sweep
 		without this guard the sweep could overzealously delete recent
 		sessions.
 
 		Retention is ``Optimus Settings.session_retention_days`` (default 30,
-		config-profile dependent — see settings.py), so the fixture age is
+		config-profile dependent see settings.py), so the fixture age is
 		taken as HALF that window rather than a hard-coded 30 days. A
 		hard-coded 30 sat exactly on the default-30 boundary and lost the race
 		against the sweep's ``now()`` cutoff."""
@@ -206,17 +206,17 @@ class TestJanitorSweepsActuallyDelete(FrappeTestCase):
 
 		assert self._session_exists(fixture["uuid"]), (
 			f"sweep_old_sessions ate a {within}-day-old session "
-			f"{fixture['uuid']!r} (retention={retention}d) — too aggressive"
+			f"{fixture['uuid']!r} (retention={retention}d) too aggressive"
 		)
 
 	def test_sweep_keeps_active_sessions_regardless_of_age(self):
 		"""The terminal-state contract. Sessions in non-terminal
 		states (Recording, Analyzing, Stopping) MUST NOT be deleted
-		by the daily sweep even when they're ancient — the 5-minute
+		by the daily sweep even when they're ancient the 5-minute
 		``sweep_stale_sessions`` handles those by force-stopping or
 		marking failed. The daily sweep's filter pins to ``status IN
 		(Ready, Failed)`` exclusively."""
-		# Create an OLD Analyzing session — the kind that would be
+		# Create an OLD Analyzing session the kind that would be
 		# tempting to GC but is wrong to.
 		fixture = self._create_session(days_old=100, status="Analyzing")
 		assert self._session_exists(fixture["uuid"])
@@ -225,7 +225,7 @@ class TestJanitorSweepsActuallyDelete(FrappeTestCase):
 
 		assert self._session_exists(fixture["uuid"]), (
 			f"sweep_old_sessions deleted a non-terminal-status session "
-			f"{fixture['uuid']!r} (status=Analyzing) — daily sweep must "
+			f"{fixture['uuid']!r} (status=Analyzing) daily sweep must "
 			f"only touch Ready/Failed; stale active sessions are the "
 			f"5-minute sweep's job"
 		)
@@ -234,7 +234,7 @@ class TestJanitorSweepsActuallyDelete(FrappeTestCase):
 		"""Disk-hygiene contract. Deleting an Optimus Session must
 		cascade to its ``raw_report_file`` File row. Orphan File rows
 		left behind by row-only deletes would inflate disk usage
-		forever — and the safe-report-on-disk is often the largest
+		forever and the safe-report-on-disk is often the largest
 		artefact per session."""
 		fixture = self._create_session(days_old=120, status="Ready", with_attached_file=True)
 		assert self._session_exists(fixture["uuid"])
@@ -243,8 +243,8 @@ class TestJanitorSweepsActuallyDelete(FrappeTestCase):
 		janitor.sweep_old_sessions()
 
 		assert not self._session_exists(fixture["uuid"]), "session not deleted; can't validate file cascade"
-		# The File row MUST also be gone — orphans inflate disk forever.
+		# The File row MUST also be gone orphans inflate disk forever.
 		assert not self._file_exists(fixture["file_url"]), (
 			f"File row {fixture['file_url']!r} survived parent session "
-			f"deletion — orphan File rows inflate disk usage"
+			f"deletion orphan File rows inflate disk usage"
 		)

--- a/optimus/tests_integration/test_phase2_tool_orphan_recovery.py
+++ b/optimus/tests_integration/test_phase2_tool_orphan_recovery.py
@@ -12,10 +12,10 @@ subsequent request in that worker line-traced → CPU peg + frozen UI.
 
 The pre-``fbf3179`` failure mode required a ``bench restart`` to
 recover. The ``fbf3179`` fix added two things:
-  * ``capture.release_monitoring_tool()`` — idempotent unwinder called
+  * ``capture.release_monitoring_tool()``: idempotent unwinder called
     from the after_* hooks (covered by the unit suite's
     ``test_line_profile_monitoring.py``).
-  * ``optimus._startup_probe_tool2()`` — worker-respawn recovery: if
+  * ``optimus._startup_probe_tool2()``: worker-respawn recovery: if
     tool 2 is owned by line_profiler at app-import (i.e. the prior
     worker died mid-Phase-2 and its line-tracing state survived the
     process restart in the *same Python process group*), the probe
@@ -33,7 +33,7 @@ release helper at the function-call boundary. It cannot prove:
 
 That gap is what this integration test fills. The tests invoke
 ``optimus._startup_probe_tool2`` directly against manipulated
-``sys.monitoring`` state — same shape as the unit tests'
+``sys.monitoring`` state same shape as the unit tests'
 ``_leak_tool`` helper, but exercised in a real-bench context.
 
 A note on "simulating worker respawn": we can't actually fork a
@@ -41,7 +41,7 @@ worker mid-Phase-2 and re-import optimus inside a test (the optimus
 module is already loaded). Instead, the test manipulates the
 ``sys.monitoring`` state to mirror what a leaked tool 2 looks like
 after a worker death, then calls the probe directly. This exercises
-the probe's recovery logic — which is the contract under test.
+the probe's recovery logic which is the contract under test.
 """
 
 from __future__ import annotations
@@ -106,12 +106,12 @@ class TestPhase2ToolOrphanRecovery(FrappeTestCase):
 
 	def _leak_as(self, owner: str) -> None:
 		"""Register tool 2 as a non-line_profiler owner. Used to
-		validate that the probe respects ownership boundaries — it
+		validate that the probe respects ownership boundaries it
 		MUST NOT reclaim a tool that belongs to a third-party
 		profiler / debugger."""
 		self._ensure_tool_2_is_free()
 		sys.monitoring.use_tool_id(_PID, owner)
-		# Don't set events — keeps the simulation lighter and matches
+		# Don't set events keeps the simulation lighter and matches
 		# the most common third-party-tool registration pattern (claim
 		# the tool slot, install events on demand).
 
@@ -136,7 +136,7 @@ class TestPhase2ToolOrphanRecovery(FrappeTestCase):
 		# the leaked LINE events would line-trace every later request
 		# in this worker → CPU peg + freeze.
 		assert sys.monitoring.get_tool(_PID) is None, (
-			"probe failed to reclaim leaked line_profiler tool 2 — "
+			"probe failed to reclaim leaked line_profiler tool 2 "
 			"a worker would line-trace every subsequent request"
 		)
 		assert sys.monitoring.get_events(_PID) == 0
@@ -151,14 +151,14 @@ class TestPhase2ToolOrphanRecovery(FrappeTestCase):
 
 		optimus._startup_probe_tool2()
 
-		# Still unowned — the probe didn't grab the slot.
+		# Still unowned the probe didn't grab the slot.
 		assert sys.monitoring.get_tool(_PID) is None
 		assert sys.monitoring.get_events(_PID) == 0
 
 	def test_probe_warns_but_does_not_reclaim_non_line_profiler_owner(self):
 		"""Boundary contract. If tool 2 is owned by something OTHER
 		than line_profiler (a third-party debugger, py-spy, an IDE
-		profiler), the probe MUST NOT reclaim it — that would silently
+		profiler), the probe MUST NOT reclaim it that would silently
 		break the third-party tool. The probe should warn (visible in
 		logs) but leave the tool alone."""
 		self._leak_as("third-party-debugger")
@@ -166,9 +166,9 @@ class TestPhase2ToolOrphanRecovery(FrappeTestCase):
 
 		optimus._startup_probe_tool2()
 
-		# The third-party tool is still in place — the probe respected
+		# The third-party tool is still in place the probe respected
 		# the boundary.
 		assert sys.monitoring.get_tool(_PID) == "third-party-debugger", (
-			"probe accidentally reclaimed a tool owned by a non-line_profiler — "
+			"probe accidentally reclaimed a tool owned by a non-line_profiler "
 			"this would silently break the third-party tool's tracing"
 		)

--- a/optimus/tests_integration/test_recording_lifecycle_e2e.py
+++ b/optimus/tests_integration/test_recording_lifecycle_e2e.py
@@ -26,7 +26,7 @@ This single test exercises:
 
 Failure here means the integration layer broke. Pure-pytest can verify
 every component in isolation but cannot catch a regression in the
-inter-component handoff — that's what this test is for.
+inter-component handoff that's what this test is for.
 """
 
 from __future__ import annotations
@@ -62,7 +62,7 @@ class TestRecordingLifecycleE2E(FrappeTestCase):
 	def setUpClass(cls):
 		super().setUpClass()
 		# Run as Administrator so the user-permission gates in api.start
-		# / api.stop don't refuse — the test is exercising the capture
+		# / api.stop don't refuse the test is exercising the capture
 		# pipeline, not the auth surface (that's covered by other tests).
 		frappe.set_user("Administrator")
 
@@ -97,7 +97,7 @@ class TestRecordingLifecycleE2E(FrappeTestCase):
 				f"{session_uuid!r}"
 			)
 		finally:
-			# Clean up so the next test starts from a known state — the
+			# Clean up so the next test starts from a known state the
 			# autouse cleanup_session fixture handles this too, but
 			# defence-in-depth keeps the test self-contained.
 			try:
@@ -153,7 +153,7 @@ class TestRecordingLifecycleE2E(FrappeTestCase):
 		session_uuid = start_result["session_uuid"]
 		docname = start_result["docname"]
 
-		# No HTTP traffic in between — a stop() immediately after start()
+		# No HTTP traffic in between a stop() immediately after start()
 		# produces a session with zero recordings. analyze.run handles
 		# that gracefully (renders a "no recordings" report) so this is
 		# still a valid smoke. A future PR can add an actual recorded
@@ -173,7 +173,7 @@ class TestRecordingLifecycleE2E(FrappeTestCase):
 		# a code path in ``analyze.run`` that DOESN'T attach a report
 		# (the empty-recordings session reaches Ready via early-
 		# return paths inside analyze, leaving ``raw_report_file``
-		# unset — observed in CI runs of this test). The production
+		# unset observed in CI runs of this test). The production
 		# answer for that case is exactly what ``regenerate_reports``
 		# does: re-render from persisted DocType fields without
 		# requiring recordings. v0.12.4's regenerate-tests prove this
@@ -184,7 +184,7 @@ class TestRecordingLifecycleE2E(FrappeTestCase):
 		api.regenerate_reports(session_uuid)
 
 		# Report URL is persisted on the session's ``raw_report_file``
-		# field — that's the authoritative side-effect contract
+		# field that's the authoritative side-effect contract
 		# (same one the v0.12.4 regenerate-tests assert against).
 		# ``analyze._render_and_attach_reports`` sets ``raw_report_file``
 		# via ``frappe.db.set_value`` as its last step; same field is
@@ -195,19 +195,19 @@ class TestRecordingLifecycleE2E(FrappeTestCase):
 		)
 		assert raw_report_file, (
 			f"no Optimus report HTML attached to session {docname!r} "
-			f"after regenerate_reports — ``raw_report_file`` field is "
+			f"after regenerate_reports ``raw_report_file`` field is "
 			f"empty, meaning the render or the attach step failed "
 			f"silently inside ``analyze._render_and_attach_reports``. "
 			f"Bench logs may show why (uploaded as integration-logs "
 			f"artifact on failure)."
 		)
 
-	# --- 5: sanity-floor — totals are populated ---------------------------
+	# --- 5: sanity-floor totals are populated ---------------------------
 
 	def test_session_totals_populated_after_analyze(self):
 		"""After a successful analyze, the session's persisted totals are
 		set to *something* (zero is fine on an empty-recording session).
-		This is the floor — if totals are None / missing, a write step
+		This is the floor if totals are None / missing, a write step
 		in analyze got skipped."""
 		from optimus import api
 
@@ -226,6 +226,6 @@ class TestRecordingLifecycleE2E(FrappeTestCase):
 		# Each field must be a number (int/float), not None.
 		for field in ("total_duration_ms", "total_query_time_ms", "total_queries", "total_requests"):
 			assert row[field] is not None, (
-				f"{field} is None after analyze — analyze.run skipped the totals write"
+				f"{field} is None after analyze analyze.run skipped the totals write"
 			)
 			assert row[field] >= 0, f"{field} should be non-negative, got {row[field]!r}"

--- a/optimus/tests_integration/test_regenerate_reports_idempotent.py
+++ b/optimus/tests_integration/test_regenerate_reports_idempotent.py
@@ -9,12 +9,12 @@ without re-running the analyze pipeline. Its purpose is to let an
 operator pick up a renderer / template upgrade on a historical session
 without paying the cost of re-analysis.
 
-The re-render path is load-bearing for upgrades — every renderer or
+The re-render path is load-bearing for upgrades every renderer or
 template polish round (v0.7.0 polish day, v0.10.0 renderer split, the
 v0.6.0 "single rendering path" round) shipped on the assumption that
 operators could regenerate old sessions to see the new UI. The
 pure-pytest unit test (``optimus/tests/test_regenerate_reports_api.py``)
-does source inspection only — confirms the endpoint is whitelisted,
+does source inspection only confirms the endpoint is whitelisted,
 takes ``session_uuid``, doesn't call ``_enqueue_analyze``, calls
 ``clear_cached_pdf``, gates on permissions. It says nothing about the
 output.
@@ -25,14 +25,14 @@ What that unit suite can't prove:
     session produce **byte-identical** HTML. If non-determinism slips
     into the renderer (a fresh UUID, a dict-iteration order change, a
     ``time.time()`` snapshot in a stamp), the upgrade path silently
-    starts producing diff'd HTML — which breaks ``regenerate`` as a
+    starts producing diff'd HTML which breaks ``regenerate`` as a
     way to roll forward, and breaks any safe-report diffing workflow
     a dev-shop might rely on.
   * That the endpoint actually attaches the rendered HTML to
     ``Optimus Session.raw_report_file`` (Attach field) and the
     attachment URL resolves to readable content.
   * That a session-data change (e.g., the operator edits the title)
-    produces a **different** HTML — the canary's complement.
+    produces a **different** HTML the canary's complement.
   * That regenerate honours its documented "Allowed on Ready OR
     Failed sessions" claim.
 
@@ -110,7 +110,7 @@ class TestRegenerateReportsIdempotent(FrappeTestCase):
 		"""Insert a minimal valid ``Optimus Session`` with status=Ready.
 
 		Reqd fields: session_uuid, title, user, status, started_at.
-		Optional analysis-data fields are left at defaults — the
+		Optional analysis-data fields are left at defaults the
 		renderer is defensive against missing data, empty sections
 		render as empty, the HTML is still valid."""
 		doc = frappe.get_doc(
@@ -188,7 +188,7 @@ class TestRegenerateReportsIdempotent(FrappeTestCase):
 		html_1 = self._read_rendered_html(self._session_doc.name)
 		assert html_1, "first render produced empty HTML"
 
-		# Second render — same session, same data, same patched _now_iso.
+		# Second render same session, same data, same patched _now_iso.
 		result_2 = api.regenerate_reports(self._uuid)
 		assert result_2.get("regenerated") is True
 		html_2 = self._read_rendered_html(self._session_doc.name)
@@ -196,7 +196,7 @@ class TestRegenerateReportsIdempotent(FrappeTestCase):
 
 		# Byte-equality is the contract under test.
 		assert html_1 == html_2, (
-			f"regenerate_reports is NOT byte-stable across consecutive calls — "
+			f"regenerate_reports is NOT byte-stable across consecutive calls "
 			f"the upgrade path silently produces diff'd HTML. "
 			f"len(html_1)={len(html_1)}, len(html_2)={len(html_2)}, "
 			f"first 200-byte diff position: "
@@ -239,14 +239,14 @@ class TestRegenerateReportsIdempotent(FrappeTestCase):
 		"""The canary's complement. Render once, snapshot HTML.
 		Mutate the session's ``title`` field via ``frappe.db.set_value``
 		(the renderer reads it through ``build_report_context``).
-		Render again, snapshot HTML. The two HTMLs must DIFFER — and
+		Render again, snapshot HTML. The two HTMLs must DIFFER and
 		the new title must appear in HTML 2 but not HTML 1. Catches
 		silent caching that would return stale HTML on field
 		changes."""
 		original_title = self._session_doc.title
 		new_title = f"MUTATED-{frappe.generate_hash(length=8)}"
 
-		# Render 1 — original title.
+		# Render 1 original title.
 		api.regenerate_reports(self._uuid)
 		html_1 = self._read_rendered_html(self._session_doc.name)
 		assert original_title.encode("utf-8") in html_1, (
@@ -256,29 +256,29 @@ class TestRegenerateReportsIdempotent(FrappeTestCase):
 			"new title should NOT appear in HTML 1 (sanity check)"
 		)
 
-		# Mutate the title — direct DB write so we don't trigger the
+		# Mutate the title direct DB write so we don't trigger the
 		# session's on_update hooks (which could side-effect the test).
 		frappe.db.set_value(
 			_SESSION_DOCTYPE, self._session_doc.name, "title", new_title
 		)
 		frappe.db.commit()
 
-		# Render 2 — new title.
+		# Render 2 new title.
 		api.regenerate_reports(self._uuid)
 		html_2 = self._read_rendered_html(self._session_doc.name)
 		assert new_title.encode("utf-8") in html_2, (
-			f"new title {new_title!r} should appear in HTML 2 — regenerate "
+			f"new title {new_title!r} should appear in HTML 2 regenerate "
 			f"did not pick up the field change (silent caching?)"
 		)
 		assert html_1 != html_2, (
-			"HTMLs should differ after the title change — regenerate is "
+			"HTMLs should differ after the title change regenerate is "
 			"silently caching the previous output"
 		)
 
 	def test_regenerate_works_on_failed_status_session(self):
 		"""Validates the docstring claim: regenerate is allowed on
 		Ready OR Failed sessions. A Failed session whose analyze
-		partially completed should still re-render — that's often the
+		partially completed should still re-render that's often the
 		whole reason for the feature ("unblock a demo when a
 		render-time bug was fixed")."""
 		# Demote the session from Ready to Failed.
@@ -305,7 +305,7 @@ class TestRegenerateReportsIdempotent(FrappeTestCase):
 		states (Recording / Stopping / Analyzing). Pre-v0.12.9 the
 		endpoint accepted any status and would attach an incomplete
 		report to a still-running analyze that the pipeline would
-		then overwrite — closing that gap is what this test pins."""
+		then overwrite closing that gap is what this test pins."""
 		# Move the session from Ready (the setUp default) to Analyzing.
 		frappe.db.set_value(
 			_SESSION_DOCTYPE, self._session_doc.name, "status", "Analyzing"

--- a/optimus/tests_integration/test_safe_report_self_contained_on_real_bench.py
+++ b/optimus/tests_integration/test_safe_report_self_contained_on_real_bench.py
@@ -17,7 +17,7 @@ It cannot prove:
   * That the report fetched from the **on-disk File attachment**
     (after ``api.regenerate_reports`` writes it through Frappe's
     real ``file_manager``) is still self-contained. File encoding,
-    Frappe's file-handling middleware, the post-write read path —
+    Frappe's file-handling middleware, the post-write read path
     all could theoretically introduce reference resolution that the
     unit-suite render doesn't see.
   * That the rendered HTML doesn't accidentally reference live-bench
@@ -116,7 +116,7 @@ class TestSafeReportSelfContainedOnRealBench(FrappeTestCase):
 		return doc
 
 	def _read_rendered_html(self, session_name: str) -> str:
-		"""Read raw_report_file content via the File doc — exercises
+		"""Read raw_report_file content via the File doc exercises
 		the same retrieval path a downstream consumer would use."""
 		file_url = frappe.db.get_value(_SESSION_DOCTYPE, session_name, "raw_report_file")
 		assert file_url, f"raw_report_file not set for {session_name!r}"
@@ -130,7 +130,7 @@ class TestSafeReportSelfContainedOnRealBench(FrappeTestCase):
 
 	def test_on_disk_report_has_no_remote_resource_urls(self):
 		"""Mirrors the unit-suite canary (``test_report_a11y.py:143``)
-		against the on-disk HTML. No external resource loads — no
+		against the on-disk HTML. No external resource loads no
 		``https?:`` in ``src=``, no ``https?:`` in ``<link href=``,
 		no ``@import``, no ``url(http``. ``data:`` URIs (the masthead
 		logo) and anchor links (https://aerele.in) are explicitly
@@ -141,35 +141,35 @@ class TestSafeReportSelfContainedOnRealBench(FrappeTestCase):
 		flat = html.replace(" ", "").replace("'", "").replace('"', "")
 
 		assert not re.search(r'src\s*=\s*["\']https?:', html), (
-			"safe-report HTML contains a remote img/script src — breaks "
+			"safe-report HTML contains a remote img/script src breaks "
 			"the offline / dev-shop-interchange guarantee"
 		)
 		assert not re.search(r'<link\b[^>]*href\s*=\s*["\']https?:', html), (
-			"safe-report HTML loads a remote stylesheet — breaks the offline / dev-shop-interchange guarantee"
+			"safe-report HTML loads a remote stylesheet breaks the offline / dev-shop-interchange guarantee"
 		)
-		assert "@import" not in html, "safe-report HTML uses @import — could fetch over network"
-		assert "url(http" not in flat, "safe-report HTML embeds url(http...) — breaks offline"
+		assert "@import" not in html, "safe-report HTML uses @import could fetch over network"
+		assert "url(http" not in flat, "safe-report HTML embeds url(http...) breaks offline"
 		# Sanity check: at least one HUMAN-facing anchor link exists
 		# (so the negative checks above aren't trivially passing on an
 		# empty / error page).
 		assert re.search(r'<a [^>]*href="https?://', html), (
-			"safe-report HTML has no human-facing anchor — the rendered "
+			"safe-report HTML has no human-facing anchor the rendered "
 			"page may be a stub or error, making the negative checks "
 			"vacuously true"
 		)
 
 	def test_on_disk_report_has_no_inline_or_external_javascript(self):
-		"""The renderer must not emit any ``<script>`` tag — neither
+		"""The renderer must not emit any ``<script>`` tag neither
 		inline JS nor an external ``<script src="...">``. This is a
 		stronger constraint than the canary: the safe report is also
 		a JS-free document, which is part of why it's safe to open in
 		an arbitrary browser without consent."""
-		# Case-insensitive substring check — the renderer might emit
+		# Case-insensitive substring check the renderer might emit
 		# uppercase or mixed-case tag names in some pre-existing
 		# block (e.g., template comments). The contract is "no
 		# script tag in any form."
 		assert "<script" not in self._html.lower(), (
-			"safe-report HTML contains a <script tag — should be JS-free "
+			"safe-report HTML contains a <script tag should be JS-free "
 			"per the self-contained-offline contract"
 		)
 
@@ -177,7 +177,7 @@ class TestSafeReportSelfContainedOnRealBench(FrappeTestCase):
 		"""Bench asset URLs (``/assets/...``, ``/files/...``,
 		``/api/method/...``) would render fine when opened from the
 		live bench but break the moment the file is moved off-bench.
-		The safe report must be **fully** self-contained — neither
+		The safe report must be **fully** self-contained neither
 		external NOR bench-local asset references."""
 		html = self._html
 		# These patterns scope to attribute-value positions so we don't
@@ -185,10 +185,10 @@ class TestSafeReportSelfContainedOnRealBench(FrappeTestCase):
 		# "/assets" as part of a code snippet or finding description.
 		assert not re.search(r'(?:src|href)\s*=\s*["\']/(?:assets|files)/', html), (
 			"safe-report HTML references a bench-local asset path "
-			"(/assets/... or /files/...) — breaks when the file is "
+			"(/assets/... or /files/...) breaks when the file is "
 			"moved off-bench"
 		)
 		assert not re.search(r'(?:src|href)\s*=\s*["\']/api/method/', html), (
 			"safe-report HTML references a bench API endpoint "
-			"(/api/method/...) — breaks when opened off-bench"
+			"(/api/method/...) breaks when opened off-bench"
 		)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ dependencies = [
 	# Already a transitive Frappe dependency; declared explicitly because
 	# ai_fix.py imports it directly to call the configured LLM endpoint.
 	"requests>=2.28",
-	# Transitive Frappe deps used by app code at module top — declared
+	# Transitive Frappe deps used by app code at module top declared
 	# explicitly so the suite installs cleanly on a non-bench Python
 	# (CI runner) without pulling in all of Frappe.
 	"sqlparse>=0.4",


### PR DESCRIPTION
## Overview

This PR removes em dashes (`—`) from user-facing text and internal documentation across the app to keep the writing style consistent and avoid unnecessary punctuation in the UI and codebase.

## Why

Em dashes had been introduced across comments, docstrings, settings help text, report templates, and user-facing strings. They were flagged during review as an inconsistent writing style.

This change standardizes the affected text without changing application behavior.

## Changes

* Removed em dashes where the sentence reads naturally without them.
* Replaced em dashes with appropriate punctuation where needed:

  * Colons for labels, headings, and definitions.
  * Parentheses for bracketed lists.
  * Commas where a natural pause is required.
* Replaced placeholder dashes in empty table cells with blank cells where no value is available.
* Updated CHANGELOG release headers to the standard `## [x.y.z] - date` format.
* Kept the em dash used by `_strip_em` in `renderer/_internal.py`, since the renderer needs the character to remove it from user-provided notes at render time.