### PR TITLE
fix(report): prevent analyze progress banner stacking on Optimus Session form

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ versions may contain breaking changes see migration notes below).
 
 ---
 
+## [0.12.46] - 2026-09-09
+
+### Fixed
+
+- **The "Preparing report" progress bar no longer stacks on the Optimus Session
+  form.** Analyze publishes `optimus_progress` many times per run (fetch, EXPLAIN,
+  one per analyzer, render, complete) and the form's handler drove
+  `frm.dashboard.set_headline` on every tick. In this Frappe version `set_headline`
+  appends a new `.form-message` each call rather than replacing it, so the form
+  filled with a stack of "Preparing report N% ..." bars. The handler now updates a
+  single self-managed banner element in place (the same pattern already used for the
+  background-jobs drain banner), styled with Frappe's native `.form-message.blue`
+  theme classes so it fits the desk UI in light and dark mode. It is removed when
+  the session reaches Ready or Failed and also cleared on every form refresh so a
+  stale bar cannot linger when you navigate to another session.
+
+---
+
 ## [0.12.45] - 2026-09-09
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,15 @@ versions may contain breaking changes see migration notes below).
   single self-managed banner element in place (the same pattern already used for the
   background-jobs drain banner), styled with Frappe's native `.form-message.blue`
   theme classes so it fits the desk UI in light and dark mode. It is removed when
-  the session reaches Ready or Failed and also cleared on every form refresh so a
-  stale bar cannot linger when you navigate to another session.
+  the session reaches Ready or Failed and on any refresh that shows a different or
+  a new session (it is tagged with its owning session), so a stale bar cannot
+  linger when you navigate away, while the banner for the session you are watching
+  keeps updating in place.
+- **The Phase 2 "Line profiling is armed" notice no longer stacks either.** It was
+  painted with `frm.set_intro`, which routes to the same `show_message` that appends
+  rather than replaces, so refreshing while a pass was Recording piled up duplicate
+  orange notices. It now uses the same single in-place banner helper and Frappe's
+  native orange theme.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@
 ```bash
 cd ~/frappe-bench
 bench get-app https://github.com/Aerele-RnD/optimus.git
+bench setup requirements
 bench --site <your-site> install-app optimus
 bench restart
 ```

--- a/optimus/__init__.py
+++ b/optimus/__init__.py
@@ -1,4 +1,4 @@
-__version__ = "0.12.45"
+__version__ = "0.12.46"
 
 
 def safe_commit() -> None:

--- a/optimus/optimus/doctype/optimus_session/optimus_session.js
+++ b/optimus/optimus/doctype/optimus_session/optimus_session.js
@@ -47,46 +47,69 @@ function render_ai_buttons(frm) {
 	});
 }
 
-// One self-managed "preparing report" banner element, updated in place. Frappe's
-// frm.dashboard.set_headline APPENDS a fresh .form-message on every call in this
-// version (frappe/public/js/frappe/form/layout.js show_message never clears the
-// container for non-empty html), so driving it from the per-tick optimus_progress
-// event stacked one bar per tick instead of updating one. This keeps a single
-// element and rewrites its contents. Pass html=null to remove it. It mirrors
-// _drain_banner's single-element mechanism (and, like it, is cleared on every
-// refresh by render_analyze_progress so a stale bar can't linger on another
-// session), but styles itself with Frappe's native .form-message.blue theme
-// classes rather than inline colours.
-function _progress_banner(frm, html) {
+// Shared single-banner mechanism for the in-form status banners (analyze
+// "preparing report" and background-jobs drain). Frappe's frm.set_intro and
+// frm.dashboard.set_headline both route to layout.js show_message, which APPENDS
+// a fresh .form-message on every non-null call rather than replacing the previous
+// one (layout.js: $html ... appendTo(this.message)), so driving either from a
+// per-tick event stacked one bar per tick instead of updating one. This keeps a
+// single element found and removed by `idClass` (which must be unique to this
+// banner) and rewrites its contents in place, returning it so the caller can tag
+// it. Pass html=null to remove it. `extraClasses` are added only when the element
+// is created (e.g. Frappe theme classes); `styler` runs once on a freshly created
+// element whose classes do not carry its colours. The element is prepended to
+// .form-layout, outside .form-message-container, so Frappe's own show_message()
+// clearing on each refresh never removes it.
+function _single_banner(frm, idClass, extraClasses, html, styler) {
 	const root = frm.$wrapper;
-	if (!root || !root.length) return;
+	if (!root || !root.length) return null;
 	if (html == null) {
-		root.find(".optimus-analyze-banner").remove();
-		return;
+		root.find("." + idClass).remove();
+		return null;
 	}
-	let $b = root.find(".optimus-analyze-banner");
+	let $b = root.find("." + idClass);
 	if (!$b.length) {
-		// Reuse Frappe's native .form-message.blue look (same padding, font
-		// size, blue scheme + dark-theme variants) so this matches the bar the
-		// old set_headline produced. It lives outside .form-message-container,
-		// so Frappe's show_message() clearing on each refresh never removes it.
-		$b = $('<div class="optimus-analyze-banner form-message blue"></div>');
+		const cls = extraClasses ? idClass + " " + extraClasses : idClass;
+		$b = $('<div class="' + cls + '"></div>');
+		if (styler) styler($b);
 		const $host = root.find(".form-layout").first();
 		($host.length ? $host : root).prepend($b);
 	}
 	$b.html(html);
+	return $b;
 }
 
-// Clear a stale progress banner on refresh / navigation. Live analyze progress
-// re-creates it via the optimus_progress handler, so whenever the shown session
-// is not Analyzing (a Ready / Failed session, or a different one you navigated
-// to) the banner must not linger. The ready / failed handlers also remove it,
-// but they are gated by mine(p) and Frappe reuses one frm object across
-// sessions of this doctype, so without this a banner left by session A would
-// stick when you switch to session B. Mirrors render_drain_progress.
+// The analyze "preparing report" banner. Uses Frappe's native .form-message.blue
+// theme (same padding, font size, blue scheme plus dark-theme variants) so it
+// matches the bar the old set_headline produced, no inline styling needed. It is
+// tagged with the owning session so render_analyze_progress can drop it once the
+// form shows a different or a new session. Pass html=null to remove it.
+function _progress_banner(frm, html) {
+	const $b = _single_banner(frm, "optimus-analyze-banner", "form-message blue", html);
+	if ($b) $b.attr("data-optimus-session", frm.doc.session_uuid || "");
+}
+
+// Clear a stale analyze banner on refresh / navigation. The banner is prepended
+// to .form-layout, which Frappe reuses across sessions of this doctype (in-app
+// navigation keeps one frm and one $wrapper), so a banner painted for session A
+// outlives the move to another form. It must be dropped on refresh unless the
+// shown form is that same session still analyzing, so three cases clear it: a new
+// unsaved form (is_new, which never emits progress to self-correct), a
+// Ready / Failed session and a different Analyzing session (which would otherwise
+// show session A's stale percentage until its own first tick). Live progress
+// repaints the banner via the optimus_progress handler, so clearing here never
+// hides current progress. The ready / failed handlers also remove it but are
+// gated by mine(p) and never fire for the form you navigate to.
 function render_analyze_progress(frm) {
-	if (frm.is_new()) return;
-	if (frm.doc.status !== "Analyzing") {
+	const root = frm.$wrapper;
+	if (!root || !root.length) return;
+	const $b = root.find(".optimus-analyze-banner");
+	if (!$b.length) return;
+	const owns_live_analyze =
+		!frm.is_new() &&
+		frm.doc.status === "Analyzing" &&
+		$b.attr("data-optimus-session") === frm.doc.session_uuid;
+	if (!owns_live_analyze) {
 		_progress_banner(frm, null);
 	}
 }
@@ -230,9 +253,21 @@ function _refill_ai_call(frm) {
 // from phase-1) plus a free-form textbox for dotted paths the user types.
 // Submission posts to api.start_line_profile_pass; realtime events drive
 // the form's Phase-2 history child table updates.
+// The Phase 2 "line profiling is armed" banner. Same in-place mechanism as the
+// analyze banner (see _single_banner); frm.set_intro appended a duplicate on every
+// refresh while a pass was Recording. Uses Frappe's native orange form-message
+// theme. Pass html=null to remove it.
+function _phase2_armed_banner(frm, html) {
+	_single_banner(frm, "optimus-phase2-armed", "form-message orange", html);
+}
+
 function render_phase2_button(frm) {
-	if (frm.is_new()) return;
-	if (frm.doc.status !== "Ready") return;
+	if (frm.is_new() || frm.doc.status !== "Ready") {
+		// Not a Ready session (or unsaved): drop any armed banner left in the
+		// reused form wrapper by a session that was mid-Recording.
+		_phase2_armed_banner(frm, null);
+		return;
+	}
 
 	// If there's an in-flight Recording row, surface Stop as the primary
 	// affordance that's what the user is looking for after they've
@@ -272,19 +307,21 @@ function render_phase2_button(frm) {
 		// v0.7.x: a Recording pass does nothing until the flow re-executes and
 		// the pass is stopped. Auto-arm (and the picker) leave users staring at
 		// a Stop button with no context spell out the two steps.
-		frm.set_intro(
+		// One in-place banner; set_intro appended a duplicate on every refresh in
+		// this Frappe version (see _single_banner).
+		_phase2_armed_banner(
+			frm,
 			__(
 				"🔬 Line profiling is armed. Re-run your flow now so the hot " +
 				"path(s) execute again, then click \"Stop Phase 2 Run\" above " +
 				"the report will then pinpoint the exact hot line(s). " +
 				"(Profiling has to re-execute your code; it can't replay the " +
 				"original run.)"
-			),
-			"orange"
+			)
 		);
 	} else {
 		// Clear the armed banner once no pass is Recording (e.g. after Stop).
-		frm.set_intro(null);
+		_phase2_armed_banner(frm, null);
 	}
 
 	// Surface a Retry button for any Phase 2 Run row stuck in Analyzing
@@ -927,20 +964,12 @@ function _drain_suffix(d) {
 	return win ? __(" · up to {0}", [win]) : "";
 }
 
-// One self-managed banner element updated in place. frm.set_intro /
-// frm.dashboard.set_headline both APPEND a dismissible .form-message in this
-// Frappe version, so polling them stacked a new bar every tick. Pass
-// html=null to remove it.
+// The background-jobs drain banner. Same single-element mechanism as the analyze
+// banner (see _single_banner); it keeps its own orange inline styling rather than
+// a .form-message theme class. Pass html=null to remove it.
 function _drain_banner(frm, html) {
-	const root = frm.$wrapper;
-	if (!root || !root.length) return;
-	if (html == null) {
-		root.find(".optimus-drain-banner").remove();
-		return;
-	}
-	let $b = root.find(".optimus-drain-banner");
-	if (!$b.length) {
-		$b = $('<div class="optimus-drain-banner"></div>').css({
+	_single_banner(frm, "optimus-drain-banner", "", html, ($b) =>
+		$b.css({
 			padding: "10px 14px",
 			margin: "8px",
 			background: "#fff7ed",
@@ -948,11 +977,8 @@ function _drain_banner(frm, html) {
 			"border-radius": "6px",
 			color: "#9a3412",
 			"font-size": "0.9rem",
-		});
-		const $host = root.find(".form-layout").first();
-		($host.length ? $host : root).prepend($b);
-	}
-	$b.html(html);
+		})
+	);
 }
 
 // While the session drains the flow's background jobs after Stop, poll the

--- a/optimus/optimus/doctype/optimus_session/optimus_session.js
+++ b/optimus/optimus/doctype/optimus_session/optimus_session.js
@@ -13,6 +13,7 @@ frappe.ui.form.on("Optimus Session", {
 		render_status_indicator(frm);
 		render_phase2_progress(frm);
 		render_drain_progress(frm);
+		render_analyze_progress(frm);
 		render_download_buttons(frm);
 		render_retry_button(frm);
 		render_regenerate_report_button(frm);
@@ -46,6 +47,50 @@ function render_ai_buttons(frm) {
 	});
 }
 
+// One self-managed "preparing report" banner element, updated in place. Frappe's
+// frm.dashboard.set_headline APPENDS a fresh .form-message on every call in this
+// version (frappe/public/js/frappe/form/layout.js show_message never clears the
+// container for non-empty html), so driving it from the per-tick optimus_progress
+// event stacked one bar per tick instead of updating one. This keeps a single
+// element and rewrites its contents. Pass html=null to remove it. It mirrors
+// _drain_banner's single-element mechanism (and, like it, is cleared on every
+// refresh by render_analyze_progress so a stale bar can't linger on another
+// session), but styles itself with Frappe's native .form-message.blue theme
+// classes rather than inline colours.
+function _progress_banner(frm, html) {
+	const root = frm.$wrapper;
+	if (!root || !root.length) return;
+	if (html == null) {
+		root.find(".optimus-analyze-banner").remove();
+		return;
+	}
+	let $b = root.find(".optimus-analyze-banner");
+	if (!$b.length) {
+		// Reuse Frappe's native .form-message.blue look (same padding, font
+		// size, blue scheme + dark-theme variants) so this matches the bar the
+		// old set_headline produced. It lives outside .form-message-container,
+		// so Frappe's show_message() clearing on each refresh never removes it.
+		$b = $('<div class="optimus-analyze-banner form-message blue"></div>');
+		const $host = root.find(".form-layout").first();
+		($host.length ? $host : root).prepend($b);
+	}
+	$b.html(html);
+}
+
+// Clear a stale progress banner on refresh / navigation. Live analyze progress
+// re-creates it via the optimus_progress handler, so whenever the shown session
+// is not Analyzing (a Ready / Failed session, or a different one you navigated
+// to) the banner must not linger. The ready / failed handlers also remove it,
+// but they are gated by mine(p) and Frappe reuses one frm object across
+// sessions of this doctype, so without this a banner left by session A would
+// stick when you switch to session B. Mirrors render_drain_progress.
+function render_analyze_progress(frm) {
+	if (frm.is_new()) return;
+	if (frm.doc.status !== "Analyzing") {
+		_progress_banner(frm, null);
+	}
+}
+
 // Show a live headline on the form while analyze is running (the floating
 // widget shows the same progress, but if you're sitting on the Profiler
 // Session form you shouldn't have to stare at a static "Analyzing" status
@@ -62,7 +107,10 @@ function subscribe_session_progress(frm) {
 		if (!mine(p)) return;
 		const pct = typeof p.percent === "number" ? Math.round(p.percent) : null;
 		const desc = frappe.utils.escape_html(p.description || "Analyzing…");
-		frm.dashboard.set_headline(
+		// Update one in-place banner rather than frm.dashboard.set_headline,
+		// which appends a new bar on every progress tick (see _progress_banner).
+		_progress_banner(
+			frm,
 			'<span class="text-muted">' +
 				'<i class="fa fa-spinner fa-spin" style="margin-right:6px;"></i>' +
 				(pct !== null ? __("Preparing report {0}% · {1}", [pct, desc]) : desc) +
@@ -71,13 +119,13 @@ function subscribe_session_progress(frm) {
 	});
 	frappe.realtime.on("optimus_session_ready", (p) => {
 		if (!mine(p)) return;
-		frm.dashboard.clear_headline();
+		_progress_banner(frm, null);
 		frappe.show_alert({ message: __("Report ready"), indicator: "green" });
 		setTimeout(() => frm.reload_doc(), 800);
 	});
 	frappe.realtime.on("optimus_session_failed", (p) => {
 		if (!mine(p)) return;
-		frm.dashboard.clear_headline();
+		_progress_banner(frm, null);
 		setTimeout(() => frm.reload_doc(), 800);
 	});
 	// v0.7.x: auto-arm fires server-side during analyze (off-form). Tell the


### PR DESCRIPTION
### Summary

During session analysis, the **"Preparing report N% ..."** message was creating a new progress bar for every update, causing multiple banners to stack on the Optimus Session form.

### Changes Made

* Replaced `set_headline` with a single reusable progress banner that updates in place.
* Clear the banner when analysis completes, fails or the user switches sessions.
* Added session checks to prevent stale progress from affecting another session.
* Reused Frappe's native styling with no hardcoded colours.

### Behaviour

**Before:** Multiple progress bars stacked for each update.

**After:** One progress bar updates its percentage in place and is removed when analysis finishes or fails.

